### PR TITLE
docs: integrate OpenAPI spec validation into quality workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,16 +44,23 @@ This project uses the following Claude Code plugins. They are configured in `.cl
 - Check `typescript-lsp` diagnostics for any TypeScript files you modified in `src/`
 - **Fix ALL critical, major, and medium severity issues** before proceeding
 
-#### Step 2: Code Review
+#### Step 2: OpenAPI Spec Validation (if API endpoints changed)
+- **REQUIRED if you modified any HTTP endpoints in `pkg/plugin/plugin.go`**
+- Update `pkg/plugin/openapi/openapi.json` to reflect endpoint changes
+- Run `nvm use 22 && npm run validate:openapi` to validate the spec
+- **Spec validation MUST pass before proceeding**
+- See [API Documentation](#api-documentation) section for detailed maintenance guidelines
+
+#### Step 3: Code Review
 - Run the `code-review` skill (via Skill tool with `skill: "code-review"`) on your changes
 - **Fix ALL critical, major, and medium severity issues** reported by the reviewer
 - Only low/info severity issues may be left as-is with justification
 
-#### Step 3: Code Simplification
+#### Step 4: Code Simplification
 - Run the `code-simplifier` agent (via Task tool with `subagent_type: "pr-review-toolkit:code-simplifier"`) on modified code
 - Apply simplifications that improve clarity without changing behavior
 
-#### Step 4: Remove AI Slop & Excessive Comments
+#### Step 5: Remove AI Slop & Excessive Comments
 - Review all modified code for AI-generated noise: remove unnecessary comments, redundant docstrings, and obvious explanations
 - Delete comments that merely restate the code (e.g., `// increment counter` above `counter++`)
 - Remove filler phrases in comments like "Note:", "Important:", "This function...", "Helper to..."
