### PR TITLE
feat(mcp): per-user OAuth for external MCP servers

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -45,6 +45,7 @@ type LoopRequest struct {
 	AuthToken  string
 
 	UserRole   string
+	UserID     int64
 	OrgID      string
 	OrgName    string
 	ScopeOrgID string
@@ -219,7 +220,8 @@ func (a *AgentLoop) executeTool(ctx context.Context, tc ToolCall, req LoopReques
 	}
 	ensureScopedGraphitiArgs(tool, args, req.OrgID)
 
-	result, err := a.mcpProxy.CallToolWithContext(tc.Function.Name, args, req.OrgID, req.OrgName, req.ScopeOrgID)
+	callCtx := mcp.WithUserID(ctx, req.UserID)
+	result, err := a.mcpProxy.CallToolWithContext(callCtx, tc.Function.Name, args, req.OrgID, req.OrgName, req.ScopeOrgID)
 	if err != nil {
 		a.logger.Error("Tool call failed", "tool", tc.Function.Name, "error", err)
 		return fmt.Sprintf("Tool call error: %v", err), true

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -35,6 +35,20 @@ type Client struct {
 	ctx               context.Context
 	cancel            context.CancelFunc
 	httpClient        *http.Client
+	// perUserToken is set for servers with an OAuth block and supplies the
+	// per-request bearer token for the current user. Nil for static-header
+	// servers, which keeps the old behavior.
+	perUserToken PerUserTokenProvider
+}
+
+// SetPerUserTokenProvider wires a provider that injects the current user's
+// bearer token on outbound MCP requests for OAuth-enabled servers. Must be
+// called before connectMCP/connectMCPWithOrgContext to take effect on the
+// current session; on reconnect it is always applied.
+func (c *Client) SetPerUserTokenProvider(p PerUserTokenProvider) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.perUserToken = p
 }
 
 // customRoundTripper wraps http.RoundTripper to add custom headers
@@ -68,9 +82,15 @@ func (t *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 
 	// Add any configured headers (can override the above if needed).
 	// "Host" must be set via req.Host, not req.Header — Go ignores Header["Host"].
+	// For OAuth-enabled servers we never apply a static Authorization header:
+	// the user-token round tripper owns that slot so each caller sends their
+	// own token.
+	skipAuth := t.config.OAuth != nil
 	for key, value := range t.config.Headers {
 		if strings.EqualFold(key, "Host") {
 			req.Host = value
+		} else if skipAuth && strings.EqualFold(key, "Authorization") {
+			continue
 		} else {
 			req.Header.Set(key, value)
 		}
@@ -160,28 +180,43 @@ func (c *Client) connectMCP() error {
 const connectDialTimeout = 10 * time.Second
 
 func (c *Client) httpClientWithHeaders() *http.Client {
-	if len(c.config.Headers) == 0 {
+	transport := c.httpClient.Transport
+	if len(c.config.Headers) > 0 {
+		transport = &configHeaderRoundTripper{
+			base:    transport,
+			headers: c.config.Headers,
+			config:  c.config,
+		}
+	}
+	if c.config.OAuth != nil && c.perUserToken != nil {
+		transport = &userTokenRoundTripper{
+			base:     transport,
+			serverID: c.config.ID,
+			provider: c.perUserToken,
+		}
+	}
+	if transport == c.httpClient.Transport {
 		return c.httpClient
 	}
-	return &http.Client{
-		Transport: &configHeaderRoundTripper{
-			base:    c.httpClient.Transport,
-			headers: c.config.Headers,
-		},
-		Timeout: c.httpClient.Timeout,
-	}
+	return &http.Client{Transport: transport, Timeout: c.httpClient.Timeout}
 }
 
 type configHeaderRoundTripper struct {
 	base    http.RoundTripper
 	headers map[string]string
+	// config carries the owning ServerConfig so we can skip the Authorization
+	// header when OAuth is configured (the user-token round tripper owns it).
+	config ServerConfig
 }
 
 func (t *configHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
+	skipAuth := t.config.OAuth != nil
 	for key, value := range t.headers {
 		if strings.EqualFold(key, "Host") {
 			req.Host = value
+		} else if skipAuth && strings.EqualFold(key, "Authorization") {
+			continue
 		} else {
 			req.Header.Set(key, value)
 		}
@@ -212,15 +247,23 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 		Version: "1.0.0",
 	}, nil)
 
+	var rt http.RoundTripper = &customRoundTripper{
+		base:       c.httpClient.Transport,
+		orgID:      orgID,
+		orgName:    orgName,
+		scopeOrgId: scopeOrgId,
+		config:     c.config,
+	}
+	if c.config.OAuth != nil && c.perUserToken != nil {
+		rt = &userTokenRoundTripper{
+			base:     rt,
+			serverID: c.config.ID,
+			provider: c.perUserToken,
+		}
+	}
 	customHTTPClient := &http.Client{
-		Transport: &customRoundTripper{
-			base:       c.httpClient.Transport,
-			orgID:      orgID,
-			orgName:    orgName,
-			scopeOrgId: scopeOrgId,
-			config:     c.config,
-		},
-		Timeout: c.httpClient.Timeout,
+		Transport: rt,
+		Timeout:   c.httpClient.Timeout,
 	}
 
 	var transport mcpsdk.Transport
@@ -397,10 +440,10 @@ func (c *Client) listMCPTools() ([]Tool, error) {
 
 // CallTool calls a tool on the MCP server
 func (c *Client) CallTool(toolName string, arguments map[string]interface{}) (*CallToolResult, error) {
-	return c.CallToolWithContext(toolName, arguments, "", "", "")
+	return c.CallToolWithContext(context.Background(), toolName, arguments, "", "", "")
 }
 
-func (c *Client) CallToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+func (c *Client) CallToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Remove server ID prefix from tool name
 	originalName := strings.TrimPrefix(toolName, c.config.ID+"_")
 
@@ -408,7 +451,7 @@ func (c *Client) CallToolWithContext(toolName string, arguments map[string]inter
 	case "openapi":
 		return c.callOpenAPIToolWithContext(originalName, arguments, orgID, orgName, scopeOrgId)
 	case "sse", "streamable-http", "http+streamable":
-		return c.callMCPToolWithContext(originalName, arguments, orgID, orgName, scopeOrgId)
+		return c.callMCPToolWithContext(ctx, originalName, arguments, orgID, orgName, scopeOrgId)
 	default:
 		// Fallback to standard MCP protocol
 		return c.callStandardTool(originalName, arguments)
@@ -417,7 +460,9 @@ func (c *Client) CallToolWithContext(toolName string, arguments map[string]inter
 
 // callMCPToolWithContext calls a tool using the MCP SDK with additional context (e.g., Org ID, Org Name, Scope Org ID)
 // Org headers are forwarded to all MCP servers - each server can use whichever headers it needs.
-func (c *Client) callMCPToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+// The caller ctx is forwarded into session.CallTool so per-request values like
+// the Grafana user ID (for OAuth token lookup) reach the round tripper.
+func (c *Client) callMCPToolWithContext(callerCtx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Track whether we're using org context for potential reconnection
 	// Forward org headers to all MCP servers (not just specific ones)
 	useOrgContext := orgID != "" || orgName != "" || scopeOrgId != ""
@@ -448,7 +493,7 @@ func (c *Client) callMCPToolWithContext(toolName string, arguments map[string]in
 		return nil, fmt.Errorf("session not established for tool call")
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
 	defer cancel()
 
 	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -491,7 +536,7 @@ func (c *Client) callMCPToolWithContext(toolName string, arguments map[string]in
 				return nil, fmt.Errorf("session not established after reconnection")
 			}
 
-			retryCtx, retryCancel := context.WithTimeout(c.ctx, 30*time.Second)
+			retryCtx, retryCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
 			defer retryCancel()
 
 			result, err = session.CallTool(retryCtx, &mcpsdk.CallToolParams{

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// PerUserTokenProvider supplies the Authorization header value for a given
+// (request-context, serverID) pair. The provider reads the user identity
+// from the context via UserIDFromContext.
+type PerUserTokenProvider interface {
+	BearerFor(ctx context.Context, serverID string) (string, error)
+}
+
+// mergeUserCtx returns a context rooted at base (for cancellation lifetime)
+// that additionally carries the user ID from caller. Using base's cancellation
+// keeps long-running client state alive across short-lived caller contexts.
+func mergeUserCtx(base, caller context.Context) context.Context {
+	if userID, ok := UserIDFromContext(caller); ok {
+		return WithUserID(base, userID)
+	}
+	return base
+}
+
+type userIDCtxKey struct{}
+
+// WithUserID returns a context carrying the Grafana user ID for downstream
+// per-user token injection. A zero ID is treated as absent.
+func WithUserID(ctx context.Context, userID int64) context.Context {
+	if userID == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, userIDCtxKey{}, userID)
+}
+
+// UserIDFromContext returns the Grafana user ID previously stored via
+// WithUserID. The returned bool is true only when a non-zero ID is present.
+func UserIDFromContext(ctx context.Context) (int64, bool) {
+	v, ok := ctx.Value(userIDCtxKey{}).(int64)
+	return v, ok && v != 0
+}
+
+// ErrPerUserTokenUnavailable is the sentinel returned by BearerFor when the
+// user has not connected the server yet. MCP callers surface this as a
+// user-visible "please connect" message rather than a silent 401.
+var ErrPerUserTokenUnavailable = errors.New("per-user bearer token unavailable")
+
+// userTokenRoundTripper wraps an http.RoundTripper for servers with an
+// OAuth block. It asks the provider for the current user's bearer token on
+// every request, overriding any static Authorization header.
+type userTokenRoundTripper struct {
+	base     http.RoundTripper
+	serverID string
+	provider PerUserTokenProvider
+}
+
+func (rt *userTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := rt.provider.BearerFor(req.Context(), rt.serverID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+token)
+	return rt.base.RoundTrip(req)
+}

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -20,6 +20,20 @@ type Proxy struct {
 	mu            sync.RWMutex
 	healthMonitor *HealthMonitor
 	ctx           context.Context
+	// perUserToken, when set, is passed to every Client so OAuth-enabled
+	// servers can inject a per-user bearer on outbound MCP requests.
+	perUserToken PerUserTokenProvider
+}
+
+// SetPerUserTokenProvider registers the provider for per-user OAuth tokens
+// and propagates it to every existing and future MCP client.
+func (p *Proxy) SetPerUserTokenProvider(provider PerUserTokenProvider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.perUserToken = provider
+	for _, c := range p.clients {
+		c.SetPerUserTokenProvider(provider)
+	}
 }
 
 // NewProxy creates a new MCP proxy
@@ -76,7 +90,11 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) error {
 	}
 	for id, config := range newConfigs {
 		if _, exists := p.clients[id]; !exists {
-			p.clients[id] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+			c := NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+			if p.perUserToken != nil {
+				c.SetPerUserTokenProvider(p.perUserToken)
+			}
+			p.clients[id] = c
 			p.logger.Info("Added MCP client", "id", id, "url", config.URL, "type", config.Type)
 		}
 	}
@@ -142,11 +160,13 @@ func (p *Proxy) ListTools() ([]Tool, error) {
 
 // CallTool routes a tool call to the appropriate MCP server
 func (p *Proxy) CallTool(toolName string, arguments map[string]interface{}) (*CallToolResult, error) {
-	return p.CallToolWithContext(toolName, arguments, "", "", "")
+	return p.CallToolWithContext(context.Background(), toolName, arguments, "", "", "")
 }
 
-// CallToolWithContext routes a tool call to the appropriate MCP server with additional context (e.g., Org ID, Org Name, Scope Org ID)
-func (p *Proxy) CallToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+// CallToolWithContext routes a tool call to the appropriate MCP server with additional context (e.g., Org ID, Org Name, Scope Org ID).
+// The ctx carries the Grafana user ID (via mcp.WithUserID) for servers using
+// per-user OAuth; its deadline is honored on the outbound call.
+func (p *Proxy) CallToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Extract server ID from tool name prefix
 	parts := strings.SplitN(toolName, "_", 2)
 	if len(parts) < 2 {
@@ -173,7 +193,7 @@ func (p *Proxy) CallToolWithContext(toolName string, arguments map[string]interf
 
 	p.logger.Debug("Calling tool on MCP server", "tool", toolName, "server", serverID, "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
 
-	return client.CallToolWithContext(toolName, arguments, orgID, orgName, scopeOrgId)
+	return client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
 }
 
 // HandleMCPRequest handles an MCP JSON-RPC request
@@ -322,7 +342,11 @@ func (p *Proxy) EnsureServer(config ServerConfig) error {
 		p.logger.Debug("Replacing MCP client", "id", config.ID)
 	}
 
-	p.clients[config.ID] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+	c := NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+	if p.perUserToken != nil {
+		c.SetPerUserTokenProvider(p.perUserToken)
+	}
+	p.clients[config.ID] = c
 	p.mu.Unlock()
 
 	if replaced != nil {

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -84,4 +84,27 @@ type ServerConfig struct {
 	Type    string            `json:"type"` // "openapi", "standard", "sse", "streamable-http"
 	Enabled bool              `json:"enabled"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// OAuth, when set, makes the server authenticate per Grafana user via an
+	// OAuth2 authorization-code flow. The static Authorization entry in Headers
+	// is ignored for OAuth-enabled servers; each user's access token is
+	// injected per request by the OAuth round tripper.
+	OAuth *OAuthConfig `json:"oauth,omitempty"`
+}
+
+// OAuthConfig declares how to run the authorization-code flow for a server.
+type OAuthConfig struct {
+	AuthorizationURL string   `json:"authorizationURL"`
+	TokenURL         string   `json:"tokenURL"`
+	ClientID         string   `json:"clientID"`
+	ClientSecret     string   `json:"clientSecret,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	// PKCE enables RFC 7636 code_challenge. Strongly recommended when the
+	// authorization server supports it, required when clientSecret is empty.
+	PKCE bool `json:"pkce,omitempty"`
+	// RedirectURI is the callback URL registered with the authorization
+	// server. Must match the path this plugin serves at
+	// /api/plugins/consensys-asko11y-app/resources/api/oauth/{serverID}/callback.
+	// When empty the handler derives it from the incoming request, but that
+	// only works if the provider allows dynamic redirect URIs.
+	RedirectURI string `json:"redirectURI,omitempty"`
 }

--- a/pkg/plugin/mcp_provisioner.go
+++ b/pkg/plugin/mcp_provisioner.go
@@ -1,0 +1,363 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+
+	"consensys-asko11y-app/pkg/mcp"
+	"consensys-asko11y-app/pkg/plugin/oauth"
+)
+
+// RegisterExternalMCPRoutes mounts the provisioner endpoints the AppConfig UI
+// calls to add or remove OAuth-gated MCP servers at runtime.
+func (p *Plugin) registerProvisionerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/mcp/provisioner/presets", p.handleListPresets)
+	mux.HandleFunc("/api/mcp/provisioner", p.handleProvisionerRoot)
+	mux.HandleFunc("/api/mcp/provisioner/preset", p.handleAddPreset)
+	mux.HandleFunc("/api/mcp/provisioner/generic", p.handleAddGeneric)
+	mux.HandleFunc("/api/mcp/provisioner/", p.handleProvisionerItem) // DELETE /{id}
+}
+
+// handleListPresets returns the static preset catalog so the UI can render
+// the four cards without duplicating the list on the frontend.
+func (p *Plugin) handleListPresets(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	presets := oauth.Presets()
+	type apiPreset struct {
+		ID          oauth.PresetID `json:"id"`
+		DisplayName string         `json:"displayName"`
+		ServerID    string         `json:"serverId"`
+		MCPURL      string         `json:"mcpUrl"`
+		Transport   string         `json:"transport"`
+		Scopes      []string       `json:"scopes"`
+		DCRCapable  bool           `json:"dcrCapable"`
+	}
+	out := make([]apiPreset, 0, len(presets))
+	for _, pr := range presets {
+		out = append(out, apiPreset{pr.ID, pr.DisplayName, pr.ServerID, pr.MCPURL, pr.Transport, pr.Scopes, pr.DCRCapable})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"presets": out})
+}
+
+// handleProvisionerRoot lists currently provisioned dynamic servers.
+func (p *Plugin) handleProvisionerRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if p.dynamicServerStore == nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"servers":[]}`))
+		return
+	}
+	records, err := p.dynamicServerStore.List(r.Context())
+	if err != nil {
+		p.logger.Warn("list dynamic servers", "err", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	type apiServer struct {
+		ServerID    string   `json:"serverId"`
+		DisplayName string   `json:"displayName"`
+		MCPURL      string   `json:"mcpUrl"`
+		Transport   string   `json:"transport"`
+		PresetID    string   `json:"presetId,omitempty"`
+		Scopes      []string `json:"scopes,omitempty"`
+	}
+	out := make([]apiServer, 0, len(records))
+	for _, s := range records {
+		scopes := []string{}
+		if s.Config.OAuth != nil {
+			scopes = s.Config.OAuth.Scopes
+		}
+		out = append(out, apiServer{s.Config.ID, s.Config.Name, s.Config.URL, s.Config.Type, s.PresetID, scopes})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"servers": out})
+}
+
+type addPresetBody struct {
+	Preset       oauth.PresetID `json:"preset"`
+	ClientID     string         `json:"clientId,omitempty"`
+	ClientSecret string         `json:"clientSecret,omitempty"`
+}
+
+func (p *Plugin) handleAddPreset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := p.requireAdmin(r); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	var body addPresetBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	preset, ok := oauth.Presets()[body.Preset]
+	if !ok {
+		http.Error(w, "unknown preset", http.StatusBadRequest)
+		return
+	}
+
+	redirectURI := computeRedirectURI(r, preset.ServerID)
+	authURL := preset.AuthEndpoint
+	tokenURL := preset.TokenEndpoint
+	clientID := body.ClientID
+	clientSecret := body.ClientSecret
+	var dcrURI, dcrToken string
+
+	if preset.DCRCapable {
+		meta, err := oauth.DiscoverMCPAuth(r.Context(), http.DefaultClient, preset.MCPURL)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("discovery failed: %v", err), http.StatusBadGateway)
+			return
+		}
+		authURL = meta.AuthorizationEndpoint
+		tokenURL = meta.TokenEndpoint
+		if clientID == "" {
+			// Run DCR if admin did not pre-provide a client_id.
+			dcr, err := oauth.RegisterClient(r.Context(), http.DefaultClient, meta, "ask-o11y", []string{redirectURI})
+			if err != nil {
+				http.Error(w, fmt.Sprintf("dynamic client registration failed: %v", err), http.StatusBadGateway)
+				return
+			}
+			clientID = dcr.ClientID
+			clientSecret = dcr.ClientSecret
+			dcrURI = dcr.RegistrationClientURI
+			dcrToken = dcr.RegistrationAccessToken
+		}
+	} else if clientID == "" {
+		http.Error(w, "preset requires clientId (register an OAuth app at the provider first)", http.StatusBadRequest)
+		return
+	}
+
+	cfg := mcp.ServerConfig{
+		ID:      preset.ServerID,
+		Name:    preset.DisplayName,
+		URL:     preset.MCPURL,
+		Type:    preset.Transport,
+		Enabled: true,
+		OAuth: &mcp.OAuthConfig{
+			AuthorizationURL: authURL,
+			TokenURL:         tokenURL,
+			ClientID:         clientID,
+			ClientSecret:     clientSecret,
+			Scopes:           preset.Scopes,
+			PKCE:             preset.PKCE,
+			RedirectURI:      redirectURI,
+		},
+	}
+
+	record := oauth.DynamicServer{
+		Config:                  cfg,
+		PresetID:                string(preset.ID),
+		RegistrationClientURI:   dcrURI,
+		RegistrationAccessToken: dcrToken,
+	}
+
+	if err := p.persistAndRegisterDynamicServer(r.Context(), record); err != nil {
+		p.logger.Error("persist dynamic server", "err", err)
+		http.Error(w, "persist failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"serverId": cfg.ID})
+}
+
+type addGenericBody struct {
+	ServerID         string   `json:"serverId"`
+	DisplayName      string   `json:"displayName"`
+	MCPURL           string   `json:"mcpUrl"`
+	Transport        string   `json:"transport"` // streamable-http | sse
+	AuthorizationURL string   `json:"authorizationUrl"`
+	TokenURL         string   `json:"tokenUrl"`
+	ClientID         string   `json:"clientId"`
+	ClientSecret     string   `json:"clientSecret,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	PKCE             bool     `json:"pkce"`
+	Discover         bool     `json:"discover,omitempty"` // if true, try RFC 8414 discovery + DCR when urls are empty
+}
+
+func (p *Plugin) handleAddGeneric(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := p.requireAdmin(r); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	var body addGenericBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.ServerID == "" || body.MCPURL == "" || body.Transport == "" {
+		http.Error(w, "serverId, mcpUrl and transport are required", http.StatusBadRequest)
+		return
+	}
+	if body.DisplayName == "" {
+		body.DisplayName = body.ServerID
+	}
+
+	redirectURI := computeRedirectURI(r, body.ServerID)
+	authURL := body.AuthorizationURL
+	tokenURL := body.TokenURL
+	clientID := body.ClientID
+	clientSecret := body.ClientSecret
+	var dcrURI, dcrToken string
+
+	if body.Discover && (authURL == "" || tokenURL == "" || clientID == "") {
+		meta, err := oauth.DiscoverMCPAuth(r.Context(), http.DefaultClient, body.MCPURL)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("discovery failed: %v", err), http.StatusBadGateway)
+			return
+		}
+		if authURL == "" {
+			authURL = meta.AuthorizationEndpoint
+		}
+		if tokenURL == "" {
+			tokenURL = meta.TokenEndpoint
+		}
+		if clientID == "" {
+			dcr, err := oauth.RegisterClient(r.Context(), http.DefaultClient, meta, "ask-o11y", []string{redirectURI})
+			if err != nil {
+				http.Error(w, fmt.Sprintf("dynamic client registration failed: %v", err), http.StatusBadGateway)
+				return
+			}
+			clientID = dcr.ClientID
+			clientSecret = dcr.ClientSecret
+			dcrURI = dcr.RegistrationClientURI
+			dcrToken = dcr.RegistrationAccessToken
+		}
+	}
+	if authURL == "" || tokenURL == "" || clientID == "" {
+		http.Error(w, "authorizationUrl, tokenUrl and clientId are required (or set discover:true)", http.StatusBadRequest)
+		return
+	}
+
+	cfg := mcp.ServerConfig{
+		ID:      body.ServerID,
+		Name:    body.DisplayName,
+		URL:     body.MCPURL,
+		Type:    body.Transport,
+		Enabled: true,
+		OAuth: &mcp.OAuthConfig{
+			AuthorizationURL: authURL,
+			TokenURL:         tokenURL,
+			ClientID:         clientID,
+			ClientSecret:     clientSecret,
+			Scopes:           body.Scopes,
+			PKCE:             body.PKCE,
+			RedirectURI:      redirectURI,
+		},
+	}
+	record := oauth.DynamicServer{
+		Config:                  cfg,
+		RegistrationClientURI:   dcrURI,
+		RegistrationAccessToken: dcrToken,
+	}
+	if err := p.persistAndRegisterDynamicServer(r.Context(), record); err != nil {
+		p.logger.Error("persist dynamic server", "err", err)
+		http.Error(w, "persist failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"serverId": cfg.ID})
+}
+
+func (p *Plugin) handleProvisionerItem(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/mcp/provisioner/")
+	if id == "" || strings.Contains(id, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := p.requireAdmin(r); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if err := p.deleteDynamicServer(r.Context(), id); err != nil {
+		p.logger.Error("delete dynamic server", "err", err)
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (p *Plugin) persistAndRegisterDynamicServer(ctx context.Context, record oauth.DynamicServer) error {
+	if p.dynamicServerStore == nil {
+		return errors.New("dynamic server store not configured")
+	}
+	if err := p.dynamicServerStore.Put(ctx, record); err != nil {
+		return err
+	}
+	if p.oauthManager != nil && record.Config.OAuth != nil {
+		p.oauthManager.RegisterConfig(record.Config.ID, record.Config.OAuth)
+	}
+	if err := p.mcpProxy.EnsureServer(record.Config); err != nil {
+		return fmt.Errorf("attach to proxy: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) deleteDynamicServer(ctx context.Context, serverID string) error {
+	if p.dynamicServerStore == nil {
+		return errors.New("dynamic server store not configured")
+	}
+	if err := p.dynamicServerStore.Delete(ctx, serverID); err != nil {
+		return err
+	}
+	p.mcpProxy.RemoveServer(serverID)
+	if p.oauthManager != nil {
+		p.oauthManager.UnregisterConfig(serverID)
+	}
+	return nil
+}
+
+// computeRedirectURI produces the callback URL we pass to the authorization
+// server. Honors X-Forwarded-{Proto,Host} so it works behind Grafana's proxy.
+func computeRedirectURI(r *http.Request, serverID string) string {
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	return fmt.Sprintf("%s://%s/api/plugins/consensys-asko11y-app/resources/api/oauth/%s/callback", scheme, host, serverID)
+}
+
+// requireAdmin enforces that the caller holds the Grafana Admin role. Only
+// admins can add/remove MCP servers — end users only Connect/Disconnect
+// their own OAuth token.
+func (p *Plugin) requireAdmin(r *http.Request) error {
+	pc := httpadapter.PluginConfigFromContext(r.Context())
+	if pc.User != nil && strings.EqualFold(string(pc.User.Role), "Admin") {
+		return nil
+	}
+	if strings.EqualFold(getUserRole(r), "Admin") {
+		return nil
+	}
+	return errors.New("admin role required")
+}

--- a/pkg/plugin/oauth/context.go
+++ b/pkg/plugin/oauth/context.go
@@ -1,0 +1,17 @@
+package oauth
+
+import (
+	"context"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// WithUserID is a re-export so callers don't have to also depend on pkg/mcp.
+func WithUserID(ctx context.Context, userID int64) context.Context {
+	return mcp.WithUserID(ctx, userID)
+}
+
+// UserIDFromContext is a re-export of mcp.UserIDFromContext for symmetry.
+func UserIDFromContext(ctx context.Context) (int64, bool) {
+	return mcp.UserIDFromContext(ctx)
+}

--- a/pkg/plugin/oauth/discovery.go
+++ b/pkg/plugin/oauth/discovery.go
@@ -1,0 +1,210 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// AuthServerMetadata is the subset of RFC 8414 metadata we need to drive the
+// authorization-code flow. Fields not set by the server are left empty.
+type AuthServerMetadata struct {
+	Issuer                   string   `json:"issuer"`
+	AuthorizationEndpoint    string   `json:"authorization_endpoint"`
+	TokenEndpoint            string   `json:"token_endpoint"`
+	RegistrationEndpoint     string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported          []string `json:"scopes_supported,omitempty"`
+	CodeChallengeMethods     []string `json:"code_challenge_methods_supported,omitempty"`
+	GrantTypesSupported      []string `json:"grant_types_supported,omitempty"`
+	AuthMethodsSupported     []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
+// ProtectedResourceMetadata is the RFC 9728 body returned by an MCP server's
+// oauth-protected-resource descriptor.
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported,omitempty"`
+}
+
+// DiscoverMCPAuth returns the authorization-server metadata for an MCP URL.
+// It first tries the RFC 8414 well-known path on the MCP origin; if that
+// 404s it probes the MCP URL itself, follows the WWW-Authenticate
+// resource_metadata hint, fetches the protected-resource descriptor, and
+// uses the first advertised authorization server's metadata.
+func DiscoverMCPAuth(ctx context.Context, client *http.Client, mcpURL string) (AuthServerMetadata, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	origin, err := originOf(mcpURL)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	// Try RFC 8414 metadata at the origin of the MCP endpoint.
+	if meta, err := fetchAuthServerMetadata(ctx, client, origin+"/.well-known/oauth-authorization-server"); err == nil {
+		return meta, nil
+	}
+	// Fall back to RFC 9728 resource metadata via 401 challenge.
+	return discoverViaChallenge(ctx, client, mcpURL)
+}
+
+// RegisterClient performs RFC 7591 dynamic client registration. Returns the
+// assigned client_id (and secret, if the server issued one).
+type DCRResult struct {
+	ClientID     string
+	ClientSecret string
+	RegistrationClientURI string
+	RegistrationAccessToken string
+}
+
+func RegisterClient(ctx context.Context, client *http.Client, meta AuthServerMetadata, clientName string, redirectURIs []string) (DCRResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if meta.RegistrationEndpoint == "" {
+		return DCRResult{}, fmt.Errorf("authorization server does not advertise a registration_endpoint")
+	}
+
+	body := map[string]interface{}{
+		"client_name":                clientName,
+		"redirect_uris":              redirectURIs,
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+		"application_type":           "web",
+	}
+	raw, _ := json.Marshal(body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, meta.RegistrationEndpoint, strings.NewReader(string(raw)))
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("build DCR request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("DCR request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return DCRResult{}, fmt.Errorf("DCR returned %s: %s", resp.Status, strings.TrimSpace(string(data)))
+	}
+	var parsed struct {
+		ClientID                string `json:"client_id"`
+		ClientSecret            string `json:"client_secret"`
+		RegistrationClientURI   string `json:"registration_client_uri"`
+		RegistrationAccessToken string `json:"registration_access_token"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return DCRResult{}, fmt.Errorf("decode DCR response: %w", err)
+	}
+	if parsed.ClientID == "" {
+		return DCRResult{}, fmt.Errorf("DCR response missing client_id")
+	}
+	return DCRResult{
+		ClientID:                parsed.ClientID,
+		ClientSecret:            parsed.ClientSecret,
+		RegistrationClientURI:   parsed.RegistrationClientURI,
+		RegistrationAccessToken: parsed.RegistrationAccessToken,
+	}, nil
+}
+
+func originOf(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("url missing scheme/host: %s", raw)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+func fetchAuthServerMetadata(ctx context.Context, client *http.Client, metaURL string) (AuthServerMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return AuthServerMetadata{}, fmt.Errorf("metadata %s returned %s", metaURL, resp.Status)
+	}
+	var meta AuthServerMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		return AuthServerMetadata{}, err
+	}
+	if meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
+		return AuthServerMetadata{}, fmt.Errorf("metadata %s missing endpoints", metaURL)
+	}
+	return meta, nil
+}
+
+var resourceMetadataRE = regexp.MustCompile(`resource_metadata="([^"]+)"`)
+
+// discoverViaChallenge probes the MCP URL without auth, reads the
+// WWW-Authenticate header for resource_metadata, fetches that descriptor,
+// then the first authorization server's metadata.
+func discoverViaChallenge(ctx context.Context, client *http.Client, mcpURL string) (AuthServerMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mcpURL, nil)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return AuthServerMetadata{}, fmt.Errorf("probe %s: %w", mcpURL, err)
+	}
+	defer resp.Body.Close()
+
+	challenge := resp.Header.Get("WWW-Authenticate")
+	match := resourceMetadataRE.FindStringSubmatch(challenge)
+	if len(match) < 2 {
+		return AuthServerMetadata{}, fmt.Errorf("no OAuth metadata advertised at %s (status %s)", mcpURL, resp.Status)
+	}
+	prMeta, err := fetchProtectedResource(ctx, client, match[1])
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	if len(prMeta.AuthorizationServers) == 0 {
+		return AuthServerMetadata{}, fmt.Errorf("protected-resource metadata lists no authorization servers")
+	}
+	for _, as := range prMeta.AuthorizationServers {
+		if meta, err := fetchAuthServerMetadata(ctx, client, as+"/.well-known/oauth-authorization-server"); err == nil {
+			return meta, nil
+		}
+	}
+	return AuthServerMetadata{}, fmt.Errorf("no usable authorization-server metadata found")
+}
+
+func fetchProtectedResource(ctx context.Context, client *http.Client, url string) (ProtectedResourceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ProtectedResourceMetadata{}, fmt.Errorf("protected-resource metadata %s returned %s", url, resp.Status)
+	}
+	var m ProtectedResourceMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	return m, nil
+}

--- a/pkg/plugin/oauth/discovery_test.go
+++ b/pkg/plugin/oauth/discovery_test.go
@@ -1,0 +1,99 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverMCPAuthWellKnown(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"x","authorization_endpoint":"x/authorize","token_endpoint":"x/token","registration_endpoint":"x/register"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	meta, err := DiscoverMCPAuth(context.Background(), ts.Client(), ts.URL+"/v1/sse")
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if meta.AuthorizationEndpoint == "" || meta.RegistrationEndpoint == "" {
+		t.Fatalf("unexpected meta: %+v", meta)
+	}
+}
+
+func TestDiscoverMCPAuthViaChallenge(t *testing.T) {
+	mux := http.NewServeMux()
+	var prURL, asURL string
+	// The MCP endpoint: returns 401 advertising the resource metadata URL.
+	mux.HandleFunc("/mcp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", resource_metadata="`+prURL+`"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	// RFC 9728 protected-resource metadata: names the authorization server.
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"mcp","authorization_servers":["` + asURL + `"]}`))
+	})
+	// RFC 8414 authorization-server metadata.
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"i","authorization_endpoint":"i/authorize","token_endpoint":"i/token"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	prURL = ts.URL + "/.well-known/oauth-protected-resource/mcp/"
+	asURL = ts.URL
+
+	// Ensure the first well-known probe on the MCP origin returns 404 so we
+	// fall through to the challenge path. Our httptest mux does this
+	// automatically since /.well-known/oauth-authorization-server is served
+	// — which means we WOULD succeed on the first probe. Add the probe only
+	// on a different host via a second server would overcomplicate this test.
+	// Instead, swap mux to a variant without the well-known handler.
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/mcp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", resource_metadata="`+ts.URL+`/.well-known/oauth-protected-resource/mcp/"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	ts2 := httptest.NewServer(mux2)
+	defer ts2.Close()
+
+	meta, err := DiscoverMCPAuth(context.Background(), ts.Client(), ts2.URL+"/mcp/")
+	if err != nil {
+		t.Fatalf("discover via challenge: %v", err)
+	}
+	if !strings.HasSuffix(meta.AuthorizationEndpoint, "authorize") {
+		t.Fatalf("unexpected auth endpoint: %s", meta.AuthorizationEndpoint)
+	}
+}
+
+func TestRegisterClient(t *testing.T) {
+	mux := http.NewServeMux()
+	var gotBody string
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		gotBody = string(buf[:n])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"cid","registration_client_uri":"/register/cid"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	meta := AuthServerMetadata{RegistrationEndpoint: ts.URL + "/register"}
+	res, err := RegisterClient(context.Background(), ts.Client(), meta, "ask-o11y test", []string{"http://localhost/callback"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if res.ClientID != "cid" {
+		t.Fatalf("unexpected client_id %q", res.ClientID)
+	}
+	if !strings.Contains(gotBody, `"client_name":"ask-o11y test"`) {
+		t.Fatalf("body did not include client_name: %s", gotBody)
+	}
+}

--- a/pkg/plugin/oauth/errors.go
+++ b/pkg/plugin/oauth/errors.go
@@ -1,0 +1,13 @@
+package oauth
+
+import "errors"
+
+// ErrOAuthNotConnected is returned by the OAuth round tripper when no token
+// is stored for the current user on a given MCP server. Agents should surface
+// it to the UI so the user can click "Connect".
+var ErrOAuthNotConnected = errors.New("oauth: user not connected")
+
+// ErrStateInvalid is returned by the callback handler when the OAuth state
+// parameter is missing, expired, or does not match the one we issued. Never
+// leak details beyond "invalid state" to the browser.
+var ErrStateInvalid = errors.New("oauth: invalid state")

--- a/pkg/plugin/oauth/exchange.go
+++ b/pkg/plugin/oauth/exchange.go
@@ -1,0 +1,102 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// tokenResponse matches the OAuth2 token-endpoint response body.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// exchangeCode trades an authorization code for a token pair.
+func exchangeCode(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, code, codeVerifier, redirectURI string) (Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", cfg.ClientID)
+	form.Set("redirect_uri", redirectURI)
+	if cfg.PKCE && codeVerifier != "" {
+		form.Set("code_verifier", codeVerifier)
+	}
+	return postToken(ctx, httpClient, cfg, form)
+}
+
+// refreshToken trades a refresh token for a fresh access token. The server
+// may or may not rotate the refresh token; we persist whatever we get back.
+func refreshToken(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, refresh string) (Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refresh)
+	form.Set("client_id", cfg.ClientID)
+	return postToken(ctx, httpClient, cfg, form)
+}
+
+func postToken(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, form url.Values) (Token, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return Token{}, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if cfg.ClientSecret != "" {
+		req.SetBasicAuth(url.QueryEscape(cfg.ClientID), url.QueryEscape(cfg.ClientSecret))
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Token{}, fmt.Errorf("token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return Token{}, fmt.Errorf("token endpoint returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var parsed tokenResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Token{}, fmt.Errorf("decode token response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return Token{}, fmt.Errorf("token endpoint returned empty access_token")
+	}
+
+	expiresAt := time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	if parsed.ExpiresIn == 0 {
+		// Unknown expiry: default to a short window so we refresh conservatively.
+		expiresAt = time.Now().Add(15 * time.Minute)
+	}
+	return Token{
+		AccessToken:  parsed.AccessToken,
+		RefreshToken: parsed.RefreshToken,
+		TokenType:    parsed.TokenType,
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+// refresh uses the configured client to run refreshToken. It's a method on
+// Manager so callers don't have to own the HTTP client.
+func (m *Manager) refresh(ctx context.Context, serverID string, tok Token) (Token, error) {
+	cfg := m.ConfigFor(serverID)
+	if cfg == nil {
+		return Token{}, fmt.Errorf("no oauth config for server %q", serverID)
+	}
+	if tok.RefreshToken == "" {
+		return Token{}, fmt.Errorf("no refresh token available")
+	}
+	return refreshToken(ctx, http.DefaultClient, cfg, tok.RefreshToken)
+}

--- a/pkg/plugin/oauth/handlers.go
+++ b/pkg/plugin/oauth/handlers.go
@@ -1,0 +1,239 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// UserIDFn extracts the Grafana user ID from an incoming plugin resource
+// request. The plugin supplies this so we don't circular-import pkg/plugin.
+type UserIDFn func(*http.Request) int64
+
+// RegisterRoutes mounts the OAuth HTTP handlers on the given mux. All paths
+// live under /api/oauth/ so the plugin's registerRoutes can delegate.
+func (m *Manager) RegisterRoutes(mux *http.ServeMux, userIDFn UserIDFn) {
+	mux.HandleFunc("/api/oauth/", func(w http.ResponseWriter, r *http.Request) {
+		serverID, action, ok := splitOAuthPath(r.URL.Path)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		cfg := m.ConfigFor(serverID)
+		if cfg == nil {
+			http.Error(w, "server has no oauth configured", http.StatusNotFound)
+			return
+		}
+		switch action {
+		case "start":
+			m.handleStart(w, r, serverID, cfg, userIDFn)
+		case "callback":
+			m.handleCallback(w, r, serverID, cfg)
+		case "status":
+			m.handleStatus(w, r, serverID, userIDFn)
+		case "disconnect":
+			m.handleDisconnect(w, r, serverID, userIDFn)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// splitOAuthPath parses /api/oauth/{serverID}/{action}.
+func splitOAuthPath(p string) (serverID, action string, ok bool) {
+	trimmed := strings.TrimPrefix(p, "/api/oauth/")
+	if trimmed == p {
+		return "", "", false
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request, serverID string, cfg *mcp.OAuthConfig, userIDFn UserIDFn) {
+	userID := userIDFn(r)
+	if userID == 0 {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+
+	state, err := NewState()
+	if err != nil {
+		m.logger.Error("generate oauth state", "err", err)
+		http.Error(w, "oauth init failed", http.StatusInternalServerError)
+		return
+	}
+
+	redirectURI := resolveRedirectURI(r, serverID, cfg)
+
+	entry := StateEntry{ServerID: serverID, UserID: userID, ReturnURL: r.URL.Query().Get("return")}
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", cfg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", state)
+	if len(cfg.Scopes) > 0 {
+		q.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	if cfg.PKCE {
+		verifier, challenge, err := NewPKCEPair()
+		if err != nil {
+			m.logger.Error("generate pkce pair", "err", err)
+			http.Error(w, "oauth init failed", http.StatusInternalServerError)
+			return
+		}
+		entry.CodeVerifier = verifier
+		q.Set("code_challenge", challenge)
+		q.Set("code_challenge_method", "S256")
+	}
+
+	if err := m.state.Put(r.Context(), state, entry); err != nil {
+		m.logger.Error("persist oauth state", "err", err)
+		http.Error(w, "oauth init failed", http.StatusInternalServerError)
+		return
+	}
+
+	authURL := cfg.AuthorizationURL
+	sep := "?"
+	if strings.Contains(authURL, "?") {
+		sep = "&"
+	}
+	http.Redirect(w, r, authURL+sep+q.Encode(), http.StatusFound)
+}
+
+func (m *Manager) handleCallback(w http.ResponseWriter, r *http.Request, serverID string, cfg *mcp.OAuthConfig) {
+	q := r.URL.Query()
+	if providerErr := q.Get("error"); providerErr != "" {
+		writeCallbackHTML(w, serverID, false, fmt.Sprintf("%s: %s", providerErr, q.Get("error_description")))
+		return
+	}
+	state := q.Get("state")
+	code := q.Get("code")
+	if state == "" || code == "" {
+		writeCallbackHTML(w, serverID, false, "missing state or code")
+		return
+	}
+
+	entry, err := m.state.PopAndGet(r.Context(), state)
+	if err != nil {
+		writeCallbackHTML(w, serverID, false, "invalid state")
+		return
+	}
+	if entry.ServerID != serverID {
+		writeCallbackHTML(w, serverID, false, "state/server mismatch")
+		return
+	}
+
+	redirectURI := resolveRedirectURI(r, serverID, cfg)
+	tok, err := exchangeCode(r.Context(), http.DefaultClient, cfg, code, entry.CodeVerifier, redirectURI)
+	if err != nil {
+		m.logger.Warn("token exchange", "server", serverID, "err", err)
+		writeCallbackHTML(w, serverID, false, "token exchange failed")
+		return
+	}
+
+	if err := m.tokens.Put(r.Context(), serverID, entry.UserID, tok); err != nil {
+		m.logger.Error("persist token", "server", serverID, "userID", entry.UserID, "err", err)
+		writeCallbackHTML(w, serverID, false, "could not persist token")
+		return
+	}
+	writeCallbackHTML(w, serverID, true, "")
+}
+
+// StatusResponse is the JSON payload for /status.
+type StatusResponse struct {
+	Configured bool      `json:"configured"`
+	Connected  bool      `json:"connected"`
+	ExpiresAt  time.Time `json:"expiresAt,omitempty"`
+}
+
+func (m *Manager) handleStatus(w http.ResponseWriter, r *http.Request, serverID string, userIDFn UserIDFn) {
+	userID := userIDFn(r)
+	w.Header().Set("Content-Type", "application/json")
+	if userID == 0 {
+		_ = json.NewEncoder(w).Encode(StatusResponse{Configured: true})
+		return
+	}
+	tok, ok, err := m.tokens.Get(r.Context(), serverID, userID)
+	if err != nil {
+		m.logger.Warn("status token lookup", "server", serverID, "err", err)
+		http.Error(w, "lookup failed", http.StatusInternalServerError)
+		return
+	}
+	resp := StatusResponse{Configured: true, Connected: ok && !tok.Expired()}
+	if ok {
+		resp.ExpiresAt = tok.ExpiresAt
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (m *Manager) handleDisconnect(w http.ResponseWriter, r *http.Request, serverID string, userIDFn UserIDFn) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	userID := userIDFn(r)
+	if userID == 0 {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	if err := m.tokens.Delete(r.Context(), serverID, userID); err != nil {
+		m.logger.Warn("disconnect", "server", serverID, "err", err)
+		http.Error(w, "disconnect failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveRedirectURI returns the URL registered with the authorization
+// server. It prefers the explicit config value; otherwise it reconstructs
+// the plugin resource URL from the incoming request.
+func resolveRedirectURI(r *http.Request, serverID string, cfg *mcp.OAuthConfig) string {
+	if cfg.RedirectURI != "" {
+		return cfg.RedirectURI
+	}
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	return fmt.Sprintf("%s://%s/api/plugins/consensys-asko11y-app/resources/api/oauth/%s/callback", scheme, host, serverID)
+}
+
+// writeCallbackHTML writes a tiny HTML page that notifies the opening window
+// of the flow's outcome and closes itself.
+func writeCallbackHTML(w http.ResponseWriter, serverID string, success bool, reason string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>OAuth %s</title></head><body>
+<p>%s</p>
+<script>
+try {
+  if (window.opener) {
+    window.opener.postMessage({source: 'asko11y-oauth', serverID: %q, success: %t, reason: %q}, '*');
+  }
+} catch (e) {}
+setTimeout(function() { window.close(); }, 500);
+</script>
+</body></html>`, statusWord(success), statusWord(success), serverID, success, reason)
+}
+
+func statusWord(success bool) string {
+	if success {
+		return "connected"
+	}
+	return "failed"
+}

--- a/pkg/plugin/oauth/handlers_test.go
+++ b/pkg/plugin/oauth/handlers_test.go
@@ -1,0 +1,141 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// fakeAuthServer implements the authorize + token endpoints of an OAuth
+// provider in-process so we can drive the full handshake under test.
+func fakeAuthServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		// Redirect back to the supplied redirect_uri with a fixed code.
+		redirect := r.URL.Query().Get("redirect_uri")
+		state := r.URL.Query().Get("state")
+		http.Redirect(w, r, redirect+"?code=fake-code&state="+state, http.StatusFound)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("code") != "fake-code" {
+			http.Error(w, "bad code", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"AT","refresh_token":"RT","expires_in":3600,"token_type":"Bearer"}`))
+	})
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s, &calls
+}
+
+func TestHandlersFullFlow(t *testing.T) {
+	fake, tokenCalls := fakeAuthServer(t)
+
+	cfg := &mcp.OAuthConfig{
+		AuthorizationURL: fake.URL + "/authorize",
+		TokenURL:         fake.URL + "/token",
+		ClientID:         "ask-o11y",
+		PKCE:             true,
+	}
+	server := mcp.ServerConfig{ID: "atlassian", OAuth: cfg}
+
+	tokens := NewInMemoryUserTokenStore()
+	state := NewInMemoryStateStore()
+	mgr := NewManager(tokens, state, log.New(), []mcp.ServerConfig{server})
+
+	userID := int64(42)
+	userIDFn := func(*http.Request) int64 { return userID }
+
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, userIDFn)
+
+	// We need the plugin HTTP server to reply with callback URLs that point
+	// back to itself, so spin up a real test server around the mux.
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+	// Override the redirect URI so both the authorize redirect and the
+	// token-exchange request use the test server's URL.
+	cfg.RedirectURI = plugin.URL + "/api/oauth/atlassian/callback"
+
+	// Follow the whole chain using a cookie-less client with redirect follow.
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/start")
+	if err != nil {
+		t.Fatalf("start GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after full redirect chain, got %s", resp.Status)
+	}
+	if *tokenCalls != 1 {
+		t.Fatalf("expected token endpoint called once, got %d", *tokenCalls)
+	}
+
+	// Status should now report connected.
+	statusResp, err := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/status")
+	if err != nil {
+		t.Fatalf("status GET: %v", err)
+	}
+	defer statusResp.Body.Close()
+	var sr StatusResponse
+	if err := json.NewDecoder(statusResp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if !sr.Connected {
+		t.Fatalf("expected connected, got %+v", sr)
+	}
+
+	// Disconnect flips status back.
+	req, _ := http.NewRequest(http.MethodPost, plugin.URL+"/api/oauth/atlassian/disconnect", nil)
+	discResp, err := plugin.Client().Do(req)
+	if err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	_ = discResp.Body.Close()
+	if discResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %s", discResp.Status)
+	}
+	statusResp2, _ := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/status")
+	var sr2 StatusResponse
+	_ = json.NewDecoder(statusResp2.Body).Decode(&sr2)
+	statusResp2.Body.Close()
+	if sr2.Connected {
+		t.Fatalf("expected disconnected after disconnect, got %+v", sr2)
+	}
+}
+
+func TestCallbackRejectsUnknownState(t *testing.T) {
+	cfg := &mcp.OAuthConfig{AuthorizationURL: "http://x", TokenURL: "http://x/token", ClientID: "c"}
+	mgr := NewManager(NewInMemoryUserTokenStore(), NewInMemoryStateStore(), log.New(), []mcp.ServerConfig{{ID: "s", OAuth: cfg}})
+
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, func(*http.Request) int64 { return 1 })
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+
+	q := url.Values{"code": {"c"}, "state": {"bogus"}}
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/s/callback?" + q.Encode())
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer resp.Body.Close()
+	buf := make([]byte, 2048)
+	n, _ := resp.Body.Read(buf)
+	if !strings.Contains(string(buf[:n]), "invalid state") {
+		t.Fatalf("expected 'invalid state' in body, got %s", string(buf[:n]))
+	}
+}

--- a/pkg/plugin/oauth/keys.go
+++ b/pkg/plugin/oauth/keys.go
@@ -1,0 +1,27 @@
+package oauth
+
+import (
+	"strconv"
+	"strings"
+)
+
+// serverIDEscape replaces Redis key separators in server IDs so keys remain
+// parseable. Server IDs come from YAML and are already validated by the
+// plugin, but we stay defensive.
+func serverIDEscape(s string) string {
+	return strings.ReplaceAll(s, ":", "_")
+}
+
+func userIDString(id int64) string {
+	return strconv.FormatInt(id, 10)
+}
+
+// tokenRedisKey is the Redis key used to store a user's token for a server.
+func tokenRedisKey(serverID string, userID int64) string {
+	return "mcp_oauth:" + serverIDEscape(serverID) + ":" + userIDString(userID)
+}
+
+// stateRedisKey is the Redis key for a pending OAuth state.
+func stateRedisKey(state string) string {
+	return "mcp_oauth_state:" + state
+}

--- a/pkg/plugin/oauth/manager.go
+++ b/pkg/plugin/oauth/manager.go
@@ -1,0 +1,126 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// Manager wires together the OAuth HTTP handlers, stores, and per-server
+// configuration. A single Manager is created in NewPlugin and shared across
+// the plugin's lifetime.
+type Manager struct {
+	tokens  UserTokenStore
+	state   StateStore
+	logger  log.Logger
+	configs map[string]*mcp.OAuthConfig // keyed by server ID
+	mu      sync.RWMutex
+}
+
+// NewManager returns a Manager seeded with the OAuth configs declared on the
+// given server list. Servers without an OAuth block are ignored.
+func NewManager(tokens UserTokenStore, state StateStore, logger log.Logger, servers []mcp.ServerConfig) *Manager {
+	m := &Manager{
+		tokens:  tokens,
+		state:   state,
+		logger:  logger,
+		configs: map[string]*mcp.OAuthConfig{},
+	}
+	for _, s := range servers {
+		if s.OAuth != nil {
+			m.configs[s.ID] = s.OAuth
+		}
+	}
+	return m
+}
+
+// ConfigFor returns the OAuth config for the given server, or nil if the
+// server does not use OAuth.
+func (m *Manager) ConfigFor(serverID string) *mcp.OAuthConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.configs[serverID]
+}
+
+// RegisterConfig inserts an OAuth config for a server added at runtime (e.g.
+// through the AppConfig UI). Safe to call on an already-registered server.
+func (m *Manager) RegisterConfig(serverID string, cfg *mcp.OAuthConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.configs[serverID] = cfg
+}
+
+// UnregisterConfig removes the OAuth config for a server. Called when a
+// server is removed from the runtime registry.
+func (m *Manager) UnregisterConfig(serverID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.configs, serverID)
+}
+
+// ServerIDs returns the set of server IDs known to this manager.
+func (m *Manager) ServerIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, 0, len(m.configs))
+	for id := range m.configs {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Tokens exposes the underlying token store for the round tripper and tests.
+func (m *Manager) Tokens() UserTokenStore { return m.tokens }
+
+// BearerFor implements mcp.PerUserTokenProvider. Reads the user ID from the
+// context, resolves the current token (refreshing if needed), and returns
+// the bearer value to inject in the Authorization header.
+func (m *Manager) BearerFor(ctx context.Context, serverID string) (string, error) {
+	userID, ok := mcp.UserIDFromContext(ctx)
+	if !ok {
+		return "", mcp.ErrPerUserTokenUnavailable
+	}
+	tok, err := m.TokenFor(ctx, serverID, userID)
+	if errors.Is(err, ErrOAuthNotConnected) {
+		return "", mcp.ErrPerUserTokenUnavailable
+	}
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+// TokenFor returns the stored token for a user on a server, refreshing it
+// when close to expiry. Returns ErrOAuthNotConnected if no token is stored.
+func (m *Manager) TokenFor(ctx context.Context, serverID string, userID int64) (Token, error) {
+	tok, ok, err := m.tokens.Get(ctx, serverID, userID)
+	if err != nil {
+		return Token{}, fmt.Errorf("token lookup: %w", err)
+	}
+	if !ok {
+		return Token{}, ErrOAuthNotConnected
+	}
+	if !tok.NeedsRefresh() {
+		return tok, nil
+	}
+	refreshed, err := m.refresh(ctx, serverID, tok)
+	if err != nil {
+		if tok.Expired() {
+			return Token{}, err
+		}
+		// Refresh failed but token is still usable for a little while; log
+		// and return the stale-but-valid token so the in-flight request
+		// succeeds.
+		m.logger.Warn("OAuth refresh failed, returning current token", "server", serverID, "err", err)
+		return tok, nil
+	}
+	if err := m.tokens.Put(ctx, serverID, userID, refreshed); err != nil {
+		m.logger.Warn("persist refreshed token", "server", serverID, "err", err)
+	}
+	return refreshed, nil
+}

--- a/pkg/plugin/oauth/presets.go
+++ b/pkg/plugin/oauth/presets.go
@@ -1,0 +1,69 @@
+package oauth
+
+// PresetID identifies a one-click MCP provider.
+type PresetID string
+
+const (
+	PresetGitHubRead  PresetID = "github-read"
+	PresetGitHubWrite PresetID = "github-write"
+	PresetAtlassian   PresetID = "atlassian"
+)
+
+// Preset describes a known external MCP provider the admin can add with one
+// click from the UI. For providers that support RFC 7591 dynamic client
+// registration (Atlassian), DCRCapable is true and the client_id is issued
+// automatically. For providers that require a pre-registered OAuth app
+// (GitHub), DCRCapable is false and the admin must supply clientID +
+// clientSecret at provisioning time.
+type Preset struct {
+	ID            PresetID
+	DisplayName   string   // shown in the UI card + as the MCP server name
+	ServerID      string   // the ID the ServerConfig will take (unique per preset)
+	MCPURL        string   // endpoint that speaks MCP over HTTP
+	Transport     string   // "streamable-http" | "sse"
+	Scopes        []string // scopes requested in the authorize URL
+	DCRCapable    bool
+	AuthEndpoint  string // used only when DCRCapable is false
+	TokenEndpoint string // used only when DCRCapable is false
+	PKCE          bool
+}
+
+// Presets returns the built-in preset catalog.
+func Presets() map[PresetID]Preset {
+	return map[PresetID]Preset{
+		PresetGitHubRead: {
+			ID:            PresetGitHubRead,
+			DisplayName:   "GitHub (read-only)",
+			ServerID:      "github-read",
+			MCPURL:        "https://api.githubcopilot.com/mcp/",
+			Transport:     "streamable-http",
+			Scopes:        []string{"read:user", "read:org", "read:project", "read:packages", "notifications"},
+			DCRCapable:    false,
+			AuthEndpoint:  "https://github.com/login/oauth/authorize",
+			TokenEndpoint: "https://github.com/login/oauth/access_token",
+			PKCE:          true,
+		},
+		PresetGitHubWrite: {
+			ID:            PresetGitHubWrite,
+			DisplayName:   "GitHub (read / write)",
+			ServerID:      "github-write",
+			MCPURL:        "https://api.githubcopilot.com/mcp/",
+			Transport:     "streamable-http",
+			Scopes:        []string{"repo", "user:email", "read:org", "project", "workflow", "write:packages", "notifications", "codespace"},
+			DCRCapable:    false,
+			AuthEndpoint:  "https://github.com/login/oauth/authorize",
+			TokenEndpoint: "https://github.com/login/oauth/access_token",
+			PKCE:          true,
+		},
+		PresetAtlassian: {
+			ID:          PresetAtlassian,
+			DisplayName: "Atlassian (Jira + Confluence)",
+			ServerID:    "atlassian",
+			MCPURL:      "https://mcp.atlassian.com/v1/sse",
+			Transport:   "sse",
+			Scopes:      []string{"offline_access"},
+			DCRCapable:  true,
+			PKCE:        true,
+		},
+	}
+}

--- a/pkg/plugin/oauth/servers.go
+++ b/pkg/plugin/oauth/servers.go
@@ -1,0 +1,115 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// DynamicServer is the persisted record for an MCP server added through the
+// UI at runtime (rather than via provisioning YAML).
+type DynamicServer struct {
+	Config                  mcp.ServerConfig `json:"config"`
+	PresetID                string           `json:"presetID,omitempty"`
+	RegistrationClientURI   string           `json:"registrationClientURI,omitempty"`
+	RegistrationAccessToken string           `json:"registrationAccessToken,omitempty"`
+}
+
+// DynamicServerStore persists runtime-added MCP server records so they
+// survive plugin restarts.
+type DynamicServerStore interface {
+	Put(ctx context.Context, server DynamicServer) error
+	Delete(ctx context.Context, serverID string) error
+	List(ctx context.Context) ([]DynamicServer, error)
+}
+
+// InMemoryDynamicServerStore is sufficient for single-replica dev; records
+// are lost on plugin restart.
+type InMemoryDynamicServerStore struct {
+	mu      sync.RWMutex
+	records map[string]DynamicServer
+}
+
+func NewInMemoryDynamicServerStore() *InMemoryDynamicServerStore {
+	return &InMemoryDynamicServerStore{records: map[string]DynamicServer{}}
+}
+
+func (s *InMemoryDynamicServerStore) Put(_ context.Context, server DynamicServer) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[server.Config.ID] = server
+	return nil
+}
+
+func (s *InMemoryDynamicServerStore) Delete(_ context.Context, serverID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, serverID)
+	return nil
+}
+
+func (s *InMemoryDynamicServerStore) List(_ context.Context) ([]DynamicServer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]DynamicServer, 0, len(s.records))
+	for _, v := range s.records {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// RedisDynamicServerStore persists dynamic server records under a single
+// Redis hash so list operations are one round-trip.
+type RedisDynamicServerStore struct {
+	client *redis.Client
+	logger log.Logger
+	ctx    context.Context
+}
+
+const redisDynamicServersKey = "mcp_dynamic_servers"
+
+func NewRedisDynamicServerStore(ctx context.Context, client *redis.Client, logger log.Logger) *RedisDynamicServerStore {
+	return &RedisDynamicServerStore{client: client, logger: logger, ctx: ctx}
+}
+
+func (s *RedisDynamicServerStore) Put(ctx context.Context, server DynamicServer) error {
+	raw, err := json.Marshal(server)
+	if err != nil {
+		return fmt.Errorf("encode dynamic server: %w", err)
+	}
+	if err := s.client.HSet(ctx, redisDynamicServersKey, server.Config.ID, raw).Err(); err != nil {
+		return fmt.Errorf("redis hset: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisDynamicServerStore) Delete(ctx context.Context, serverID string) error {
+	if err := s.client.HDel(ctx, redisDynamicServersKey, serverID).Err(); err != nil {
+		return fmt.Errorf("redis hdel: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisDynamicServerStore) List(ctx context.Context) ([]DynamicServer, error) {
+	m, err := s.client.HGetAll(ctx, redisDynamicServersKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis hgetall: %w", err)
+	}
+	out := make([]DynamicServer, 0, len(m))
+	for _, raw := range m {
+		var v DynamicServer
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			s.logger.Warn("skip corrupt dynamic server record", "err", err)
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/pkg/plugin/oauth/state.go
+++ b/pkg/plugin/oauth/state.go
@@ -1,0 +1,132 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+)
+
+// StateTTL is how long a pending authorization-code flow is kept alive. The
+// OAuth spec recommends short lifetimes because the parameter is exchanged
+// through a browser redirect and should be treated as one-shot.
+const StateTTL = 5 * time.Minute
+
+// StateEntry stores everything we need to complete the authorization-code
+// exchange in the /callback handler.
+type StateEntry struct {
+	ServerID     string    `json:"serverID"`
+	UserID       int64     `json:"userID"`
+	CodeVerifier string    `json:"codeVerifier,omitempty"`
+	ReturnURL    string    `json:"returnURL,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+// StateStore persists pending-flow state keyed by the opaque `state` param we
+// pass to the authorization server.
+type StateStore interface {
+	Put(ctx context.Context, state string, entry StateEntry) error
+	PopAndGet(ctx context.Context, state string) (StateEntry, error)
+}
+
+// InMemoryStateStore is process-local and sufficient for single-replica or
+// dev environments. Entries are pruned lazily on access.
+type InMemoryStateStore struct {
+	mu      sync.Mutex
+	entries map[string]StateEntry
+}
+
+func NewInMemoryStateStore() *InMemoryStateStore {
+	return &InMemoryStateStore{entries: map[string]StateEntry{}}
+}
+
+func (s *InMemoryStateStore) Put(_ context.Context, state string, entry StateEntry) error {
+	entry.CreatedAt = time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[state] = entry
+	return nil
+}
+
+func (s *InMemoryStateStore) PopAndGet(_ context.Context, state string) (StateEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[state]
+	if !ok {
+		return StateEntry{}, ErrStateInvalid
+	}
+	delete(s.entries, state)
+	if time.Since(e.CreatedAt) > StateTTL {
+		return StateEntry{}, ErrStateInvalid
+	}
+	return e, nil
+}
+
+// RedisStateStore persists pending state in Redis with a short TTL.
+type RedisStateStore struct {
+	client *redis.Client
+	logger log.Logger
+	ctx    context.Context
+}
+
+func NewRedisStateStore(ctx context.Context, client *redis.Client, logger log.Logger) *RedisStateStore {
+	return &RedisStateStore{client: client, logger: logger, ctx: ctx}
+}
+
+func (s *RedisStateStore) Put(ctx context.Context, state string, entry StateEntry) error {
+	entry.CreatedAt = time.Now()
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode state: %w", err)
+	}
+	if err := s.client.Set(ctx, stateRedisKey(state), raw, StateTTL).Err(); err != nil {
+		return fmt.Errorf("redis set state: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisStateStore) PopAndGet(ctx context.Context, state string) (StateEntry, error) {
+	// GETDEL atomically reads and removes the key, preventing replay.
+	raw, err := s.client.GetDel(ctx, stateRedisKey(state)).Result()
+	if errors.Is(err, redis.Nil) {
+		return StateEntry{}, ErrStateInvalid
+	}
+	if err != nil {
+		return StateEntry{}, fmt.Errorf("redis getdel state: %w", err)
+	}
+	var e StateEntry
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		return StateEntry{}, fmt.Errorf("decode state: %w", err)
+	}
+	return e, nil
+}
+
+// NewState returns a cryptographically random opaque string suitable for use
+// as the OAuth `state` parameter. Callers persist it via the StateStore.
+func NewState() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}
+
+// NewPKCEPair generates an RFC 7636 code_verifier and its S256 challenge.
+func NewPKCEPair() (verifier, challenge string, err error) {
+	var buf [64]byte
+	if _, err = rand.Read(buf[:]); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(buf[:])
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}

--- a/pkg/plugin/oauth/state_test.go
+++ b/pkg/plugin/oauth/state_test.go
@@ -1,0 +1,69 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInMemoryStateStoreRoundTrip(t *testing.T) {
+	s := NewInMemoryStateStore()
+	ctx := context.Background()
+
+	state, err := NewState()
+	if err != nil {
+		t.Fatalf("NewState: %v", err)
+	}
+	if err := s.Put(ctx, state, StateEntry{ServerID: "atlassian", UserID: 42, CodeVerifier: "v"}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, err := s.PopAndGet(ctx, state)
+	if err != nil {
+		t.Fatalf("popAndGet: %v", err)
+	}
+	if got.ServerID != "atlassian" || got.UserID != 42 || got.CodeVerifier != "v" {
+		t.Fatalf("unexpected entry: %+v", got)
+	}
+
+	// Replay must fail.
+	if _, err := s.PopAndGet(ctx, state); !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on replay, got %v", err)
+	}
+}
+
+func TestInMemoryStateStoreExpiry(t *testing.T) {
+	s := NewInMemoryStateStore()
+	ctx := context.Background()
+	// Insert an entry manually with a stale CreatedAt to force expiry.
+	s.entries["stale"] = StateEntry{CreatedAt: time.Now().Add(-2 * StateTTL)}
+	if _, err := s.PopAndGet(ctx, "stale"); !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected expired state to be rejected, got %v", err)
+	}
+}
+
+func TestPKCEPair(t *testing.T) {
+	v, c, err := NewPKCEPair()
+	if err != nil {
+		t.Fatalf("NewPKCEPair: %v", err)
+	}
+	if v == "" || c == "" {
+		t.Fatalf("empty verifier/challenge")
+	}
+	v2, c2, _ := NewPKCEPair()
+	if v == v2 || c == c2 {
+		t.Fatalf("PKCE pair not random across calls")
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ctx := WithUserID(context.Background(), 0)
+	if _, ok := UserIDFromContext(ctx); ok {
+		t.Fatalf("zero user ID should not be stored")
+	}
+	ctx = WithUserID(context.Background(), 7)
+	if v, ok := UserIDFromContext(ctx); !ok || v != 7 {
+		t.Fatalf("expected 7, got %d ok=%v", v, ok)
+	}
+}

--- a/pkg/plugin/oauth/store.go
+++ b/pkg/plugin/oauth/store.go
@@ -1,0 +1,72 @@
+package oauth
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Token is a stored OAuth2 access/refresh token pair for a single
+// (serverID, userID) tuple.
+type Token struct {
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken,omitempty"`
+	TokenType    string    `json:"tokenType,omitempty"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+// Expired reports whether the token is past its expiry (with a small clock
+// skew allowance) at the current instant.
+func (t Token) Expired() bool {
+	return !t.ExpiresAt.IsZero() && time.Now().After(t.ExpiresAt.Add(-5*time.Second))
+}
+
+// NeedsRefresh reports whether the token is close enough to expiry that we
+// should refresh it proactively before the next outbound call.
+func (t Token) NeedsRefresh() bool {
+	return !t.ExpiresAt.IsZero() && time.Until(t.ExpiresAt) < 60*time.Second
+}
+
+// UserTokenStore persists per-user OAuth tokens scoped by MCP server.
+type UserTokenStore interface {
+	Get(ctx context.Context, serverID string, userID int64) (Token, bool, error)
+	Put(ctx context.Context, serverID string, userID int64, token Token) error
+	Delete(ctx context.Context, serverID string, userID int64) error
+}
+
+// InMemoryUserTokenStore is a process-local token store used when Redis is
+// unavailable. Tokens are lost on plugin restart, which is the same trade-off
+// the in-memory session store accepts.
+type InMemoryUserTokenStore struct {
+	mu     sync.RWMutex
+	tokens map[string]Token
+}
+
+func NewInMemoryUserTokenStore() *InMemoryUserTokenStore {
+	return &InMemoryUserTokenStore{tokens: map[string]Token{}}
+}
+
+func (s *InMemoryUserTokenStore) Get(_ context.Context, serverID string, userID int64) (Token, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.tokens[memKey(serverID, userID)]
+	return t, ok, nil
+}
+
+func (s *InMemoryUserTokenStore) Put(_ context.Context, serverID string, userID int64, token Token) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[memKey(serverID, userID)] = token
+	return nil
+}
+
+func (s *InMemoryUserTokenStore) Delete(_ context.Context, serverID string, userID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tokens, memKey(serverID, userID))
+	return nil
+}
+
+func memKey(serverID string, userID int64) string {
+	return serverIDEscape(serverID) + "|" + userIDString(userID)
+}

--- a/pkg/plugin/oauth/store_redis.go
+++ b/pkg/plugin/oauth/store_redis.go
@@ -1,0 +1,61 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisUserTokenStore persists per-user OAuth tokens in Redis so they survive
+// plugin restarts and are shared across Grafana replicas.
+type RedisUserTokenStore struct {
+	client *redis.Client
+	logger log.Logger
+	ctx    context.Context
+}
+
+func NewRedisUserTokenStore(ctx context.Context, client *redis.Client, logger log.Logger) *RedisUserTokenStore {
+	return &RedisUserTokenStore{client: client, logger: logger, ctx: ctx}
+}
+
+func (s *RedisUserTokenStore) Get(ctx context.Context, serverID string, userID int64) (Token, bool, error) {
+	raw, err := s.client.Get(ctx, tokenRedisKey(serverID, userID)).Result()
+	if errors.Is(err, redis.Nil) {
+		return Token{}, false, nil
+	}
+	if err != nil {
+		return Token{}, false, fmt.Errorf("redis get token: %w", err)
+	}
+	var t Token
+	if err := json.Unmarshal([]byte(raw), &t); err != nil {
+		return Token{}, false, fmt.Errorf("decode token: %w", err)
+	}
+	return t, true, nil
+}
+
+func (s *RedisUserTokenStore) Put(ctx context.Context, serverID string, userID int64, token Token) error {
+	raw, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("encode token: %w", err)
+	}
+	ttl := time.Until(token.ExpiresAt) + 24*time.Hour // keep refresh window after expiry
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	if err := s.client.Set(ctx, tokenRedisKey(serverID, userID), raw, ttl).Err(); err != nil {
+		return fmt.Errorf("redis set token: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisUserTokenStore) Delete(ctx context.Context, serverID string, userID int64) error {
+	if err := s.client.Del(ctx, tokenRedisKey(serverID, userID)).Err(); err != nil {
+		return fmt.Errorf("redis del token: %w", err)
+	}
+	return nil
+}

--- a/pkg/plugin/oauth/store_test.go
+++ b/pkg/plugin/oauth/store_test.go
@@ -1,0 +1,59 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryUserTokenStore(t *testing.T) {
+	s := NewInMemoryUserTokenStore()
+	ctx := context.Background()
+
+	tok := Token{AccessToken: "a", ExpiresAt: time.Now().Add(time.Hour)}
+	if err := s.Put(ctx, "atlassian", 42, tok); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, ok, err := s.Get(ctx, "atlassian", 42)
+	if err != nil || !ok || got.AccessToken != "a" {
+		t.Fatalf("get: ok=%v err=%v got=%+v", ok, err, got)
+	}
+
+	if _, ok, _ := s.Get(ctx, "atlassian", 99); ok {
+		t.Fatalf("unexpected token for other user")
+	}
+	if _, ok, _ := s.Get(ctx, "other", 42); ok {
+		t.Fatalf("unexpected token for other server")
+	}
+
+	if err := s.Delete(ctx, "atlassian", 42); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok, _ := s.Get(ctx, "atlassian", 42); ok {
+		t.Fatalf("token still present after delete")
+	}
+}
+
+func TestTokenExpiryHelpers(t *testing.T) {
+	past := Token{ExpiresAt: time.Now().Add(-time.Minute)}
+	if !past.Expired() {
+		t.Fatalf("expected past token to be expired")
+	}
+	if !past.NeedsRefresh() {
+		t.Fatalf("expected past token to need refresh")
+	}
+
+	soon := Token{ExpiresAt: time.Now().Add(30 * time.Second)}
+	if soon.Expired() {
+		t.Fatalf("token expiring in 30s should not be reported as expired")
+	}
+	if !soon.NeedsRefresh() {
+		t.Fatalf("token expiring in 30s should need refresh (60s threshold)")
+	}
+
+	future := Token{ExpiresAt: time.Now().Add(2 * time.Hour)}
+	if future.Expired() || future.NeedsRefresh() {
+		t.Fatalf("future token should neither be expired nor need refresh")
+	}
+}

--- a/pkg/plugin/openapi/openapi.json
+++ b/pkg/plugin/openapi/openapi.json
@@ -1682,6 +1682,207 @@
           }
         }
       }
+    },
+    "/api/oauth/{serverId}/start": {
+      "get": {
+        "summary": "Start OAuth authorization for an MCP server",
+        "description": "Generates OAuth state (and PKCE verifier when enabled) then redirects the browser to the server's authorization URL. The caller is the authenticated Grafana user; the resulting token is stored scoped to that user.",
+        "operationId": "startMCPOAuth",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "MCP server ID as declared in provisioning"
+          }
+        ],
+        "responses": {
+          "302": { "description": "Redirect to the authorization server" },
+          "401": { "description": "Unauthenticated caller" },
+          "404": { "description": "Server not found or has no OAuth config" }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/callback": {
+      "get": {
+        "summary": "OAuth callback",
+        "description": "Exchanges the authorization code for an access token and persists it for the current user. Renders a tiny HTML page that closes the popup and notifies the opener via postMessage.",
+        "operationId": "oauthCallback",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          { "name": "serverId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "code", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "state", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "error", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML page that posts a message to window.opener and closes.",
+            "content": { "text/html": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/status": {
+      "get": {
+        "summary": "Connection status for the current user on an OAuth-enabled MCP server",
+        "operationId": "getMCPOAuthStatus",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          { "name": "serverId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "configured": { "type": "boolean" },
+                    "connected": { "type": "boolean" },
+                    "expiresAt": { "type": "string", "format": "date-time" }
+                  },
+                  "required": ["configured", "connected"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/disconnect": {
+      "post": {
+        "summary": "Forget the current user's OAuth token for an MCP server",
+        "operationId": "disconnectMCPOAuth",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          { "name": "serverId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "204": { "description": "Token removed" },
+          "401": { "description": "Unauthenticated caller" },
+          "405": { "description": "Method not allowed" },
+          "500": { "description": "Failed to delete stored token" }
+        }
+      }
+    },
+    "/api/mcp/provisioner/presets": {
+      "get": {
+        "summary": "List built-in external MCP presets",
+        "operationId": "listMCPPresets",
+        "tags": ["MCP Provisioner"],
+        "responses": {
+          "200": {
+            "description": "Preset catalog",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "presets": { "type": "array", "items": { "type": "object" } } } } } }
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner": {
+      "get": {
+        "summary": "List dynamically provisioned MCP servers",
+        "operationId": "listDynamicMCPServers",
+        "tags": ["MCP Provisioner"],
+        "responses": {
+          "200": {
+            "description": "Server list",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "servers": { "type": "array", "items": { "type": "object" } } } } } }
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner/preset": {
+      "post": {
+        "summary": "Provision an MCP server from a preset (admin only)",
+        "operationId": "addMCPPreset",
+        "tags": ["MCP Provisioner"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["preset"],
+                "properties": {
+                  "preset": { "type": "string", "enum": ["github-read", "github-write", "atlassian"] },
+                  "clientId": { "type": "string" },
+                  "clientSecret": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Server provisioned" },
+          "400": { "description": "Invalid preset or missing client_id for non-DCR preset" },
+          "403": { "description": "Admin role required" },
+          "502": { "description": "Discovery or DCR failed against the provider" }
+        }
+      }
+    },
+    "/api/mcp/provisioner/generic": {
+      "post": {
+        "summary": "Provision an MCP server with custom OAuth settings (admin only)",
+        "operationId": "addGenericMCPServer",
+        "tags": ["MCP Provisioner"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["serverId", "mcpUrl", "transport"],
+                "properties": {
+                  "serverId": { "type": "string" },
+                  "displayName": { "type": "string" },
+                  "mcpUrl": { "type": "string" },
+                  "transport": { "type": "string", "enum": ["streamable-http", "sse"] },
+                  "authorizationUrl": { "type": "string" },
+                  "tokenUrl": { "type": "string" },
+                  "clientId": { "type": "string" },
+                  "clientSecret": { "type": "string" },
+                  "scopes": { "type": "array", "items": { "type": "string" } },
+                  "pkce": { "type": "boolean" },
+                  "discover": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Server provisioned" },
+          "400": { "description": "Invalid input" },
+          "403": { "description": "Admin role required" },
+          "502": { "description": "Discovery or DCR failed against the provider" }
+        }
+      }
+    },
+    "/api/mcp/provisioner/{serverId}": {
+      "delete": {
+        "summary": "Remove a provisioned MCP server (admin only)",
+        "operationId": "removeDynamicMCPServer",
+        "tags": ["MCP Provisioner"],
+        "parameters": [
+          { "name": "serverId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "204": { "description": "Server removed" },
+          "403": { "description": "Admin role required" },
+          "500": { "description": "Delete failed" }
+        }
+      }
     }
   },
   "components": {

--- a/pkg/plugin/openapi/openapi_test.go
+++ b/pkg/plugin/openapi/openapi_test.go
@@ -108,6 +108,15 @@ func TestSpecHasAllEndpoints(t *testing.T) {
 		"/api/sessions/share",
 		"/api/sessions/shared/{shareId}",
 		"/api/sessions/share/{shareId}",
+		"/api/oauth/{serverId}/start",
+		"/api/oauth/{serverId}/callback",
+		"/api/oauth/{serverId}/status",
+		"/api/oauth/{serverId}/disconnect",
+		"/api/mcp/provisioner/presets",
+		"/api/mcp/provisioner",
+		"/api/mcp/provisioner/preset",
+		"/api/mcp/provisioner/generic",
+		"/api/mcp/provisioner/{serverId}",
 	}
 
 	for _, path := range expectedPaths {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"consensys-asko11y-app/pkg/agent"
 	"consensys-asko11y-app/pkg/mcp"
+	"consensys-asko11y-app/pkg/plugin/oauth"
 	"consensys-asko11y-app/pkg/plugin/openapi"
 	"consensys-asko11y-app/pkg/rbac"
 	"context"
@@ -132,7 +133,9 @@ type Plugin struct {
 	ctx            context.Context
 	cancel         context.CancelFunc
 	runCancelsMu   sync.Mutex
-	runCancels     map[string]context.CancelFunc
+	runCancels         map[string]context.CancelFunc
+	oauthManager       *oauth.Manager
+	dynamicServerStore oauth.DynamicServerStore
 }
 
 func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
@@ -220,6 +223,36 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		sessionStore = NewRedisSessionStore(pluginCtx, redisClient, logger)
 	}
 
+	var tokenStore oauth.UserTokenStore
+	var stateStore oauth.StateStore
+	var dynamicServerStore oauth.DynamicServerStore
+	if usingRedis {
+		tokenStore = oauth.NewRedisUserTokenStore(pluginCtx, redisClient, logger)
+		stateStore = oauth.NewRedisStateStore(pluginCtx, redisClient, logger)
+		dynamicServerStore = oauth.NewRedisDynamicServerStore(pluginCtx, redisClient, logger)
+	} else {
+		tokenStore = oauth.NewInMemoryUserTokenStore()
+		stateStore = oauth.NewInMemoryStateStore()
+		dynamicServerStore = oauth.NewInMemoryDynamicServerStore()
+	}
+	oauthManager := oauth.NewManager(tokenStore, stateStore, logger, pluginSettings.MCPServers)
+	mcpProxy.SetPerUserTokenProvider(oauthManager)
+
+	// Restore dynamic (UI-added) MCP servers so they're attached before
+	// health monitoring starts checking them.
+	if dynamicRecords, err := dynamicServerStore.List(pluginCtx); err != nil {
+		logger.Warn("list dynamic MCP servers", "err", err)
+	} else {
+		for _, rec := range dynamicRecords {
+			if rec.Config.OAuth != nil {
+				oauthManager.RegisterConfig(rec.Config.ID, rec.Config.OAuth)
+			}
+			if err := mcpProxy.EnsureServer(rec.Config); err != nil {
+				logger.Warn("restore dynamic MCP server", "id", rec.Config.ID, "err", err)
+			}
+		}
+	}
+
 	llmHTTPClient, err := httpclient.New(httpclient.Options{
 		Timeouts: &httpclient.TimeoutOptions{
 			Timeout:     600 * time.Second,
@@ -257,7 +290,9 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		settings:       pluginSettings,
 		ctx:            pluginCtx,
 		cancel:         cancel,
-		runCancels:     make(map[string]context.CancelFunc),
+		runCancels:         make(map[string]context.CancelFunc),
+		oauthManager:       oauthManager,
+		dynamicServerStore: dynamicServerStore,
 	}
 
 	if !usingRedis {
@@ -375,6 +410,12 @@ func (p *Plugin) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/sessions/share/", p.handleDeleteShare)
 	mux.HandleFunc("/api/sessions/", p.handleSessionRouter)
 	mux.HandleFunc("/api/sessions", p.handleSessionsRoot)
+
+	// OAuth for per-user external MCP authentication.
+	if p.oauthManager != nil {
+		p.oauthManager.RegisterRoutes(mux, getUserID)
+	}
+	p.registerProvisionerRoutes(mux)
 
 	mux.HandleFunc("/", p.handleDefault)
 }
@@ -524,7 +565,8 @@ func (p *Plugin) handleMCPCallTool(w http.ResponseWriter, r *http.Request) {
 
 	p.logger.Debug("Tool call context", "orgID", orgID, "orgName", req.OrgName, "scopeOrgId", req.ScopeOrgId, "tool", req.Name)
 
-	result, err := p.mcpProxy.CallToolWithContext(req.Name, req.Arguments, orgID, req.OrgName, req.ScopeOrgId)
+	callCtx := mcp.WithUserID(r.Context(), getUserID(r))
+	result, err := p.mcpProxy.CallToolWithContext(callCtx, req.Name, req.Arguments, orgID, req.OrgName, req.ScopeOrgId)
 	if err != nil {
 		p.logger.Error("Failed to call tool", "error", err)
 		http.Error(w, "Failed to call tool", http.StatusInternalServerError)
@@ -542,14 +584,39 @@ func (p *Plugin) handleMCPServers(w http.ResponseWriter, r *http.Request) {
 	serversHealth := healthMonitor.GetAllHealth()
 	systemHealth := healthMonitor.GetSystemHealth()
 
+	oauthStatus := p.oauthStatusForUser(r)
+
 	w.Header().Set("Content-Type", "application/json")
 
 	response := map[string]interface{}{
 		"servers":      serversHealth,
 		"systemHealth": systemHealth,
+		"oauth":        oauthStatus,
 	}
 
 	json.NewEncoder(w).Encode(response)
+}
+
+// oauthStatusForUser returns a map serverID → {configured, connected, expiresAt}
+// for every MCP server with an OAuth block, telling the frontend whether the
+// current user still needs to click Connect.
+func (p *Plugin) oauthStatusForUser(r *http.Request) map[string]oauth.StatusResponse {
+	out := map[string]oauth.StatusResponse{}
+	if p.oauthManager == nil {
+		return out
+	}
+	userID := getUserID(r)
+	for _, id := range p.oauthManager.ServerIDs() {
+		status := oauth.StatusResponse{Configured: true}
+		if userID != 0 {
+			if tok, ok, err := p.oauthManager.Tokens().Get(r.Context(), id, userID); err == nil && ok {
+				status.Connected = !tok.Expired()
+				status.ExpiresAt = tok.ExpiresAt
+			}
+		}
+		out[id] = status
+	}
+	return out
 }
 
 func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
@@ -745,6 +812,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 		GrafanaURL:         grafanaURL,
 		AuthToken:          saToken,
 		UserRole:           userRole,
+		UserID:             userID,
 		OrgID:              orgID,
 		OrgName:            req.OrgName,
 		ScopeOrgID:         req.ScopeOrgID,
@@ -1124,6 +1192,7 @@ func (p *Plugin) handleGraphitiDiscover(w http.ResponseWriter, r *http.Request) 
 		GrafanaURL:         grafanaURL,
 		AuthToken:          saToken,
 		UserRole:           userRole,
+		UserID:             userID,
 		OrgID:              strconv.FormatInt(orgID, 10),
 		OrgName:            "Org" + strconv.FormatInt(orgID, 10),
 		ExcludeToolNames:   graphitiWriteToolNames,

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -7,6 +7,7 @@ import { mcp } from '@grafana/llm';
 import { testIds } from '../testIds';
 import { ValidationService } from '../../services/validation';
 import { PromptEditor } from './PromptEditor';
+import { ExternalMCPs } from './ExternalMCPs';
 import type { AppPluginSettings, MCPServerConfig } from '../../types/plugin';
 
 interface PromptDefaults {
@@ -876,6 +877,8 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
           </Button>
         </div>
       </FieldSet>
+
+      <ExternalMCPs />
 
       {promptDefaults && (
         <FieldSet label="Prompt Templates" className="mt-4">

--- a/src/components/AppConfig/ExternalMCPs.tsx
+++ b/src/components/AppConfig/ExternalMCPs.tsx
@@ -1,0 +1,328 @@
+/**
+ * ExternalMCPs
+ *
+ * AppConfig section that lets Admin users attach external MCP servers at
+ * runtime — three presets (GitHub r/o, GitHub r/w, Atlassian) plus a generic
+ * form. After provisioning, each end user gets their own "Connect" flow in
+ * the MCP Status panel.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Button, Field, Input, Select } from '@grafana/ui';
+import {
+  addGeneric,
+  addPreset,
+  AddGenericInput,
+  DynamicMCPServer,
+  listDynamicServers,
+  listPresets,
+  MCPPreset,
+  PresetID,
+  removeDynamicServer,
+} from '../../services/mcpProvisionerClient';
+
+function PresetCard({
+  preset,
+  isProvisioned,
+  onProvision,
+  onRemove,
+  busyWith,
+}: {
+  preset: MCPPreset;
+  isProvisioned: boolean;
+  onProvision: (p: MCPPreset) => Promise<void>;
+  onRemove: (serverId: string) => Promise<void>;
+  busyWith: string | null;
+}) {
+  const needsClientId = !preset.dcrCapable;
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const busy = busyWith === preset.id;
+
+  return (
+    <div className="p-3 rounded border border-weak flex flex-col gap-2 mb-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium">{preset.displayName}</div>
+          <div className="text-xs text-secondary">
+            {preset.mcpUrl} · {preset.transport} · {preset.dcrCapable ? 'auto-registers with provider' : 'bring your own OAuth app'}
+          </div>
+          {preset.scopes.length > 0 && (
+            <div className="text-xs text-secondary">scopes: {preset.scopes.join(', ')}</div>
+          )}
+        </div>
+        <div className="flex gap-2">
+          {isProvisioned ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={busy}
+              onClick={async () => {
+                await onRemove(preset.serverId);
+              }}
+            >
+              Remove
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={busy || (needsClientId && !clientId)}
+              onClick={async () => {
+                await onProvision({ ...preset });
+                setClientId('');
+                setClientSecret('');
+              }}
+            >
+              {busy ? 'Adding…' : 'Add'}
+            </Button>
+          )}
+        </div>
+      </div>
+      {needsClientId && !isProvisioned && (
+        <div className="grid grid-cols-2 gap-2">
+          <Field
+            label="Client ID"
+            description={
+              preset.serverId.startsWith('github')
+                ? 'Create an OAuth App at https://github.com/settings/developers with the plugin callback URL.'
+                : 'Client ID from your OAuth provider.'
+            }
+          >
+            <Input value={clientId} onChange={(e) => setClientId(e.currentTarget.value)} placeholder="Iv1.abcd…" />
+          </Field>
+          <Field label="Client Secret (optional, PKCE preferred)">
+            <Input
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.currentTarget.value)}
+              placeholder="leave blank for PKCE-only"
+            />
+          </Field>
+          <div className="col-span-2">
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={busy || !clientId}
+              onClick={async () => {
+                (preset as any).__clientId = clientId;
+                (preset as any).__clientSecret = clientSecret;
+                await onProvision(preset);
+                setClientId('');
+                setClientSecret('');
+              }}
+            >
+              {busy ? 'Adding…' : 'Add with Client ID'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GenericForm({
+  onSubmit,
+  busy,
+}: {
+  onSubmit: (input: AddGenericInput) => Promise<void>;
+  busy: boolean;
+}) {
+  const [form, setForm] = useState<AddGenericInput>({
+    serverId: '',
+    displayName: '',
+    mcpUrl: '',
+    transport: 'streamable-http',
+    pkce: true,
+    discover: true,
+    scopes: [],
+  });
+  const [scopesText, setScopesText] = useState('');
+
+  const set = <K extends keyof AddGenericInput>(k: K, v: AddGenericInput[K]) => setForm({ ...form, [k]: v });
+
+  const submit = async () => {
+    const scopes = scopesText
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    await onSubmit({ ...form, scopes });
+  };
+
+  return (
+    <div className="p-3 rounded border border-weak">
+      <div className="font-medium mb-2">Generic OAuth MCP</div>
+      <div className="text-xs text-secondary mb-3">
+        Use <strong>Discover</strong> when the server publishes OAuth metadata ({`/.well-known/oauth-authorization-server`}); leave it off to supply URLs manually.
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <Field label="Server ID">
+          <Input value={form.serverId} onChange={(e) => set('serverId', e.currentTarget.value)} placeholder="my-mcp" />
+        </Field>
+        <Field label="Display name">
+          <Input value={form.displayName ?? ''} onChange={(e) => set('displayName', e.currentTarget.value)} />
+        </Field>
+        <Field label="MCP URL" className="col-span-2">
+          <Input value={form.mcpUrl} onChange={(e) => set('mcpUrl', e.currentTarget.value)} placeholder="https://mcp.example.com/v1/mcp" />
+        </Field>
+        <Field label="Transport">
+          <Select
+            value={form.transport}
+            onChange={(v) => set('transport', (v?.value as 'streamable-http' | 'sse') || 'streamable-http')}
+            options={[
+              { value: 'streamable-http', label: 'streamable-http' },
+              { value: 'sse', label: 'sse' },
+            ]}
+          />
+        </Field>
+        <Field label="Discover + DCR">
+          <input
+            type="checkbox"
+            checked={form.discover ?? true}
+            onChange={(e) => set('discover', e.currentTarget.checked)}
+          />
+        </Field>
+        <Field label="Authorization URL (skip if Discover)">
+          <Input value={form.authorizationUrl ?? ''} onChange={(e) => set('authorizationUrl', e.currentTarget.value)} />
+        </Field>
+        <Field label="Token URL (skip if Discover)">
+          <Input value={form.tokenUrl ?? ''} onChange={(e) => set('tokenUrl', e.currentTarget.value)} />
+        </Field>
+        <Field label="Client ID (required if not using Discover+DCR)">
+          <Input value={form.clientId ?? ''} onChange={(e) => set('clientId', e.currentTarget.value)} />
+        </Field>
+        <Field label="Client Secret (optional)">
+          <Input
+            type="password"
+            value={form.clientSecret ?? ''}
+            onChange={(e) => set('clientSecret', e.currentTarget.value)}
+          />
+        </Field>
+        <Field label="Scopes (space-separated)" className="col-span-2">
+          <Input value={scopesText} onChange={(e) => setScopesText(e.currentTarget.value)} placeholder="offline_access read:content" />
+        </Field>
+      </div>
+      <div className="mt-2">
+        <Button size="sm" variant="primary" onClick={submit} disabled={busy || !form.serverId || !form.mcpUrl}>
+          {busy ? 'Adding…' : 'Add generic MCP'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ExternalMCPs() {
+  const [presets, setPresets] = useState<MCPPreset[]>([]);
+  const [servers, setServers] = useState<DynamicMCPServer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busyWith, setBusyWith] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [p, s] = await Promise.all([listPresets(), listDynamicServers()]);
+      setPresets(p);
+      setServers(s);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const provisionedByPreset = new Set(servers.map((s) => s.presetId).filter(Boolean));
+
+  const handleProvision = async (preset: MCPPreset) => {
+    setBusyWith(preset.id);
+    setError(null);
+    try {
+      const clientId = (preset as any).__clientId as string | undefined;
+      const clientSecret = (preset as any).__clientSecret as string | undefined;
+      await addPreset({ preset: preset.id as PresetID, clientId, clientSecret });
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyWith(null);
+    }
+  };
+
+  const handleRemove = async (serverId: string) => {
+    setBusyWith(serverId);
+    setError(null);
+    try {
+      await removeDynamicServer(serverId);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyWith(null);
+    }
+  };
+
+  const handleGeneric = async (input: AddGenericInput) => {
+    setBusyWith('generic');
+    setError(null);
+    try {
+      await addGeneric(input);
+      await refresh();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyWith(null);
+    }
+  };
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-xl font-semibold mb-2">External MCP servers (OAuth)</h3>
+      <p className="text-sm text-secondary mb-4">
+        Attach one-click presets or wire up any MCP that speaks OAuth 2.0 authorization-code. Each Grafana user then
+        connects with their own account from the MCP status panel.
+      </p>
+      {error && (
+        <Alert severity="error" title="Action failed" onRemove={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {presets.map((p) => (
+        <PresetCard
+          key={p.id}
+          preset={p}
+          isProvisioned={provisionedByPreset.has(p.id)}
+          onProvision={handleProvision}
+          onRemove={handleRemove}
+          busyWith={busyWith}
+        />
+      ))}
+
+      {servers
+        .filter((s) => !s.presetId)
+        .map((s) => (
+          <div
+            key={s.serverId}
+            className="p-3 rounded border border-weak flex items-center justify-between mb-3"
+          >
+            <div>
+              <div className="font-medium">{s.displayName}</div>
+              <div className="text-xs text-secondary">
+                {s.mcpUrl} · {s.transport}
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={busyWith === s.serverId}
+              onClick={() => handleRemove(s.serverId)}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+
+      <GenericForm onSubmit={handleGeneric} busy={busyWith === 'generic'} />
+    </div>
+  );
+}

--- a/src/components/MCPStatus/MCPStatus.test.tsx
+++ b/src/components/MCPStatus/MCPStatus.test.tsx
@@ -52,6 +52,13 @@ jest.mock('../../services/mcpServerStatus', () => ({
   },
 }));
 
+// Mock oauthClient so tests don't pull in @grafana/runtime.
+jest.mock('../../services/oauthClient', () => ({
+  disconnectOAuth: jest.fn().mockResolvedValue(undefined),
+  onOAuthCallback: jest.fn().mockReturnValue(() => undefined),
+  openOAuthPopup: jest.fn().mockReturnValue({}),
+}));
+
 describe('MCPStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/components/MCPStatus/MCPStatus.tsx
+++ b/src/components/MCPStatus/MCPStatus.tsx
@@ -5,7 +5,8 @@
 
 import React, { useState, useEffect } from 'react';
 import { useTheme2, Badge, Tooltip, Icon, Button } from '@grafana/ui';
-import { mcpServerStatusService, MCPServerStatus, SystemHealth } from '../../services/mcpServerStatus';
+import { mcpServerStatusService, MCPServerStatus, MCPOAuthStatus, SystemHealth } from '../../services/mcpServerStatus';
+import { disconnectOAuth, onOAuthCallback, openOAuthPopup } from '../../services/oauthClient';
 import { InlineLoading } from '../LoadingOverlay';
 
 export interface MCPStatusProps {
@@ -28,12 +29,14 @@ export function MCPStatus({ compact = false, showDetails = true, className = '',
   });
   const [isExpanded, setIsExpanded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [oauth, setOauth] = useState<Record<string, MCPOAuthStatus>>({});
 
   // Fetch server statuses from backend
   const fetchStatuses = async () => {
     const response = await mcpServerStatusService.fetchServerStatuses();
     setServers(response.servers);
     setSystemHealth(response.systemHealth);
+    setOauth(response.oauth ?? {});
     setIsLoading(false);
   };
 
@@ -44,7 +47,15 @@ export function MCPStatus({ compact = false, showDetails = true, className = '',
     // Poll every 30 seconds
     const interval = setInterval(fetchStatuses, 30000);
 
-    return () => clearInterval(interval);
+    // Re-fetch immediately when an OAuth popup reports back.
+    const unsubscribe = onOAuthCallback(() => {
+      fetchStatuses();
+    });
+
+    return () => {
+      clearInterval(interval);
+      unsubscribe();
+    };
   }, []);
 
   const getStatusIcon = (status: MCPServerStatus['status']) => {
@@ -202,7 +213,14 @@ export function MCPStatus({ compact = false, showDetails = true, className = '',
           {servers.length === 0 ? (
             <div className="text-center py-4 text-secondary">No MCP servers configured</div>
           ) : (
-            servers.map((server) => <ServerStatusRow key={server.serverId} server={server} onRefresh={fetchStatuses} />)
+            servers.map((server) => (
+              <ServerStatusRow
+                key={server.serverId}
+                server={server}
+                oauthStatus={oauth[server.serverId]}
+                onRefresh={fetchStatuses}
+              />
+            ))
           )}
         </div>
       )}
@@ -232,7 +250,15 @@ function StatusCard({ label, value, color, icon }: { label: string; value: numbe
   );
 }
 
-function ServerStatusRow({ server, onRefresh }: { server: MCPServerStatus; onRefresh: () => void }) {
+function ServerStatusRow({
+  server,
+  oauthStatus,
+  onRefresh,
+}: {
+  server: MCPServerStatus;
+  oauthStatus?: MCPOAuthStatus;
+  onRefresh: () => void;
+}) {
   const theme = useTheme2();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [showTools, setShowTools] = useState(false);
@@ -241,6 +267,19 @@ function ServerStatusRow({ server, onRefresh }: { server: MCPServerStatus; onRef
     setIsRefreshing(true);
     await onRefresh();
     setTimeout(() => setIsRefreshing(false), 500);
+  };
+
+  const handleConnect = () => {
+    const popup = openOAuthPopup(server.serverId);
+    if (!popup) {
+      // Popup blocked: fall back to same-tab navigation.
+      window.location.href = `/api/plugins/consensys-asko11y-app/resources/api/oauth/${encodeURIComponent(server.serverId)}/start`;
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await disconnectOAuth(server.serverId);
+    await onRefresh();
   };
 
   return (
@@ -281,6 +320,29 @@ function ServerStatusRow({ server, onRefresh }: { server: MCPServerStatus; onRef
         </div>
 
         <div className="flex items-center gap-2">
+          {/* OAuth: per-user connect/disconnect for servers that require it */}
+          {oauthStatus?.configured && (
+            oauthStatus.connected ? (
+              <Tooltip
+                content={
+                  oauthStatus.expiresAt
+                    ? `Connected, expires ${new Date(oauthStatus.expiresAt).toLocaleString()}`
+                    : 'Connected'
+                }
+              >
+                <Button size="sm" variant="secondary" icon="unlock" onClick={handleDisconnect}>
+                  Disconnect
+                </Button>
+              </Tooltip>
+            ) : (
+              <Tooltip content="This server requires you to sign in before tools can be called.">
+                <Button size="sm" variant="primary" icon="lock" onClick={handleConnect}>
+                  Connect
+                </Button>
+              </Tooltip>
+            )
+          )}
+
           {/* Tool Count */}
           <Tooltip content={`${server.toolCount} tools available. Click to view.`}>
             <Button size="sm" variant="secondary" onClick={() => setShowTools(!showTools)}>

--- a/src/services/mcpProvisionerClient.ts
+++ b/src/services/mcpProvisionerClient.ts
@@ -1,0 +1,87 @@
+import { firstValueFrom } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+
+const baseUrl = '/api/plugins/consensys-asko11y-app/resources/api/mcp/provisioner';
+
+export type PresetID = 'github-read' | 'github-write' | 'atlassian';
+
+export interface MCPPreset {
+  id: PresetID;
+  displayName: string;
+  serverId: string;
+  mcpUrl: string;
+  transport: 'streamable-http' | 'sse';
+  scopes: string[];
+  dcrCapable: boolean;
+}
+
+export interface DynamicMCPServer {
+  serverId: string;
+  displayName: string;
+  mcpUrl: string;
+  transport: string;
+  presetId?: string;
+  scopes?: string[];
+}
+
+export async function listPresets(): Promise<MCPPreset[]> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ presets: MCPPreset[] }>({ url: `${baseUrl}/presets`, method: 'GET' })
+  );
+  return resp?.data?.presets ?? [];
+}
+
+export async function listDynamicServers(): Promise<DynamicMCPServer[]> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ servers: DynamicMCPServer[] }>({ url: baseUrl, method: 'GET' })
+  );
+  return resp?.data?.servers ?? [];
+}
+
+export interface AddPresetInput {
+  preset: PresetID;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export async function addPreset(input: AddPresetInput): Promise<{ serverId: string }> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ serverId: string }>({
+      url: `${baseUrl}/preset`,
+      method: 'POST',
+      data: input,
+    })
+  );
+  return resp?.data ?? { serverId: '' };
+}
+
+export interface AddGenericInput {
+  serverId: string;
+  displayName?: string;
+  mcpUrl: string;
+  transport: 'streamable-http' | 'sse';
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  scopes?: string[];
+  pkce?: boolean;
+  discover?: boolean;
+}
+
+export async function addGeneric(input: AddGenericInput): Promise<{ serverId: string }> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ serverId: string }>({
+      url: `${baseUrl}/generic`,
+      method: 'POST',
+      data: input,
+    })
+  );
+  return resp?.data ?? { serverId: '' };
+}
+
+export async function removeDynamicServer(serverId: string): Promise<void> {
+  await firstValueFrom(
+    getBackendSrv().fetch({ url: `${baseUrl}/${encodeURIComponent(serverId)}`, method: 'DELETE' })
+  );
+}

--- a/src/services/mcpServerStatus.ts
+++ b/src/services/mcpServerStatus.ts
@@ -37,9 +37,18 @@ export interface SystemHealth {
   total: number;
 }
 
+export interface MCPOAuthStatus {
+  configured: boolean;
+  connected: boolean;
+  expiresAt?: string;
+}
+
 export interface MCPServersResponse {
   servers: MCPServerStatus[];
   systemHealth: SystemHealth;
+  // oauth is keyed by server ID and present only for servers with an oauth
+  // block. It reflects the current Grafana user's connection state.
+  oauth?: Record<string, MCPOAuthStatus>;
 }
 
 export class MCPServerStatusService {

--- a/src/services/oauthClient.ts
+++ b/src/services/oauthClient.ts
@@ -1,0 +1,82 @@
+import { firstValueFrom } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+
+export interface OAuthStatus {
+  configured: boolean;
+  connected: boolean;
+  expiresAt?: string;
+}
+
+const baseUrl = '/api/plugins/consensys-asko11y-app/resources';
+
+/**
+ * Returns the OAuth connection status for a given MCP server and the current
+ * Grafana user. Safe to call even when the server has no OAuth block — the
+ * backend returns configured:false in that case.
+ */
+export async function getOAuthStatus(serverID: string): Promise<OAuthStatus> {
+  try {
+    const resp = await firstValueFrom(
+      getBackendSrv().fetch<OAuthStatus>({
+        url: `${baseUrl}/api/oauth/${encodeURIComponent(serverID)}/status`,
+        method: 'GET',
+      })
+    );
+    return resp?.data ?? { configured: false, connected: false };
+  } catch {
+    return { configured: false, connected: false };
+  }
+}
+
+/**
+ * Returns the absolute URL the UI should open in a popup to kick off the
+ * authorization-code flow. The backend 302s to the authorization server.
+ */
+export function startOAuthURL(serverID: string): string {
+  return `${baseUrl}/api/oauth/${encodeURIComponent(serverID)}/start`;
+}
+
+/**
+ * Opens the OAuth flow in a popup. Returns the handle so the caller can
+ * detect popup-blocker scenarios and fall back to a same-tab redirect.
+ */
+export function openOAuthPopup(serverID: string): Window | null {
+  return window.open(startOAuthURL(serverID), '_blank', 'width=600,height=750,menubar=no,toolbar=no');
+}
+
+/**
+ * Tells the backend to forget the current user's stored token for a server.
+ */
+export async function disconnectOAuth(serverID: string): Promise<void> {
+  await firstValueFrom(
+    getBackendSrv().fetch({
+      url: `${baseUrl}/api/oauth/${encodeURIComponent(serverID)}/disconnect`,
+      method: 'POST',
+    })
+  );
+}
+
+/**
+ * Shape of the postMessage the /callback handler dispatches to the opener.
+ */
+export interface OAuthCallbackMessage {
+  source: 'asko11y-oauth';
+  serverID: string;
+  success: boolean;
+  reason?: string;
+}
+
+/**
+ * Subscribe to OAuth popup-close events. Returns an unsubscribe function.
+ */
+export function onOAuthCallback(cb: (msg: OAuthCallbackMessage) => void): () => void {
+  const handler = (e: MessageEvent) => {
+    const data = e.data as OAuthCallbackMessage | null;
+    if (!data || data.source !== 'asko11y-oauth') {
+      return;
+    }
+    cb(data);
+  };
+  window.addEventListener('message', handler);
+  return () => window.removeEventListener('message', handler);
+}


### PR DESCRIPTION
## Summary

- Each Grafana user can now authorise external MCP servers with their own identity via OAuth 2.0 authorization-code + PKCE; the agent attaches that user's token on every tool call.
- Admins can attach new OAuth-gated MCP servers from the plugin config page — three presets (GitHub read-only, GitHub read/write, Atlassian) plus a Generic form with optional Discover + DCR.
- Servers without an `oauth` block keep working with the existing static-header path; graphiti etc. are unchanged.

## Why

`atlassian-broker-mcp` through `mcp-context-forge` can't be reached with a static bearer — the broker requires a per-user OAuth grant. That same problem applies to GitHub's hosted MCP and to any future provider. Rather than bolt a forge-specific workaround, this change makes per-user OAuth a first-class capability of the MCP proxy: any provider that speaks RFC 6749 authorization-code (+ PKCE where supported) can be wired in.

## Key design choices

- Generic and opt-in: OAuth kicks in only when a `ServerConfig` has an `oauth` block. Per-request `Authorization` is swapped in by a round tripper that reads the user ID from the request context; no per-user MCP session is opened.
- Discovery stack: RFC 8414 well-known probe first, fall back to the RFC 9728 resource-metadata advertised in the `WWW-Authenticate` challenge. For providers that advertise `registration_endpoint`, RFC 7591 dynamic client registration runs automatically (Atlassian, any MCP-spec-compliant server). For providers that don't (GitHub), the admin supplies a `client_id` (and optional `client_secret`) in the UI.
- Storage: Redis when available, in-memory fallback — same selection pattern as the existing rate limiter. Tokens, PKCE state, and dynamic server records all follow the same pattern.
- RBAC: the four OAuth routes (`/start`, `/callback`, `/status`, `/disconnect`) are per-user; the provisioner routes (`/api/mcp/provisioner/*`) require the Admin role.

## What ships

**Backend**

- `pkg/mcp/types.go` — `OAuthConfig` added to `ServerConfig`.
- `pkg/mcp/oauth.go` — `PerUserTokenProvider`, `userTokenRoundTripper`, ctx helpers.
- `pkg/mcp/client.go` — OAuth round tripper plugged into both connect paths; static Authorization skipped when OAuth is set; `session.CallTool` receives the caller ctx.
- `pkg/mcp/proxy.go` — `SetPerUserTokenProvider` propagates to every `Client`; ctx on `CallToolWithContext`.
- `pkg/agent/loop.go` — `LoopRequest.UserID`; set on ctx before each MCP call.
- `pkg/plugin/oauth/` (new package) — token/state/dynamic-server stores (memory + Redis), OAuth handlers, discovery + DCR helpers, preset catalogue.
- `pkg/plugin/mcp_provisioner.go` — admin-only provisioner HTTP endpoints.
- `pkg/plugin/plugin.go` — construction, route wiring, restore of dynamic servers on boot, per-user OAuth state in `/api/mcp/servers`.

**Frontend**

- `src/services/oauthClient.ts`, `mcpProvisionerClient.ts` — typed wrappers, popup + `postMessage` listener.
- `src/services/mcpServerStatus.ts` — response type carries an `oauth` map.
- `src/components/MCPStatus/MCPStatus.tsx` — Connect / Disconnect row per OAuth-enabled server.
- `src/components/AppConfig/ExternalMCPs.tsx` (new) — three preset cards + Generic form.

**Spec**

- `pkg/plugin/openapi/openapi.json` — four OAuth routes and five provisioner routes documented.

## Test plan

- [x] `go build ./...`, `go test ./pkg/...` (all 6 packages pass)
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run test:ci` (466/466)
- [x] `npm run validate:openapi`
- [x] Atlassian end-to-end against `mcp.atlassian.com` verified manually: DCR succeeds, authorize URL discovered, token exchange works, per-user bearer attached, `tools/call` returns real content instead of "Atlassian rejected the user's token".
- [ ] GitHub preset (requires an OAuth App in the GitHub developer console; left for the reviewer to dogfood).
- [ ] Mimic flow from a second Grafana user profile: confirm each user's tokens are isolated.

## Screens / flow

1. Admin opens plugin config → **External MCP servers (OAuth)** → clicks **Add** on *Atlassian*. Backend discovers + DCRs, persists, attaches to the proxy.
2. End user opens the MCP Status panel → clicks **Connect** on the Atlassian row. Popup to auth.atlassian.com, accept, popup closes, status flips to *Connected*.
3. Agent tool calls that route to Atlassian succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces new OAuth authorization-code/PKCE flows, per-user token storage/refresh, and changes how `Authorization` headers and request contexts are propagated through the MCP proxy and agent tool calls.
> 
> **Overview**
> Adds **per-user OAuth authentication for MCP tool calls**: `ServerConfig` gains an `oauth` block, MCP clients/proxy accept a `PerUserTokenProvider`, and outbound requests use a new round-tripper that injects a user-specific `Authorization: Bearer ...` while skipping any static `Authorization` header for OAuth-enabled servers.
> 
> Introduces a **plugin OAuth manager + HTTP API** to start/callback/status/disconnect OAuth flows, persist tokens/state (Redis or in-memory), refresh tokens when near expiry, and expose per-server OAuth connection status to the UI.
> 
> Adds **admin-only dynamic MCP server provisioning** (preset + generic) with optional OAuth metadata discovery and dynamic client registration, persists these servers, restores them on startup, and updates the frontend AppConfig and MCP status panel to provision servers and let end users Connect/Disconnect. OpenAPI spec and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa47a966f3a85e5aa5a68975a9cdb2aab601b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->