### PR TITLE
feat: add attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write # Required for provenance attestation
+      attestations: write # Required for provenance attestation
     runs-on: ubuntu-latest
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ""
@@ -25,6 +27,7 @@ jobs:
         with:
           node-version: '22'
           go-version: '1.24'
+          attestation: true # Enable build provenance attestation
           # Plugin signing enabled with Grafana Access Policy token
           # (For more info see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
           # policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds provenance attestation to the release workflow.
> 
> - Grants `id-token: write` and `attestations: write` permissions to the `release` job in `.github/workflows/release.yml`
> - Enables build provenance by setting `attestation: true` on `grafana/plugin-actions/build-plugin`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba4926b59bfa0ee1df6cf9d86d1d771efd0e3cef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->