### PR TITLE
refactor(mcp): use Grafana SDK httpclient instead of bare http.Client

### DIFF
--- a/pkg/agent/llm_client.go
+++ b/pkg/agent/llm_client.go
@@ -27,9 +27,9 @@ type LLMClient struct {
 	logger     log.Logger
 }
 
-func NewLLMClient(logger log.Logger) *LLMClient {
+func NewLLMClient(logger log.Logger, httpClient *http.Client) *LLMClient {
 	return &LLMClient{
-		httpClient: &http.Client{Timeout: llmTimeout},
+		httpClient: httpClient,
 		logger:     logger,
 	}
 }

--- a/pkg/agent/llm_client_test.go
+++ b/pkg/agent/llm_client_test.go
@@ -58,7 +58,7 @@ func TestLLMClient_ChatCompletion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewLLMClient(log.DefaultLogger)
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 
 	resp, err := client.ChatCompletion(context.Background(), ChatCompletionRequest{
 		Messages: []Message{{Role: "user", Content: "hi"}},
@@ -97,7 +97,7 @@ func TestLLMClient_ChatCompletion_FallbackToToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewLLMClient(log.DefaultLogger)
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	resp, err := client.ChatCompletion(context.Background(), ChatCompletionRequest{
 		Messages: []Message{{Role: "user", Content: "hi"}},
 	}, server.URL, "sa-token", "1")
@@ -117,7 +117,7 @@ func TestLLMClient_ChatCompletion_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewLLMClient(log.DefaultLogger)
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	_, err := client.ChatCompletion(context.Background(), ChatCompletionRequest{
 		Messages: []Message{{Role: "user", Content: "hi"}},
 	}, server.URL, "", "1")
@@ -133,7 +133,7 @@ func TestLLMClient_ChatCompletion_NoChoices(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewLLMClient(log.DefaultLogger)
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	_, err := client.ChatCompletion(context.Background(), ChatCompletionRequest{
 		Messages: []Message{{Role: "user", Content: "hi"}},
 	}, server.URL, "", "1")
@@ -150,7 +150,7 @@ func TestLLMClient_ChatCompletion_ContextCancelled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewLLMClient(log.DefaultLogger)
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -27,7 +27,7 @@ func setupTestLoop(t *testing.T, llmResponses []ChatCompletionResponse) (*AgentL
 		callIdx++
 	}))
 
-	llmClient := NewLLMClient(log.DefaultLogger)
+	llmClient := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	mcpProxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
 	loop := NewAgentLoop(llmClient, mcpProxy, log.DefaultLogger)
 
@@ -269,7 +269,7 @@ func TestAgentLoop_ContextCancellation(t *testing.T) {
 	}))
 	defer slowServer.Close()
 
-	llmClient := NewLLMClient(log.DefaultLogger)
+	llmClient := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
 	mcpProxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
 	loop := NewAgentLoop(llmClient, mcpProxy, log.DefaultLogger)
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -75,8 +74,10 @@ func (t *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return t.base.RoundTrip(req)
 }
 
