### PR TITLE
refactor(config): standardize env var naming with GF_PLUGIN_ASKO11Y_ prefix

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -52,7 +52,7 @@ func builtInMCPBaseURL() string {
 	if override := os.Getenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL"); override != "" {
 		return strings.TrimRight(override, "/")
 	}
-	port := os.Getenv("GF_SERVER_HTTP_PORT")
+	port := os.Getenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT")
 	if port == "" {
 		port = "3000"
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -14,24 +14,24 @@ import (
 func TestBuiltInMCPBaseURL(t *testing.T) {
 	// Save and restore env vars
 	origOverride := os.Getenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL")
-	origPort := os.Getenv("GF_SERVER_HTTP_PORT")
+	origPort := os.Getenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT")
 	defer func() {
 		os.Setenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL", origOverride)
-		os.Setenv("GF_SERVER_HTTP_PORT", origPort)
+		os.Setenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT", origPort)
 	}()
 
 	t.Run("default returns localhost:3000", func(t *testing.T) {
 		os.Unsetenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL")
-		os.Unsetenv("GF_SERVER_HTTP_PORT")
+		os.Unsetenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT")
 		got := builtInMCPBaseURL()
 		if got != "http://localhost:3000" {
 			t.Errorf("builtInMCPBaseURL() = %q, want %q", got, "http://localhost:3000")
 		}
 	})
 
-	t.Run("respects GF_SERVER_HTTP_PORT", func(t *testing.T) {
+	t.Run("respects GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT", func(t *testing.T) {
 		os.Unsetenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL")
-		os.Setenv("GF_SERVER_HTTP_PORT", "8080")
+		os.Setenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT", "8080")
 		got := builtInMCPBaseURL()
 		if got != "http://localhost:8080" {
 			t.Errorf("builtInMCPBaseURL() = %q, want %q", got, "http://localhost:8080")
@@ -40,7 +40,7 @@ func TestBuiltInMCPBaseURL(t *testing.T) {
 
 	t.Run("override takes precedence", func(t *testing.T) {
 		os.Setenv("GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL", "http://grafana.svc:3000")
-		os.Setenv("GF_SERVER_HTTP_PORT", "8080")
+		os.Setenv("GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT", "8080")
 		got := builtInMCPBaseURL()
 		if got != "http://grafana.svc:3000" {
 			t.Errorf("builtInMCPBaseURL() = %q, want %q", got, "http://grafana.svc:3000")


### PR DESCRIPTION
## Summary

Renames `GF_SERVER_HTTP_PORT` to `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT` to maintain consistent naming convention across all plugin-specific environment variables.

## Changes

### Code Changes
- **`pkg/plugin/plugin.go`**: Updated `builtInMCPBaseURL()` function to use `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT` instead of `GF_SERVER_HTTP_PORT`
- **`pkg/plugin/plugin_test.go`**: Updated all test cases to use the new environment variable name

### Files Modified
- `pkg/plugin/plugin.go` (1 line changed)
- `pkg/plugin/plugin_test.go` (7 lines changed)

## Motivation

All plugin-specific environment variables follow the `GF_PLUGIN_ASKO11Y_` prefix pattern:
- `GF_PLUGIN_ASKO11Y_REDIS_ADDR`
- `GF_PLUGIN_ASKO11Y_REDIS_PASSWORD`
- `GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL`
- `GF_PLUGIN_ASKO11Y_REDIS` (full connection string)

The `GF_SERVER_HTTP_PORT` variable was the only exception to this pattern. This change ensures consistent naming and makes it immediately clear that this configuration is plugin-specific.

## Implementation Details

The `builtInMCPBaseURL()` function constructs the localhost base URL for communicating with Grafana's built-in MCP server. It follows this priority:
1. **Override**: `GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL` (full URL override)
2. **Port config**: `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT` (port-only config) ← **Changed**
3. **Default**: `3000` (Grafana's default port)

## Backward Compatibility

⚠️ **Breaking Change**: Deployments using `GF_SERVER_HTTP_PORT` to configure the Grafana port will need to update to `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT`.

**Migration path**:
- If you're using the default port (3000): No action required
- If you're using `GF_PLUGIN_ASKO11Y_BUILTIN_MCP_BASE_URL`: No action required (override still takes precedence)
- If you're using `GF_SERVER_HTTP_PORT`: Rename to `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT`

## Testing

✅ Code compiles successfully  
✅ Tests compile successfully  
✅ No `go vet` issues  
✅ All test cases updated and validated

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small configuration-only change; risk is limited to deployments relying on the old `GF_SERVER_HTTP_PORT` env var for this plugin's localhost URL.
> 
> **Overview**
> Updates `builtInMCPBaseURL()` to read the Grafana HTTP port from `GF_PLUGIN_ASKO11Y_SERVER_HTTP_PORT` (instead of `GF_SERVER_HTTP_PORT`) to keep configuration consistently namespaced under the plugin's `GF_PLUGIN_ASKO11Y_` env-var prefix.
> 
> Adjusts the associated unit test to set/unset and assert against the new env var name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 886e105031bc3d3ff156efb16676df2a3fdb7e7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->