### PR TITLE
revert: restore skip-github-release in release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,7 +7,8 @@
       "component": "ask-o11y-plugin",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "skip-github-release": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Reverts the incorrect change from #72. The GH release is created by `grafana/plugin-actions/build-plugin` on tag push, not by release-please.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting release automation; main impact would be on how/where GitHub Releases get created if the pipeline assumptions are wrong.
> 
> **Overview**
> Re-enables `skip-github-release: true` in `.github/release-please-config.json`, reverting release-please behavior to **only manage tags/changelogs** while leaving GitHub Release creation to other automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a4a601bdc8d6da3f912da242c432601ba7e074a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->