-// NewClient creates a new MCP client
-func NewClient(parent context.Context, config ServerConfig, logger log.Logger) *Client {
+// NewClient creates a new MCP client.
+// The baseTransport should be obtained from the Grafana SDK httpclient package
+// to respect proxy configuration, custom CA bundles, and auth middleware.
+func NewClient(parent context.Context, config ServerConfig, logger log.Logger, baseTransport http.RoundTripper) *Client {
 	ctx, cancel := context.WithCancel(parent)
 
 	return &Client{
@@ -85,6 +86,7 @@ func NewClient(parent context.Context, config ServerConfig, logger log.Logger) *
 		operationMetadata: make(map[string]OperationMetadata),
 		ctx:               ctx,
 		cancel:            cancel,
+		httpClient:        &http.Client{Transport: baseTransport, Timeout: 30 * time.Second},
 	}
 }
 
@@ -154,19 +156,14 @@ func (c *Client) connectMCP() error {
 
 const connectDialTimeout = 10 * time.Second
 
-func baseTransport() *http.Transport {
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.DialContext = (&net.Dialer{Timeout: connectDialTimeout}).DialContext
-	return t
-}
-
 func (c *Client) httpClientWithHeaders() *http.Client {
+	transport := c.httpClient.Transport
 	if len(c.config.Headers) == 0 {
-		return &http.Client{Transport: baseTransport()}
+		return &http.Client{Transport: transport}
 	}
 	return &http.Client{
 		Transport: &configHeaderRoundTripper{
-			base:    baseTransport(),
+			base:    transport,
 			headers: c.config.Headers,
 		},
 	}
@@ -208,10 +205,9 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 		Version: "1.0.0",
 	}, nil)
 
-	// Create custom HTTP client with customRoundTripper
 	customHTTPClient := &http.Client{
 		Transport: &customRoundTripper{
-			base:       baseTransport(),
+			base:       c.httpClient.Transport,
 			orgID:      orgID,
 			orgName:    orgName,
 			scopeOrgId: scopeOrgId,
@@ -572,7 +568,7 @@ func (c *Client) listOpenAPITools() ([]Tool, error) {
 		req.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OpenAPI spec: %w", err)
 	}
@@ -750,7 +746,7 @@ func (c *Client) listStandardTools() ([]Tool, error) {
 		req.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tools: %w", err)
 	}
@@ -990,7 +986,7 @@ func (c *Client) callOpenAPIToolWithContext(toolName string, arguments map[strin
 		req.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}
@@ -1068,7 +1064,7 @@ func (c *Client) callStandardTool(toolName string, arguments map[string]interfac
 		req.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
@@ -55,6 +57,8 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) {
 		}
 	}
 
+	transport := p.sdkTransport()
+
 	// Collect stale clients under lock, then close outside the lock
 	// to avoid holding mu while blocking on network I/O.
 	var stale []*Client
@@ -69,7 +73,7 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) {
 	}
 	for id, config := range newConfigs {
 		if _, exists := p.clients[id]; !exists {
-			p.clients[id] = NewClient(p.ctx, config, p.logger)
+			p.clients[id] = NewClient(p.ctx, config, p.logger, transport)
 			p.logger.Info("Added MCP client", "id", id, "url", config.URL, "type", config.Type)
 		}
 	}
@@ -309,7 +313,7 @@ func (p *Proxy) EnsureServer(config ServerConfig) {
 		p.logger.Debug("Replacing MCP client", "id", config.ID)
 	}
 
-	p.clients[config.ID] = NewClient(p.ctx, config, p.logger)
+	p.clients[config.ID] = NewClient(p.ctx, config, p.logger, p.sdkTransport())
 	p.mu.Unlock()
 
 	if replaced != nil {
@@ -319,6 +323,19 @@ func (p *Proxy) EnsureServer(config ServerConfig) {
 	}
 
 	p.logger.Info("Ensured MCP client", "id", config.ID, "url", config.URL, "type", config.Type)
+}
+
+func (p *Proxy) sdkTransport() http.RoundTripper {
+	transport, err := httpclient.GetTransport(httpclient.Options{
+		Timeouts: &httpclient.TimeoutOptions{
+			DialTimeout: connectDialTimeout,
+		},
+	})
+	if err != nil {
+		p.logger.Error("Failed to create SDK HTTP transport, falling back to default", "error", err)
+		return http.DefaultTransport
+	}
+	return transport
 }
 
 func headersEqual(a, b map[string]string) bool {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
@@ -173,7 +174,17 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		sessionStore = NewRedisSessionStore(pluginCtx, redisClient, logger)
 	}
 
-	llmClient := agent.NewLLMClient(logger)
+	llmHTTPClient, err := httpclient.New(httpclient.Options{
+		Timeouts: &httpclient.TimeoutOptions{
+			Timeout:     120 * time.Second,
+			DialTimeout: 10 * time.Second,
+		},
+	})
+	if err != nil {
+		logger.Error("Failed to create SDK HTTP client for LLM, using default", "error", err)
+		llmHTTPClient = &http.Client{Timeout: 120 * time.Second}
+	}
+	llmClient := agent.NewLLMClient(logger, llmHTTPClient)
 	agentLoop := agent.NewAgentLoop(llmClient, mcpProxy, logger)
 
 	p := &Plugin{


### PR DESCRIPTION
## Summary

- Replace all bare `&http.Client{}` and `http.DefaultClient` usage in the Go backend with Grafana SDK's `httpclient` package
- SDK-provided transports respect proxy configuration, custom CA bundles, and auth middleware required by enterprise Grafana environments
- Add 30s default timeout to MCP client HTTP calls that previously had no timeout at all

## What changed

| File | Change |
|------|--------|
| `pkg/mcp/client.go` | `NewClient` accepts an `http.RoundTripper` from SDK; deleted `baseTransport()`; replaced 4x `http.DefaultClient.Do()` with `c.httpClient.Do()` |
| `pkg/mcp/proxy.go` | Added `sdkTransport()` helper using `httpclient.GetTransport()`; passes SDK transport to all `NewClient` calls |
| `pkg/agent/llm_client.go` | `NewLLMClient` accepts `*http.Client` instead of creating a bare one internally |
| `pkg/plugin/plugin.go` | Creates SDK HTTP client via `httpclient.New()` with 120s timeout for LLM calls |
| `pkg/agent/llm_client_test.go` | Updated 5 test call sites for new signature |
| `pkg/agent/loop_test.go` | Updated 2 test call sites for new signature |

## Why

The previous implementation used `http.DefaultClient` (no timeout, no TLS config) and `&http.Client{}` with only a basic cloned transport. This bypasses:
- **Proxy configuration** — enterprise environments behind corporate proxies
- **Custom CA bundles** — internal PKI / self-signed certificates
- **Auth middleware** — SDK-provided authentication and tracing middleware

The Grafana SDK `httpclient` package handles all of these automatically.

## Design

**Get-transport-then-wrap**: SDK transport created once per proxy/client lifecycle, stored on the struct, then wrapped by existing `customRoundTripper` / `configHeaderRoundTripper` for org header injection. Fallback to `http.DefaultTransport` if SDK transport creation fails.

## Test plan

- [x] `go build ./pkg/...` compiles cleanly
- [x] `go test ./pkg/...` — all backend tests pass
- [ ] Manual verification with enterprise proxy/TLS configuration