@@ -61,14 +68,15 @@ This project uses the following Claude Code plugins. They are configured in `.cl
 - Do NOT add comments, docstrings, or type annotations to code you didn't change
 - Only keep comments where the **why** is non-obvious — never comment the **what**
 
-#### Step 5: Tests & Lint
+#### Step 6: Tests & Lint
 - Run `nvm use 22 && npm run test:ci` (frontend unit tests)
 - Run `go test ./pkg/...` (backend tests)
 - Run `nvm use 22 && npm run lint` (linting)
 - Run `nvm use 22 && npm run typecheck` (type checking)
+- Run `nvm use 22 && npm run validate:openapi` (OpenAPI spec validation)
 - **Fix any failures** - iterate until all pass
 
-#### Step 6: PR Review (before commit/PR)
+#### Step 7: PR Review (before commit/PR)
 - Run the full `pr-review-toolkit:review-pr` and the skill for comprehensive analysis
 - Fix critical/major/medium issues from: code-reviewer, silent-failure-hunter, type-design-analyzer
 
@@ -755,6 +763,11 @@ RBAC checking pattern:
 1. Extract role from `req.Context()`
 2. Call `canAccessTool(role, toolName)`
 3. Return 403 if unauthorized
+
+**CRITICAL: After modifying routes:**
+1. Update `pkg/plugin/openapi/openapi.json` to reflect endpoint changes
+2. Run `nvm use 22 && npm run validate:openapi` to validate the spec
+3. Follow the complete quality workflow (see [Mandatory Quality Workflow](#mandatory-quality-workflow))
 
 ### Debugging Common Issues
 


### PR DESCRIPTION
## Summary

Integrates OpenAPI spec validation as a mandatory quality gate in the development workflow to ensure API documentation stays in sync with code changes.

## Changes

### Quality Workflow Updates (CLAUDE.md)
- **Added Step 2: OpenAPI Spec Validation** - New dedicated step after LSP diagnostics
  - Marked as REQUIRED when HTTP endpoints are modified in `pkg/plugin/plugin.go`
  - Includes clear instructions to update `pkg/plugin/openapi/openapi.json`
  - Command: `nvm use 22 && npm run validate:openapi`
  - Links to API Documentation section for detailed maintenance guidelines

- **Updated Step 6: Tests & Lint** - Added `npm run validate:openapi` to the test suite alongside unit tests, linting, and type checking

- **Enhanced "Modifying HTTP Routes" section** - Added CRITICAL reminder block with 3-step process:
  1. Update `pkg/plugin/openapi/openapi.json` to reflect endpoint changes
  2. Run `nvm use 22 && npm run validate:openapi` to validate the spec
  3. Follow the complete quality workflow

### Step Renumbering
All subsequent steps were renumbered to accommodate the new OpenAPI validation step:
- Step 2: OpenAPI Spec Validation (NEW)
- Step 3: Code Review (was Step 2)
- Step 4: Code Simplification (was Step 3)
- Step 5: Remove AI Slop & Excessive Comments (was Step 4)
- Step 6: Tests & Lint (was Step 5) - now includes OpenAPI validation
- Step 7: PR Review (was Step 6)

The workflow maintains a logical flow: LSP → OpenAPI → Code Review → Simplification → Tests → PR Review

## Why These Changes

The plugin's REST API is fully documented in OpenAPI 3.0.3 spec at `pkg/plugin/openapi/openapi.json` (all 23 endpoints). The validation infrastructure already exists:
- Validation command: `npm run validate:openapi`
- Test suite: `pkg/plugin/openapi/openapi_test.go`
- Spec served at: `/api/plugins/consensys-asko11y-app/resources/openapi.json`

However, there was **no explicit requirement** in the quality workflow to update and validate the spec when endpoints change. This could lead to:
- API documentation drift between code and spec
- Outdated specs served to API consumers
- Missing documentation for new endpoints
- Invalid specs that break tooling (Swagger Editor, API clients)

By making OpenAPI validation a required quality gate:
- ✅ Specs are validated early (Step 2) to catch issues before code review
- ✅ Developers are explicitly reminded to update specs alongside code changes
- ✅ Validation runs in both dedicated step AND test suite (double enforcement)
- ✅ Consistent enforcement across all API changes
- ✅ Links to comprehensive maintenance guidelines (API Documentation section)

## Implementation Details

**Positioning:** Step 2 (after LSP diagnostics, before code review)
- Early validation provides fast feedback
- Catches spec issues before investing time in code review
- Complements LSP diagnostics with API-level validation

**Conditional Enforcement:**
- Only required when HTTP endpoints are modified in `pkg/plugin/plugin.go`
- Clearly marked with "if API endpoints changed" conditional
- Reduces noise for non-API changes

**Double Enforcement Strategy:**
1. **Dedicated Step 2:** OpenAPI Spec Validation with detailed instructions
2. **Step 6 Integration:** Validation runs in test suite alongside unit tests/linting

**Cross-References:**
- Links to API Documentation section (lines 608-674 in CLAUDE.md)
- References maintenance workflow: update spec → validate → commit together
- Documents all 23 endpoints, RBAC requirements, rate limiting, SSE streaming

## Related Files

- **Spec:** `pkg/plugin/openapi/openapi.json` (2050+ lines)
- **Tests:** `pkg/plugin/openapi/openapi_test.go` (381 lines)
- **Serve Logic:** `pkg/plugin/openapi/openapi.go` (embedded at compile time)
- **Route:** `/api/plugins/consensys-asko11y-app/resources/openapi.json`

## Testing

The OpenAPI validation infrastructure is already in place:
```bash
# Validation command
nvm use 22 && npm run validate:openapi

# Go tests include spec validation
go test ./pkg/plugin/openapi/...

# Manual testing with Swagger Editor
curl http://localhost:3000/api/plugins/consensys-asko11y-app/resources/openapi.json > spec.json
# Load spec.json into https://editor.swagger.io/
```

Validation tests check for:
- JSON validity and OpenAPI 3.0.3 format
- All 23 endpoints documented
- RBAC documentation (403 responses)
- SSE streaming endpoint format (`text/event-stream`)
- Rate limiting documentation (429 responses)
- Required schemas (RunRequest, ChatSession, Tool, etc.)
- Security schemes (GrafanaSession cookie auth)

---

**Impact:** This change ensures the quality workflow enforces the API documentation maintenance practices that were already documented but not explicitly required as a quality gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust the development checklist; no runtime code, API behavior, or data handling is modified.
> 
> **Overview**
> Updates `CLAUDE.md` to make OpenAPI spec validation an explicit quality gate when backend HTTP routes change, requiring updates to `pkg/plugin/openapi/openapi.json` and running `nvm use 22 && npm run validate:openapi`.
> 
> Renumbers the workflow steps accordingly, adds the OpenAPI validation command to the standard “Tests & Lint” checklist, and adds a prominent reminder in the “Modifying HTTP Routes” section to keep routes and the spec in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c81d3883ea989841769512d20df0cccb5bfcbf1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->