### PR TITLE
fix(release): use PAT for release-please and skip GitHub Release creation

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,7 +7,8 @@
       "component": "ask-o11y-plugin",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "skip-github-release": true
     }
   },
   "changelog-sections": [

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
## Summary
- Use `RELEASE_TOKEN` (PAT) instead of `GITHUB_TOKEN` in release-please so tag pushes trigger the `release.yml` workflow
- Add `skip-github-release: true` so release-please only creates the tag — `release.yml` handles the actual GitHub Release with built artifacts + attestation

## Why
Tags created by `GITHUB_TOKEN` don't trigger downstream workflows (GitHub security feature). This is why `v0.2.5` tag was created but `release.yml` never ran.

## Test plan
- [ ] After merge: delete `v0.2.5` tag, merge next release-please PR, verify `release.yml` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release configuration-only changes; main risk is misconfigured permissions/secret leading to releases not triggering or being created.
> 
> **Overview**
> Switches the `release-please` GitHub Action to authenticate with `secrets.RELEASE_TOKEN` instead of `GITHUB_TOKEN`, so tag pushes can trigger downstream workflows.
> 
> Updates `release-please` config to set `skip-github-release: true`, making it generate PRs/tags/changelogs without creating a GitHub Release (delegating release asset publishing to another workflow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966aeef223ef5f9353145d0ab97bf79f917e0e4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->