### PR TITLE
fix: use http client from grafana sdk everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ mcpServers:
 - **No hardcoded colors** — use semantic Tailwind: `bg-background`, `text-primary`, `border-weak`, etc.
 - **No `any`** — use `unknown`
 - **No raw errors in HTTP responses** — log server-side, return generic message to client
+- **No `&http.Client{}` direct construction** — always use `github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.New()`. When wrapping for custom headers, copy `.Timeout` from the SDK client into the wrapper. Never create a bare `&http.Client{}` as a fallback — propagate the error instead.
 - Prefer `@grafana/ui` components over custom implementations
 - Catch blocks must handle errors meaningfully — never swallow silently
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -74,10 +74,7 @@ func (t *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return t.base.RoundTrip(req)
 }
 
-// NewClient creates a new MCP client.
-// The baseTransport should be obtained from the Grafana SDK httpclient package
-// to respect proxy configuration, custom CA bundles, and auth middleware.
-func NewClient(parent context.Context, config ServerConfig, logger log.Logger, baseTransport http.RoundTripper) *Client {
+func NewClient(parent context.Context, config ServerConfig, logger log.Logger, httpClient *http.Client) *Client {
 	ctx, cancel := context.WithCancel(parent)
 
 	return &Client{
@@ -86,7 +83,7 @@ func NewClient(parent context.Context, config ServerConfig, logger log.Logger, b
 		operationMetadata: make(map[string]OperationMetadata),
 		ctx:               ctx,
 		cancel:            cancel,
-		httpClient:        &http.Client{Transport: baseTransport, Timeout: 30 * time.Second},
+		httpClient:        httpClient,
 	}
 }
 
@@ -157,15 +154,15 @@ func (c *Client) connectMCP() error {
 const connectDialTimeout = 10 * time.Second
 
 func (c *Client) httpClientWithHeaders() *http.Client {
-	transport := c.httpClient.Transport
 	if len(c.config.Headers) == 0 {
-		return &http.Client{Transport: transport}
+		return c.httpClient
 	}
 	return &http.Client{
 		Transport: &configHeaderRoundTripper{
-			base:    transport,
+			base:    c.httpClient.Transport,
 			headers: c.config.Headers,
 		},
+		Timeout: c.httpClient.Timeout,
 	}
 }
 
@@ -213,6 +210,7 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 			scopeOrgId: scopeOrgId,
 			config:     c.config,
 		},
+		Timeout: c.httpClient.Timeout,
 	}
 
 	var transport mcpsdk.Transport

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -49,7 +49,7 @@ func (p *Proxy) GetHealthMonitor() *HealthMonitor {
 }
 
 // UpdateConfig updates the proxy configuration with new server configs
-func (p *Proxy) UpdateConfig(configs []ServerConfig) {
+func (p *Proxy) UpdateConfig(configs []ServerConfig) error {
 	newConfigs := make(map[string]ServerConfig)
 	for _, config := range configs {
 		if config.Enabled {
@@ -57,7 +57,10 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) {
 		}
 	}
 
-	transport := p.sdkTransport()
+	sdkHTTPClient, err := p.sdkClient()
+	if err != nil {
+		return fmt.Errorf("failed to create SDK HTTP client: %w", err)
+	}
 
 	// Collect stale clients under lock, then close outside the lock
 	// to avoid holding mu while blocking on network I/O.
@@ -73,7 +76,7 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) {
 	}
 	for id, config := range newConfigs {
 		if _, exists := p.clients[id]; !exists {
-			p.clients[id] = NewClient(p.ctx, config, p.logger, transport)
+			p.clients[id] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
 			p.logger.Info("Added MCP client", "id", id, "url", config.URL, "type", config.Type)
 		}
 	}
@@ -84,6 +87,7 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) {
 			p.logger.Warn("Failed to close removed MCP client", "error", err)
 		}
 	}
+	return nil
 }
 
 // ListTools aggregates tools from all configured MCP servers
@@ -298,7 +302,12 @@ func (p *Proxy) Close() {
 	}
 }
 
