### PR TITLE
docs: move REST API reference from catalog README to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ This project and everyone participating in it is expected to uphold professional
 - [Contributing Code](#contributing-code)
 - [Development Setup](#development-setup)
 - [Code Standards](#code-standards)
+- [REST API Reference](#rest-api-reference)
 - [Testing Guidelines](#testing-guidelines)
 - [Pull Request Process](#pull-request-process)
 - [Commit Message Guidelines](#commit-message-guidelines)
@@ -288,6 +289,42 @@ pkg/
 ├── plugin/         # Plugin implementation, routes, RBAC
 └── mcp/            # MCP client, proxy, health
 ```
+
+---
+
+## REST API Reference
+
+Ask O11y exposes a REST API under `/api/plugins/consensys-asko11y-app/resources/`. All endpoints require Grafana session authentication.
+
+The full OpenAPI 3.0.3 spec is available at:
+
+```
+/api/plugins/consensys-asko11y-app/resources/openapi.json
+```
+
+Key endpoints:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/health` | Plugin and MCP server health status |
+| `POST` | `/api/agent/run` | Start an AI conversation (SSE streaming) |
+| `GET/POST` | `/api/agent/runs/{runId}/events` | Reconnect to an active SSE stream |
+| `POST` | `/api/agent/runs/{runId}/cancel` | Cancel an in-progress run |
+| `GET` | `/api/mcp/tools` | List available MCP tools (RBAC-filtered) |
+| `POST` | `/api/mcp/call-tool` | Execute an MCP tool directly |
+| `GET` | `/api/mcp/servers` | List configured MCP servers and health |
+| `GET` | `/api/sessions` | List your sessions |
+| `GET/PUT/DELETE` | `/api/sessions/{id}` | Get, update, or delete a session |
+| `POST` | `/api/sessions/share` | Create a share link |
+| `GET` | `/api/sessions/shared/{shareId}` | Fetch a shared session (public) |
+| `DELETE` | `/api/sessions/share/{shareId}` | Revoke a share link |
+| `GET` | `/api/sessions/{id}/shares` | List all shares for a session |
+| `GET` | `/api/prompt-defaults` | Get default prompt templates |
+
+**Limits:**
+- Max 50 sessions per user per org (oldest auto-evicted)
+- Max 25 agent iterations per run
+- Max 50 share links created per hour per user
 
 ---
 

--- a/src/README.md
+++ b/src/README.md
@@ -155,37 +155,9 @@ Customize three prompts: **System Prompt** (base AI instructions), **Investigati
 
 ## REST API
 
-Ask O11y exposes a REST API under `/api/plugins/consensys-asko11y-app/resources/`. All endpoints require Grafana session authentication.
+Ask O11y exposes a REST API for programmatic access. The OpenAPI 3.0.3 spec is served at `/api/plugins/consensys-asko11y-app/resources/openapi.json`.
 
-The full OpenAPI 3.0.3 spec is available at:
-
-```
-/api/plugins/consensys-asko11y-app/resources/openapi.json
-```
-
-Key endpoints:
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/health` | Plugin and MCP server health status |
-| `POST` | `/api/agent/run` | Start an AI conversation (SSE streaming) |
-| `GET/POST` | `/api/agent/runs/{runId}/events` | Reconnect to an active SSE stream |
-| `POST` | `/api/agent/runs/{runId}/cancel` | Cancel an in-progress run |
-| `GET` | `/api/mcp/tools` | List available MCP tools (RBAC-filtered) |
-| `POST` | `/api/mcp/call-tool` | Execute an MCP tool directly |
-| `GET` | `/api/mcp/servers` | List configured MCP servers and health |
-| `GET` | `/api/sessions` | List your sessions |
-| `GET/PUT/DELETE` | `/api/sessions/{id}` | Get, update, or delete a session |
-| `POST` | `/api/sessions/share` | Create a share link |
-| `GET` | `/api/sessions/shared/{shareId}` | Fetch a shared session (public) |
-| `DELETE` | `/api/sessions/share/{shareId}` | Revoke a share link |
-| `GET` | `/api/sessions/{id}/shares` | List all shares for a session |
-| `GET` | `/api/prompt-defaults` | Get default prompt templates |
-
-**Limits:**
-- Max 50 sessions per user per org (oldest auto-evicted)
-- Max 25 agent iterations per run
-- Max 50 share links created per hour per user
+For the full endpoint reference, see the [REST API Reference](https://github.com/Consensys/ask-o11y-plugin/blob/main/CONTRIBUTING.md#rest-api-reference) in the contributing guide.
 
 ---
 


### PR DESCRIPTION
## Summary

- Moved the detailed REST API endpoint table and rate limits from `src/README.md` (the Grafana plugin catalog README) to `CONTRIBUTING.md`
- Replaced the full API section in the catalog README with a brief pointer to the OpenAPI spec URL and a link to the contributing guide

## Why

The REST API reference (endpoint table, rate limits) is developer/contributor-facing content. End users browsing the Grafana plugin catalog don't need a full endpoint listing — they need to know the API exists and where to find the spec. Moving this to `CONTRIBUTING.md` keeps the catalog README focused on user-facing documentation while preserving the reference for contributors.

## Changes

- **`src/README.md`**: Replaced 34-line endpoint table with a 2-line summary pointing to the OpenAPI spec and contributing guide
- **`CONTRIBUTING.md`**: Added "REST API Reference" section (with ToC entry) between "Code Standards" and "Testing Guidelines"

## Test plan

- [ ] Verify `src/README.md` renders correctly in the Grafana plugin catalog
- [ ] Verify `CONTRIBUTING.md` REST API Reference section renders correctly on GitHub
- [ ] Verify the cross-link from `src/README.md` to `CONTRIBUTING.md#rest-api-reference` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)