### PR TITLE
ci(release): remove skip-github-release to unblock release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,8 +7,7 @@
       "component": "ask-o11y-plugin",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "skip-github-release": true
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
release-please aborts with 'untagged, merged release PRs outstanding' because `skip-github-release: true` prevents it from creating a GH Release, so it can't detect v0.2.10 was released. Removing this flag lets release-please create the release (tag still triggers the build workflow).