-func (p *Proxy) EnsureServer(config ServerConfig) {
+func (p *Proxy) EnsureServer(config ServerConfig) error {
+	sdkHTTPClient, err := p.sdkClient()
+	if err != nil {
+		return fmt.Errorf("failed to create SDK HTTP client: %w", err)
+	}
+
 	// Capture replaced client under lock, then close it outside the lock
 	// to avoid holding mu while blocking on network I/O.
 	var replaced *Client
@@ -307,13 +316,13 @@ func (p *Proxy) EnsureServer(config ServerConfig) {
 	if existing, ok := p.clients[config.ID]; ok {
 		if existing.config.URL == config.URL && headersEqual(existing.config.Headers, config.Headers) {
 			p.mu.Unlock()
-			return
+			return nil
 		}
 		replaced = existing
 		p.logger.Debug("Replacing MCP client", "id", config.ID)
 	}
 
-	p.clients[config.ID] = NewClient(p.ctx, config, p.logger, p.sdkTransport())
+	p.clients[config.ID] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
 	p.mu.Unlock()
 
 	if replaced != nil {
@@ -323,6 +332,7 @@ func (p *Proxy) EnsureServer(config ServerConfig) {
 	}
 
 	p.logger.Info("Ensured MCP client", "id", config.ID, "url", config.URL, "type", config.Type)
+	return nil
 }
 
 func (p *Proxy) RemoveServer(id string) {
@@ -341,17 +351,13 @@ func (p *Proxy) RemoveServer(id string) {
 	}
 }
 
-func (p *Proxy) sdkTransport() http.RoundTripper {
-	transport, err := httpclient.GetTransport(httpclient.Options{
+func (p *Proxy) sdkClient() (*http.Client, error) {
+	return httpclient.New(httpclient.Options{
 		Timeouts: &httpclient.TimeoutOptions{
+			Timeout:     30 * time.Second,
 			DialTimeout: connectDialTimeout,
 		},
 	})
-	if err != nil {
-		p.logger.Error("Failed to create SDK HTTP transport, falling back to default", "error", err)
-		return http.DefaultTransport
-	}
-	return transport
 }
 
 func headersEqual(a, b map[string]string) bool {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -174,7 +174,10 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 	pluginCtx, cancel := context.WithCancel(context.Background())
 
 	mcpProxy := mcp.NewProxy(pluginCtx, logger)
-	mcpProxy.UpdateConfig(pluginSettings.MCPServers)
+	if err := mcpProxy.UpdateConfig(pluginSettings.MCPServers); err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to configure MCP servers: %w", err)
+	}
 
 	mcpProxy.StartHealthMonitoring(MCPHealthMonitoringInterval)
 
@@ -221,8 +224,8 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		},
 	})
 	if err != nil {
-		logger.Error("Failed to create SDK HTTP client for LLM, using default", "error", err)
-		llmHTTPClient = &http.Client{Timeout: 120 * time.Second}
+		cancel()
+		return nil, fmt.Errorf("failed to create SDK HTTP client for LLM: %w", err)
 	}
 	llmClient := agent.NewLLMClient(logger, llmHTTPClient)
 	agentLoop := agent.NewAgentLoop(llmClient, mcpProxy, logger)
@@ -582,7 +585,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 			p.mcpProxy.RemoveServer("mcp-grafana")
 		} else {
 			builtInURL := grafanaURL + "/api/plugins/grafana-llm-app/resources/mcp/grafana"
-			p.mcpProxy.EnsureServer(mcp.ServerConfig{
+			if err := p.mcpProxy.EnsureServer(mcp.ServerConfig{
 				ID:      "mcp-grafana",
 				Name:    "Grafana Built-in MCP",
 				URL:     builtInURL,
@@ -591,7 +594,11 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 				Headers: map[string]string{
 					"Authorization": "Bearer " + saToken,
 				},
-			})
+			}); err != nil {
+				p.logger.Error("Failed to register built-in MCP server", "error", err)
+				http.Error(w, "Failed to initialize MCP server", http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes HTTP client construction and error handling for MCP/LLM calls, which can affect proxy behavior and plugin startup when SDK client creation fails. Main risk is altered timeout/transport usage and new fail-fast paths instead of silent fallbacks.
> 
> **Overview**
> **Standardizes outbound HTTP on the Grafana SDK client.** `mcp.NewClient` now takes an injected `*http.Client`, and MCP header-wrapping clients (`httpClientWithHeaders`, org-context transport) explicitly preserve the SDK client’s `Timeout`.
> 
> **Removes silent fallbacks and propagates errors.** `Proxy.UpdateConfig`/`EnsureServer` now return errors when the SDK HTTP client can’t be created (instead of falling back to `http.DefaultTransport`), and plugin initialization/agent-run registration fails early with clear errors/HTTP 500 when MCP or LLM SDK client setup fails.
> 
> Documentation (`CLAUDE.md`) is updated to codify “no direct `&http.Client{}` construction” and to require propagating SDK client creation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fd1888fe0dfc70b7313f0e0118dbc813723cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->