### PR TITLE
fix(ci): automate git tag creation when release PRs are merged

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,34 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+
+      - name: Create git tag for merged release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$COMMIT_MSG" =~ chore\(main\):\ release ]]; then
+            VERSION=$(jq -r '."."' .github/release-please-manifest.json)
+            TAG_NAME="v${VERSION}"
+
+            if git ls-remote --tags origin "$TAG_NAME" | grep -q "$TAG_NAME"; then
+              echo "Tag ${TAG_NAME} already exists on remote, skipping"
+              exit 0
+            fi
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG_NAME" "$COMMIT_SHA" -m "Release $TAG_NAME"
+            git push origin "$TAG_NAME"
+          fi


### PR DESCRIPTION
## Summary
- Add automatic git tag creation step to release-please workflow
- When a release PR is merged, the workflow detects it via commit message, extracts the version from the manifest, and creates/pushes the git tag
- This triggers the existing `release.yml` workflow (grafana/plugin-actions) to build and publish

## Context
Release-please was blocked with "untagged, merged release PRs" because `skip-github-release: true` prevents both GitHub Releases and git tags. The Grafana plugin build action creates the releases, so we keep that setting but automate the tag creation.

## Test plan
- [x] v0.2.7 tag manually created to verify the release.yml workflow triggers correctly
- [ ] Verify the tag creation step works on next release PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/CD release automation to create and push git tags, so mis-detection or manifest/commit mismatches could create incorrect tags or trigger unintended release workflows.
> 
> **Overview**
> Ensures `release-please` merges result in a corresponding git tag by checking out the repo with `RELEASE_TOKEN` and adding a post-step that detects `chore(main): release` merge commits, reads the version from `.github/release-please-manifest.json`, and pushes an annotated `vX.Y.Z` tag if it doesn’t already exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4ba24e150d127e67de7d767ed8ba1b0b2bb81d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->