### PR TITLE
fix(ci): make release-please PRs mergeable

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,17 +7,7 @@
       "component": "ask-o11y-plugin",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "src/components/Chat/components/WelcomeMessage/WelcomeMessage.tsx"
-        },
-        {
-          "type": "generic",
-          "path": "src/services/builtInMCPClient.ts"
-        }
-      ]
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             code:
               - 'src/**'
               - 'pkg/**'
+              - 'tests/**'
               - '*.config.*'
               - 'Magefile.go'
               - 'go.mod'
@@ -33,7 +34,7 @@ jobs:
   build:
     name: Build, lint and unit tests
     needs: check-changes
-    if: needs.check-changes.outputs.code == 'true' || github.event_name == 'push'
+    if: needs.check-changes.outputs.code == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Detect if code changed (for fast-pass on release-please PRs)
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'pkg/**'
+              - 'tests/**'
+              - '*.config.*'
+              - 'Magefile.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'tsconfig.json'
+
   build:
     name: Build Plugin with Coverage
+    needs: check-changes
+    if: needs.check-changes.outputs.code == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,7 +89,8 @@ jobs:
 
   e2e-tests:
     name: E2E Tests with Coverage
-    needs: build
+    needs: [check-changes, build]
+    if: needs.check-changes.outputs.code == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -169,3 +195,20 @@ jobs:
       - name: Stop Grafana
         if: always()
         run: docker compose down
+
+  # Fast pass for release-please PRs (no code changes)
+  skip-build:
+    name: Build Plugin with Coverage
+    needs: check-changes
+    if: needs.check-changes.outputs.code == 'false' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes detected, skipping build (release-please PR)"
+
+  skip-e2e:
+    name: E2E Tests with Coverage
+    needs: check-changes
+    if: needs.check-changes.outputs.code == 'false' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes detected, skipping E2E tests (release-please PR)"

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -2,7 +2,32 @@ name: Latest Grafana API compatibility check
 on: [pull_request]
 
 jobs:
+  # Detect if code changed (for fast-pass on release-please PRs)
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'pkg/**'
+              - 'tests/**'
+              - '*.config.*'
+              - 'Magefile.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'tsconfig.json'
+
   compatibilitycheck:
+    needs: check-changes
+    if: needs.check-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -49,3 +74,12 @@ jobs:
           module: ${{ steps.find-module-ts.outputs.modulets }}
           comment-pr: 'no'
           fail-if-incompatible: 'yes'
+
+  # Fast pass for release-please PRs (no code changes)
+  skip-compatibilitycheck:
+    name: compatibilitycheck
+    needs: check-changes
+    if: needs.check-changes.outputs.code == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes detected, skipping compatibility check (release-please PR)"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,6 +38,7 @@ jobs:
             ui
             deps
             release
+            ci
             main
           requireScope: false
           subjectPattern: ^.+$

--- a/src/components/Chat/components/WelcomeMessage/WelcomeMessage.test.tsx
+++ b/src/components/Chat/components/WelcomeMessage/WelcomeMessage.test.tsx
@@ -29,17 +29,6 @@ describe('WelcomeMessage', () => {
     expect(screen.getByText('Ask O11y Assistant')).toBeInTheDocument();
   });
 
-  it('should render the BETA badge', () => {
-    render(<WelcomeMessage />);
-    expect(screen.getByText('BETA')).toBeInTheDocument();
-  });
-
-  it('should render a version number', () => {
-    render(<WelcomeMessage />);
-    // Match any semantic version pattern (vX.Y.Z)
-    expect(screen.getByText(/v\d+\.\d+\.\d+/)).toBeInTheDocument();
-  });
-
   it('should render the description', () => {
     render(<WelcomeMessage />);
     expect(screen.getByText(/agentic LLM assistant/i)).toBeInTheDocument();

--- a/src/components/Chat/components/WelcomeMessage/WelcomeMessage.tsx
+++ b/src/components/Chat/components/WelcomeMessage/WelcomeMessage.tsx
@@ -20,14 +20,6 @@ export const WelcomeMessage: React.FC = () => {
         </h1>
       </div>
 
-      {/* Status badge and version */}
-      <div className="flex items-center gap-3 mb-8">
-        <span className="status-badge">BETA</span>
-        <span className="text-base" style={{ color: theme.colors.text.secondary }}>
-          v0.2.4 {/* x-release-please-version */}
-        </span>
-      </div>
-
       {/* Description with highlighted text */}
       <p className="text-lg max-w-2xl mx-auto leading-relaxed" style={{ color: theme.colors.text.secondary }}>
         An{' '}

--- a/src/index.css
+++ b/src/index.css
@@ -188,21 +188,6 @@
   animation: sparkle 2s ease-in-out infinite;
 }
 
-/* Status badge styling */
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 14px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  border: 1px solid var(--grafana-color-warning);
-  color: var(--grafana-color-warning);
-  background: transparent;
-}
-
 /* Suggestion pill styling */
 .suggestion-pill {
   display: inline-flex;

--- a/src/services/builtInMCPClient.ts
+++ b/src/services/builtInMCPClient.ts
@@ -54,7 +54,7 @@ export class BuiltInMCPClient {
     try {
       this.mcpClient = new mcp.Client({
         name: 'ask-o11y-plugin',
-        version: '0.2.4', // x-release-please-version
+        version: '1.0.0',
       });
 
       const transport = new mcp.StreamableHTTPClientTransport(mcp.streamableHTTPURL());

--- a/tests/chatFlows.spec.ts
+++ b/tests/chatFlows.spec.ts
@@ -160,9 +160,6 @@ test.describe('Chat UI States', () => {
       // Welcome heading
       await expect(page.getByRole('heading', { name: 'Ask O11y Assistant' })).toBeVisible();
 
-      // Version badge
-      await expect(page.getByText('BETA')).toBeVisible();
-
       // Description
       await expect(page.getByText('agentic LLM assistant')).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Remove BETA badge and version display from WelcomeMessage component (no longer user-facing)
- Remove `extra-files` from release-please config so it no longer modifies `src/` files
- Add fast-pass pattern (dorny/paths-filter + skip jobs) to `e2e.yml` and `is-compatible.yml` workflows
- This ensures all required checks pass immediately for release-please PRs (which only modify CHANGELOG, package.json, manifest)

## Test plan
- [x] Unit tests pass (`npm run test:ci` — 886 tests, 45 suites)
- [x] Lint passes (0 errors)
- [ ] Verify CI fast-pass works on this PR (code changes → full CI runs)
- [ ] Verify release-please PR gets fast-pass (no code changes → skip jobs pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly workflow/config changes, but they alter which CI jobs run and when; a misconfigured path filter or condition could inadvertently skip needed checks on some PRs.
> 
> **Overview**
> **CI now “fast-passes” release-please PRs.** Workflows add a `check-changes` paths filter (including `tests/**`) and gate `build`/`e2e`/compatibility jobs to only run when code changes are detected; otherwise new `skip-*` jobs run so required checks pass.
> 
> Release automation is adjusted to stop modifying source files by removing `extra-files` from `release-please-config.json`, and the PR-title validator adds the `ci` scope.
> 
> UI/tests cleanup removes the Welcome screen’s `BETA` badge/version display (and associated CSS and test assertions), and updates the built-in MCP client version string to `1.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f34181154a67f86c2529401e76f33cb8a5dbcd11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->