### PR TITLE
fix: side panel disappearing after each new question

### DIFF
--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -332,11 +332,8 @@ export const useChat = (pluginSettings: AppPluginSettings, initialSession?: Chat
   const detectedPageRefs = useMemo((): Array<GrafanaPageRef & { messageIndex: number }> => {
     for (let i = chatHistory.length - 1; i >= 0; i--) {
       const msg = chatHistory[i];
-      if (msg.role === 'assistant') {
-        if (msg.pageRefs && msg.pageRefs.length > 0) {
-          return msg.pageRefs.map((ref) => ({ ...ref, messageIndex: i }));
-        }
-        return [];
+      if (msg.role === 'assistant' && msg.pageRefs && msg.pageRefs.length > 0) {
+        return msg.pageRefs.map((ref) => ({ ...ref, messageIndex: i }));
       }
     }
     return [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes page ref detection logic in `useChat.ts` to avoid clearing detected refs when the latest assistant message lacks `pageRefs`.
> 
> - `detectedPageRefs` now scans backward and returns refs from the most recent assistant message that has `pageRefs`, instead of returning an empty array upon encountering an assistant message without refs
> - Prevents UI from dropping the side panel when a new assistant message lacks `pageRefs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63d576c7fb791830f2ef2cd3b18ec31415d0fffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->