### PR TITLE
feat: add attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write # Required for provenance attestation
+      attestations: write # Required for provenance attestation
     runs-on: ubuntu-latest
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ""
@@ -25,6 +27,7 @@ jobs:
         with:
           node-version: '22'
           go-version: '1.24'
+          attestation: true # Enable build provenance attestation
           # Plugin signing enabled with Grafana Access Policy token
           # (For more info see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
           # policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds build provenance attestation to the GitHub Actions release workflow.
> 
> - Grants `id-token` and `attestations` write permissions in `jobs.release.permissions`
> - Enables `attestation: true` on `grafana/plugin-actions/build-plugin` in `release.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9dd1d136f1a33b1a3bd5e06f3f040a284251a8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->