### PR TITLE
fix(mcp): namespace mcp-tool-settings localStorage key with plugin ID

### DIFF
--- a/src/pages/MCPTools.test.tsx
+++ b/src/pages/MCPTools.test.tsx
@@ -11,34 +11,34 @@ describe('MCPToolsPage utilities', () => {
 
     it('should store tool settings in localStorage', () => {
       const settings = { 'prometheus_query': true, 'loki_query': false };
-      localStorage.setItem('mcp-tool-settings', JSON.stringify(settings));
+      localStorage.setItem('consensys-asko11y-app:mcp-tool-settings', JSON.stringify(settings));
 
-      const stored = localStorage.getItem('mcp-tool-settings');
+      const stored = localStorage.getItem('consensys-asko11y-app:mcp-tool-settings');
       expect(stored).not.toBeNull();
       expect(JSON.parse(stored!)).toEqual(settings);
     });
 
     it('should retrieve tool settings from localStorage', () => {
       const settings = { 'grafana_dashboard_list': true };
-      localStorage.setItem('mcp-tool-settings', JSON.stringify(settings));
+      localStorage.setItem('consensys-asko11y-app:mcp-tool-settings', JSON.stringify(settings));
 
-      const stored = JSON.parse(localStorage.getItem('mcp-tool-settings')!);
+      const stored = JSON.parse(localStorage.getItem('consensys-asko11y-app:mcp-tool-settings')!);
       expect(stored).toHaveProperty('grafana_dashboard_list', true);
     });
 
     it('should handle empty localStorage', () => {
-      const stored = localStorage.getItem('mcp-tool-settings');
+      const stored = localStorage.getItem('consensys-asko11y-app:mcp-tool-settings');
       expect(stored).toBeNull();
     });
 
     it('should allow updating tool settings', () => {
       const settings = { 'tool1': true, 'tool2': true };
-      localStorage.setItem('mcp-tool-settings', JSON.stringify(settings));
+      localStorage.setItem('consensys-asko11y-app:mcp-tool-settings', JSON.stringify(settings));
 
       const updated = { ...settings, 'tool2': false };
-      localStorage.setItem('mcp-tool-settings', JSON.stringify(updated));
+      localStorage.setItem('consensys-asko11y-app:mcp-tool-settings', JSON.stringify(updated));
 
-      const stored = JSON.parse(localStorage.getItem('mcp-tool-settings')!);
+      const stored = JSON.parse(localStorage.getItem('consensys-asko11y-app:mcp-tool-settings')!);
       expect(stored.tool2).toBe(false);
     });
   });

--- a/src/pages/MCPTools.tsx
+++ b/src/pages/MCPTools.tsx
@@ -11,6 +11,8 @@ import { PluginPage, config } from '@grafana/runtime';
 import { css } from '@emotion/css';
 import { backendMCPClient } from '../services/backendMCPClient';
 
+const TOOL_SETTINGS_KEY = 'consensys-asko11y-app:mcp-tool-settings';
+
 interface Tool {
   name: string;
   description?: string;
@@ -47,7 +49,7 @@ export function MCPToolsPage() {
       setTools(fetchedTools);
 
       // Load tool settings from localStorage
-      const savedSettings = localStorage.getItem('mcp-tool-settings');
+      const savedSettings = localStorage.getItem(TOOL_SETTINGS_KEY);
       if (savedSettings) {
         setToolSettings(JSON.parse(savedSettings));
       } else {
@@ -68,7 +70,7 @@ export function MCPToolsPage() {
   // Save settings to localStorage
   const saveSettings = (newSettings: ToolSettings) => {
     setToolSettings(newSettings);
-    localStorage.setItem('mcp-tool-settings', JSON.stringify(newSettings));
+    localStorage.setItem(TOOL_SETTINGS_KEY, JSON.stringify(newSettings));
   };
 
   // Toggle tool enabled state


### PR DESCRIPTION
## Summary

- Namespace the `mcp-tool-settings` localStorage key with the plugin ID (`consensys-asko11y-app:mcp-tool-settings`) to avoid collisions with other Grafana plugins that might use the same generic key name
- Extract the key into a `TOOL_SETTINGS_KEY` constant in `MCPTools.tsx` for maintainability
- Update all test references to use the new namespaced key

## Why

The `mcp-tool-settings` localStorage key was a generic name with no plugin-specific prefix. In a Grafana instance running multiple plugins, any other plugin using the same key would overwrite or read incorrect tool settings. The `consensys-asko11y-app:` prefix follows the namespacing convention already used by other storage keys in this codebase (e.g., the `consensys-asko11y` prefix referenced in `ErrorBoundary.tsx` cleanup logic).

## Changes

- `src/pages/MCPTools.tsx` — Added `TOOL_SETTINGS_KEY` constant, replaced inline string literals
- `src/pages/MCPTools.test.tsx` — Updated all localStorage references to use the namespaced key

## Test plan

- [x] Unit tests pass (`npm run test:ci`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only affects client-side persistence, but it will stop reading the old `mcp-tool-settings` key so existing users may see their saved tool enable/disable preferences reset once.
> 
> **Overview**
> Tool enable/disable settings for the MCP Tools page are now persisted under a plugin-namespaced localStorage key (`consensys-asko11y-app:mcp-tool-settings`) instead of the generic `mcp-tool-settings` to avoid collisions with other plugins.
> 
> Adds a shared `TOOL_SETTINGS_KEY` constant in `MCPTools.tsx` and updates the related unit tests to use the new key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a96be82d2025e5b2a08d4cb20c24a9cb89f223ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->