### PR TITLE
ci(release): fix attestation verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           gh attestation verify "${PLUGIN_ID}-${VERSION}.zip" \
             --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
+            --cert-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary
- fix the release workflow provenance verification command by using `--cert-identity` for the exact GitHub Actions certificate SAN
- this preserves the strict tag-scoped workflow identity check without using the wrong `--signer-workflow` format

## Verification
- downloaded the v0.2.26 release zip
- verified it locally with:
  `gh attestation verify <zip> --repo Consensys/ask-o11y-plugin --cert-identity https://github.com/Consensys/ask-o11y-plugin/.github/workflows/release.yml@refs/tags/v0.2.26`

The failed v0.2.26 job created the attestation and uploaded the release asset before this post-build verification step failed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts `gh attestation verify` arguments; main impact is whether releases pass/fail provenance verification.
> 
> **Overview**
> Updates the release workflow’s provenance verification step to use `gh attestation verify --cert-identity` (tag-scoped workflow identity) instead of `--signer-workflow`, so verification matches the GitHub Actions certificate SAN and the job no longer fails after uploading the release asset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f912eb6c6ba12c2e6f7b3bb3ef18a8c49afa89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->