### PR TITLE
fix: filter node_modules from Go manifest

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -1,11 +1,38 @@
-//+build mage
+//go:build mage
 
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	// mage:import
 	build "github.com/grafana/grafana-plugin-sdk-go/build"
 )
 
-// Default configures the default target.
-var Default = build.BuildAll
+func Default() error {
+	build.BuildAll()
+	return CleanManifest()
+}
+
+// CleanManifest strips node_modules/ entries from dist/go_plugin_build_manifest.
+// Workaround for https://github.com/grafana/grafana-plugin-sdk-go/issues/XXX
+func CleanManifest() error {
+	p := filepath.Join("dist", "go_plugin_build_manifest")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	var filtered []string
+	for _, line := range lines {
+		if !strings.Contains(line, "node_modules/") {
+			filtered = append(filtered, line)
+		}
+	}
+	return os.WriteFile(p, []byte(strings.Join(filtered, "\n")), 0644)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,9 +3621,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -10720,10 +10720,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -13439,9 +13442,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -21773,9 +21776,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
   },
   "packageManager": "npm@11.5.1",
   "overrides": {
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.4",
+    "hono": "^4.12.5",
+    "@hono/node-server": "^1.19.11"
   }
 }


### PR DESCRIPTION
## Problem

The v0.2.10 release failed Grafana Cloud validation with:
```
Invalid Go manifest file: node_modules/flatted/golang/pkg/flatted/flatted.go
is in the manifest but not in source code
```

The SDK's `GenerateManifest()` walks the entire directory tree and picks up `.go` files from npm packages. The `flatted` package (transitive dependency of `streamdown`) ships Go source in older versions.

**CI passed** because it validates with `-sourceCodeUri file://./` (includes node_modules).
**Grafana Cloud failed** because it validates standalone archives (no source directory).

## Solution

Override `BuildAll` in `Magefile.go` to post-process `go_plugin_build_manifest` and filter out `node_modules/` entries.

## Testing

- [ ] Build locally: `npm run build`
- [ ] Verify manifest: `grep node_modules dist/go_plugin_build_manifest` (should return nothing)
- [ ] Validate archive: `npm run validate:run`

## Related

- Opened upstream PR on grafana/plugin-validator to skip node_modules validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the build/release pipeline and directly rewrites the generated manifest; incorrect filtering or file handling could affect plugin packaging/validation but not runtime behavior.
> 
> **Overview**
> Ensures the default Mage build runs the SDK `BuildAll` and then *cleans the generated Go build manifest* to drop any entries under `node_modules/`.
> 
> Adds a `CleanManifest()` step that reads `dist/go_plugin_build_manifest`, filters out lines containing `node_modules/`, and writes the result back (no-op if the manifest is missing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e6c5a181c7d64eeb46beb6c9f6410d9325afa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->