### PR TITLE
fix(validation): remove overly strict XSS check blocking observability queries

### DIFF
--- a/src/services/__tests__/validation.test.ts
+++ b/src/services/__tests__/validation.test.ts
@@ -42,33 +42,33 @@ describe('ValidationService', () => {
       expect(result).toBe('HelloWorld');
     });
 
-    it('should throw on script injection', () => {
-      expect(() => ValidationService.validateChatInput('<script>alert("xss")</script>')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries with container= label selector', () => {
+      expect(ValidationService.validateChatInput('Show me logs where container=nginx')).toBe(
+        'Show me logs where container=nginx'
       );
     });
 
-    it('should throw on javascript: protocol', () => {
-      expect(() => ValidationService.validateChatInput('javascript:alert(1)')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries mentioning PromQL expressions', () => {
+      expect(ValidationService.validateChatInput('What is a PromQL expression (rate vs irate)?')).toBe(
+        'What is a PromQL expression (rate vs irate)?'
       );
     });
 
-    it('should throw on event handler injection', () => {
-      expect(() => ValidationService.validateChatInput('<img onerror=alert(1)>')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries with connection= labels', () => {
+      expect(ValidationService.validateChatInput('Find metrics where connection=active')).toBe(
+        'Find metrics where connection=active'
       );
     });
 
-    it('should throw on iframe injection', () => {
-      expect(() => ValidationService.validateChatInput('<iframe src="evil.com">')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries discussing eval in alerting', () => {
+      expect(ValidationService.validateChatInput('How does the eval (evaluation) interval work?')).toBe(
+        'How does the eval (evaluation) interval work?'
       );
     });
 
-    it('should throw on eval injection', () => {
-      expect(() => ValidationService.validateChatInput('eval("malicious")')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries with version= and region= selectors', () => {
+      expect(ValidationService.validateChatInput('Show pods where version=v2 and region=us-east-1')).toBe(
+        'Show pods where version=v2 and region=us-east-1'
       );
     });
   });
@@ -566,34 +566,22 @@ describe('ValidationService', () => {
     });
   });
 
-  describe('validateChatInput edge cases', () => {
-    it('should throw on expression() injection', () => {
-      expect(() => ValidationService.validateChatInput('expression(test)')).toThrow(
-        'Input contains potentially harmful content'
+  describe('validateChatInput - observability label selectors', () => {
+    it('should accept queries with action= and session= labels', () => {
+      expect(ValidationService.validateChatInput('Filter by action=deploy and session=abc123')).toBe(
+        'Filter by action=deploy and session=abc123'
       );
     });
 
-    it('should throw on vbscript protocol', () => {
-      expect(() => ValidationService.validateChatInput('vbscript:msgbox(1)')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries with function= labels', () => {
+      expect(ValidationService.validateChatInput('Show traces where function=handleRequest')).toBe(
+        'Show traces where function=handleRequest'
       );
     });
 
-    it('should throw on data:text/html', () => {
-      expect(() => ValidationService.validateChatInput('data:text/html,<script>alert(1)</script>')).toThrow(
-        'Input contains potentially harmful content'
-      );
-    });
-
-    it('should throw on object tag injection', () => {
-      expect(() => ValidationService.validateChatInput('<object data="evil.swf">')).toThrow(
-        'Input contains potentially harmful content'
-      );
-    });
-
-    it('should throw on embed tag injection', () => {
-      expect(() => ValidationService.validateChatInput('<embed src="evil.swf">')).toThrow(
-        'Input contains potentially harmful content'
+    it('should accept queries mentioning javascript in logs', () => {
+      expect(ValidationService.validateChatInput('I see javascript: errors in my browser logs')).toBe(
+        'I see javascript: errors in my browser logs'
       );
     });
   });

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -39,13 +39,7 @@ export class ValidationService {
    */
   static validateChatInput(input: string): string {
     const trimmed = this.validateNonEmptyString(input, 'Input', this.MAX_INPUT_LENGTH);
-    const cleaned = this.removeControlCharacters(trimmed);
-
-    if (this.containsScriptInjection(cleaned)) {
-      throw new Error('Input contains potentially harmful content');
-    }
-
-    return cleaned;
+    return this.removeControlCharacters(trimmed);
   }
 
   /**
@@ -258,23 +252,6 @@ export class ValidationService {
     return input.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
   }
 
-  private static containsScriptInjection(input: string): boolean {
-    const dangerousPatterns = [
-      /<script\b/i,
-      /javascript:/i,
-      /on\w+\s*=/i, // Event handlers
-      /<iframe/i,
-      /<object/i,
-      /<embed/i,
-      /eval\s*\(/i,
-      /expression\s*\(/i,
-      /vbscript:/i,
-      /data:text\/html/i,
-    ];
-
-    return dangerousPatterns.some((pattern) => pattern.test(input));
-  }
-
   /**
    * Check if brackets are balanced in a string
    */
@@ -302,16 +279,7 @@ export class ValidationService {
   }
 
   private static validateLogQL(query: string): void {
-    // Basic LogQL structure validation
-    // Similar to PromQL but with LogQL-specific checks
-
-    // Check for balanced brackets and quotes
-    this.validatePromQL(query); // Reuse basic structure validation
-
-    // LogQL-specific: Check for valid stream selectors
-    if (!query.includes('{') && !query.includes('}')) {
-      // LogQL queries should typically have stream selectors (warning silenced)
-    }
+    this.validatePromQL(query);
   }
 
   /**
@@ -431,14 +399,3 @@ export class ValidationService {
   }
 }
 
-// Export validation functions for convenience
-export const {
-  validateChatInput,
-  validateQuery,
-  validateMCPServerURL,
-  validateSessionData,
-  sanitizeMessageContent,
-  escapeHTML,
-  validateConfigValue,
-  validateCustomSystemPrompt,
-} = ValidationService;


### PR DESCRIPTION
## Summary

- **Removed `containsScriptInjection()` from chat input validation** — the regex `/on\w+\s*=/i` matched the substring "on" inside common observability label names (e.g. `container=`, `connection=`, `session=`, `function=`, `region=`, `version=`, `action=`), blocking users from typing legitimate queries
- **Removed broken convenience exports** from `ValidationService` — destructured static methods lose `this` context and would fail at runtime
- **Simplified `validateLogQL()`** — removed a no-op conditional block

## Why

Fixes [W3FS-1309](https://consensyssoftware.atlassian.net/browse/W3FS-1309) ("Forbidden words on critical label names"). Users were unable to type common observability queries like `container=nginx` in the chat input because the XSS validation regex treated them as event handler injection attempts.

The XSS check was unnecessary defense-in-depth for this context:
- User messages are rendered via React JSX interpolation (`{message.content}`) which auto-escapes all HTML entities
- No `dangerouslySetInnerHTML` exists anywhere in the rendering path
- `sanitizeMessageContent()` (used for session imports where untrusted HTML is a real risk) remains untouched

## What's preserved

| Security measure | Status |
|---|---|
| Max input length (10,000 chars) | Kept |
| Control character removal | Kept |
| Non-empty validation | Kept |
| `sanitizeMessageContent()` for session imports | Kept |
| `validateQuery()` SQL injection checks | Kept |

## Test changes

- Removed 10 tests asserting script injection blocking in `validateChatInput`
- Added 8 tests confirming observability queries now pass: `container=`, `connection=`, `expression()`, `eval()`, `version=`/`region=`, `action=`/`session=`, `function=`, `javascript:` in log context

## Test plan

- [x] `npm run test:ci` — 699 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] Verified `container=nginx`, `connection=active`, `expression(rate)`, `eval(...)` no longer blocked

---

[W3FS-1309]: https://consensyssoftware.atlassian.net/browse/W3FS-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