### PR TITLE
fix(backend): change per-request MCP log statements from Info to Debug

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -381,7 +381,7 @@ func (p *Plugin) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 func (p *Plugin) handleMCPTools(w http.ResponseWriter, r *http.Request) {
 	userRole := getUserRole(r)
-	p.logger.Info("MCP tools request", "method", r.Method, "role", userRole)
+	p.logger.Debug("MCP tools request", "method", r.Method, "role", userRole)
 
 	tools, err := p.mcpProxy.ListTools()
 	if err != nil {
@@ -422,7 +422,7 @@ func (p *Plugin) handleMCPCallTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p.logger.Info("MCP call tool request", "tool", req.Name, "role", userRole)
+	p.logger.Debug("MCP call tool request", "tool", req.Name, "role", userRole)
 
 	tool, found := p.mcpProxy.FindToolByName(req.Name)
 	if !found {
@@ -460,7 +460,7 @@ func (p *Plugin) handleMCPCallTool(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Plugin) handleMCPServers(w http.ResponseWriter, r *http.Request) {
-	p.logger.Info("MCP servers status request", "method", r.Method)
+	p.logger.Debug("MCP servers status request", "method", r.Method)
 
 	healthMonitor := p.mcpProxy.GetHealthMonitor()
 	serversHealth := healthMonitor.GetAllHealth()


### PR DESCRIPTION
## Summary

- Changed three per-request MCP log statements from `Info` to `Debug` level in `pkg/plugin/plugin.go`
  - `handleMCPTools` — "MCP tools request"
  - `handleMCPCallTool` — "MCP call tool request"
  - `handleMCPServers` — "MCP servers status request"

## Why

These endpoints are called frequently during normal operation (every tool listing, every tool call, every status check). At `Info` level they create significant log noise in production, making it harder to spot meaningful events. `Debug` level keeps them available for troubleshooting without cluttering default log output.

## Test plan

- [x] `go test ./pkg/...` — all backend tests pass
- [ ] Verify logs appear at debug level in Grafana dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)