### PR TITLE
fix(chat): integrate alert runbook URLs into investigation workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,6 +589,7 @@ One-click RCA from alert notifications. URL params trigger auto-send of investig
 
 **Implementation:**
 - `src/hooks/useAlertInvestigation.ts` - Parses URL, validates alert name, builds RCA prompt
+- `pkg/plugin/prompt_defaults.go` - Investigation prompt template with runbook annotation support
 - `src/pages/Home.tsx` - Renders loading/error states, passes initialMessage to Chat
 - `src/components/Chat/hooks/useChat.ts` - Auto-send state machine (idle → creating-session → ready-to-send → sent)
 
@@ -597,6 +598,9 @@ One-click RCA from alert notifications. URL params trigger auto-send of investig
 2. `useAlertInvestigation` parses `alertName` from URL, validates format
 3. Creates new session titled "Alert Investigation: {alertName}"
 4. Auto-sends RCA prompt to AI
+
+**Runbook Integration:**
+The investigation prompt instructs the agent to check for a `runbook_url` annotation when retrieving the alert. If present, the agent fetches and reads the runbook content before proceeding with the investigation, using it to guide the analysis and remediation steps.
 
 **Slack/Alertmanager Template:**
 ```go

--- a/pkg/plugin/prompt_defaults.go
+++ b/pkg/plugin/prompt_defaults.go
@@ -222,14 +222,16 @@ const DefaultInvestigationPrompt = `Investigate the alert "{{.AlertName}}" and p
 1. Prometheus datasource alerts (list available datasources first to get the Prometheus datasource UID)
 2. Grafana-managed alerts
 
-Once you find the alert, proceed with:
+Once you find the alert, check its annotations for a runbook URL (commonly found in the ` + "`runbook_url`" + ` annotation). If a runbook URL is present, fetch and read the runbook content BEFORE proceeding with further investigation. Use the appropriate tool based on the URL type (e.g., web_fetch for HTTP pages, confluence_get_page for Confluence URLs). The runbook will contain known causes, investigation steps, and resolution procedures specific to this alert — follow them.
+
+Then proceed with:
 1. Check the current alert status and recent state changes
 2. Query related metrics around the time the alert fired
 3. Search for relevant error logs in the affected services
 4. Check distributed traces for failed requests or high latency (if applicable)
 5. Identify correlations and patterns across the data
 6. Determine the root cause based on the evidence
-7. Suggest remediation steps to resolve the issue
+7. Suggest remediation steps, referencing the runbook's recommended actions if one was found
 
 Please use the available MCP tools to gather real data and provide actionable insights.`
 


### PR DESCRIPTION
## Summary

Enhances the alert investigation prompt to automatically fetch and follow runbook documentation when a `runbook_url` annotation is present on an alert.

## Changes

**Investigation Prompt (`pkg/plugin/prompt_defaults.go`):**
- After retrieving an alert, the agent now checks its annotations for a `runbook_url` field
- If a runbook URL is found, the agent fetches and reads it **before** continuing the investigation
- The agent uses the appropriate tool based on URL type:
  - `web_fetch` for HTTP/HTTPS pages
  - `confluence_get_page` for Confluence URLs
  - Other MCP tools as needed
- Remediation steps now reference the runbook's recommended actions

**Documentation (`CLAUDE.md`):**
- Added runbook integration section to Alert Investigation Mode docs
- Documented the expected workflow when runbook URLs are present

## Why

Alert runbooks contain critical context for troubleshooting:
- Known causes and symptoms specific to the alert
- Investigation steps tailored to the alert type
- Resolution procedures and workarounds
- Escalation paths

By automatically fetching runbooks, the AI can follow established procedures instead of using generic investigation patterns.

## Implementation Details

- **No frontend changes** — runbook URLs come from the alert's own annotations (e.g., Prometheus `runbook_url` annotation), not from URL parameters
- **Backward compatible** — investigation works exactly as before if no runbook URL is present
- **Tool-agnostic** — agent selects the appropriate fetch tool based on URL type
- **Prompt-only change** — no new code, just enhanced investigation instructions

## Example Alert with Runbook

```yaml
groups:
  - name: example
    rules:
      - alert: HighCPUUsage
        expr: rate(cpu_usage[5m]) > 0.9
        annotations:
          summary: "High CPU usage detected"
          runbook_url: "https://wiki.example.com/runbooks/high-cpu"
```

When investigating "HighCPUUsage", the agent will:
1. Retrieve the alert and find the `runbook_url` annotation
2. Fetch `https://wiki.example.com/runbooks/high-cpu` using `web_fetch`
3. Read the runbook content
4. Follow the documented investigation steps
5. Reference runbook-recommended actions in remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt/documentation-only change with no code-path, auth, or data-handling modifications; risk is limited to altered agent behavior during investigations.
> 
> **Overview**
> Alert investigation now explicitly checks alert annotations for a `runbook_url` and, when present, **fetches and reads the runbook before continuing RCA**, selecting an appropriate retrieval tool (e.g., `web_fetch`, `confluence_get_page`).
> 
> Remediation guidance is updated to **reference runbook-recommended actions**, and `CLAUDE.md` documents the new runbook-aware investigation flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf271fdf3825c8dc258f5c8acaf19851beffdc4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->