### PR TITLE
fix(frontend): scope plugin styles and use theme font size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ consensys-asko11y-app.zip
 
 # Claude Code
 .claude/agents/
+exports/
 
 # Local secrets / prod data extractions (do not commit)
 local/prod-redis-sessions/

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,9 +22,26 @@ module.exports = {
     },
   },
   webpackFinal: async (config) => {
-    // Add support for CSS modules
+    const cssModuleLoader = {
+      loader: 'css-loader',
+      options: {
+        importLoaders: 1,
+        modules: {
+          mode: 'global',
+          exportGlobals: true,
+          localIdentName: '[path][name]__[local]',
+        },
+      },
+    };
+
+    config.module.rules.push({
+      test: /\.module\.css$/,
+      use: ['style-loader', cssModuleLoader, 'postcss-loader'],
+    });
+
     config.module.rules.push({
       test: /\.css$/,
+      exclude: /\.module\.css$/,
       use: ['style-loader', 'css-loader', 'postcss-loader'],
     });
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '../src/index.css';
+import '../src/PluginRoot.module.css';
 import { themes } from '@storybook/theming';
 
 export const parameters = {

--- a/docker/graphiti/Dockerfile
+++ b/docker/graphiti/Dockerfile
@@ -1,2 +1,15 @@
 FROM zepai/knowledge-graph-mcp:standalone
-RUN pip install --no-cache-dir --target=/app/mcp/.venv/lib/python3.11/site-packages anthropic
+RUN pip install --no-cache-dir --target=/app/mcp/.venv/lib/python3.11/site-packages anthropic \
+    && groupadd --system --gid 1000 graphiti \
+    && useradd --system --uid 1000 --gid graphiti --home-dir /tmp --shell /usr/sbin/nologin graphiti \
+    && cp /root/.local/bin/uv /usr/local/bin/uv \
+    && cp /root/.local/bin/uvx /usr/local/bin/uvx \
+    && chown -R 1000:1000 /app/mcp
+
+ENV HOME=/tmp \
+    UV_CACHE_DIR=/tmp/uv-cache \
+    UV_COMPILE_BYTECODE=0 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+USER 1000:1000

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,7 @@ export default defineConfig([
       '**/coverage-unit/',
       '**/coverage-combined/',
       '**/dist/',
+      '**/.react19-*/',
       '**/artifacts/',
       '**/work/',
       '**/ci/',

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -17,7 +17,13 @@ const isInsideIgnoredAtRule = (rule) => {
 const scopeSelector = (selector) => {
   const trimmed = selector.trim();
 
-  if (trimmed === '' || trimmed.startsWith(pluginRootSelector) || trimmed.includes('&')) {
+  if (
+    trimmed === '' ||
+    trimmed.startsWith(pluginRootSelector) ||
+    trimmed.startsWith(':local') ||
+    trimmed.startsWith(':global') ||
+    trimmed.includes('&')
+  ) {
     return selector;
   }
 

--- a/scripts/dump-redis-sessions.sh
+++ b/scripts/dump-redis-sessions.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Archives Redis persistence files from the Kubernetes Redis pod into /tmp and
+# copies the archive locally. Set FRESH_BGSAVE=true only when you explicitly
+# want Redis to write a fresh snapshot before copying.
+
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-w3f-o11y-prod-us}"
+NAMESPACE="${NAMESPACE:-monitoring}"
+REDIS_SELECTOR="${REDIS_SELECTOR:-app.kubernetes.io/name=redis}"
+REDIS_POD="${REDIS_POD:-}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-}"
+LOCAL_OUTPUT_DIR="${LOCAL_OUTPUT_DIR:-/tmp}"
+FRESH_BGSAVE="${FRESH_BGSAVE:-false}"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+REMOTE_FILE="${REMOTE_FILE:-/tmp/ask-o11y-redis-sessions-${timestamp}.tar}"
+LOCAL_FILE="${LOCAL_FILE:-${LOCAL_OUTPUT_DIR}/$(basename "${REMOTE_FILE}")}"
+
+kubectl_base=(kubectl --context "${KUBECTL_CONTEXT}" -n "${NAMESPACE}")
+container_args=()
+if [[ -n "${REDIS_CONTAINER}" ]]; then
+  container_args=(-c "${REDIS_CONTAINER}")
+fi
+
+remote_env=(
+  "DUMP_FILE=${REMOTE_FILE}"
+  "FRESH_BGSAVE=${FRESH_BGSAVE}"
+  "REDIS_CLI_ARGS=${REDIS_CLI_ARGS:-}"
+)
+if [[ -n "${REDISCLI_AUTH:-}" ]]; then
+  remote_env+=("REDISCLI_AUTH=${REDISCLI_AUTH}")
+fi
+
+if [[ -z "${REDIS_POD}" ]]; then
+  mapfile -t redis_pods < <("${kubectl_base[@]}" get pods \
+    -l "${REDIS_SELECTOR}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+  if [[ "${#redis_pods[@]}" -ne 1 ]]; then
+    printf 'Expected exactly one Redis pod in namespace %s using selector %s, found %d.\n' \
+      "${NAMESPACE}" "${REDIS_SELECTOR}" "${#redis_pods[@]}" >&2
+    printf 'Set REDIS_POD explicitly, for example:\n' >&2
+    printf '  REDIS_POD=redis-... %s\n' "$0" >&2
+    exit 1
+  fi
+
+  REDIS_POD="${redis_pods[0]}"
+fi
+
+mkdir -p "${LOCAL_OUTPUT_DIR}"
+
+printf 'Archiving Redis persistence files from %s/%s using context %s\n' \
+  "${NAMESPACE}" "${REDIS_POD}" "${KUBECTL_CONTEXT}"
+printf 'Remote file: %s\n' "${REMOTE_FILE}"
+printf 'Local file:  %s\n' "${LOCAL_FILE}"
+
+"${kubectl_base[@]}" exec -i "${REDIS_POD}" "${container_args[@]}" -- \
+  env "${remote_env[@]}" sh -s <<'REMOTE_SCRIPT'
+set -eu
+
+redis() {
+  # REDIS_CLI_ARGS intentionally allows operators to pass options like:
+  #   REDIS_CLI_ARGS="-h redis -p 6379 -n 0"
+  # shellcheck disable=SC2086
+  redis-cli --no-auth-warning ${REDIS_CLI_ARGS:-} "$@"
+}
+
+config_value() {
+  redis --raw CONFIG GET "$1" | tail -n 1
+}
+
+if [ "${FRESH_BGSAVE}" = "true" ]; then
+  before="$(redis --raw LASTSAVE)"
+  redis --raw BGSAVE >/dev/null
+
+  while :; do
+    in_progress="$(redis --raw INFO persistence | awk -F: '/^rdb_bgsave_in_progress:/ { gsub("\r", "", $2); print $2 }')"
+    lastsave="$(redis --raw LASTSAVE)"
+    if [ "${in_progress}" = "0" ] && [ "${lastsave}" != "${before}" ]; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
+redis_dir="$(config_value dir)"
+dbfilename="$(config_value dbfilename)"
+appendonly="$(config_value appendonly || printf 'no')"
+appendfilename="$(config_value appendfilename || true)"
+appenddirname="$(config_value appenddirname || true)"
+manifest="${DUMP_FILE}.manifest"
+
+cd "${redis_dir}"
+
+set --
+if [ -n "${dbfilename}" ] && [ -f "${dbfilename}" ]; then
+  set -- "$@" "${dbfilename}"
+fi
+
+if [ "${appendonly}" = "yes" ]; then
+  if [ -n "${appenddirname}" ] && [ -e "${appenddirname}" ]; then
+    set -- "$@" "${appenddirname}"
+  elif [ -n "${appendfilename}" ] && [ -f "${appendfilename}" ]; then
+    set -- "$@" "${appendfilename}"
+  fi
+fi
+
+if [ "$#" -eq 0 ]; then
+  printf 'No Redis persistence files found in %s\n' "${redis_dir}" >&2
+  exit 1
+fi
+
+{
+  printf 'exported_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'redis_dir=%s\n' "${redis_dir}"
+  printf 'fresh_bgsave=%s\n' "${FRESH_BGSAVE}"
+  printf 'appendonly=%s\n' "${appendonly}"
+  printf 'dbsize=%s\n' "$(redis --raw DBSIZE)"
+  printf 'files='
+  printf '%s ' "$@"
+  printf '\n'
+} > "${manifest}"
+
+rm -f "${DUMP_FILE}"
+tar -cf "${DUMP_FILE}" "$@" -C "$(dirname "${manifest}")" "$(basename "${manifest}")"
+rm -f "${manifest}"
+
+printf 'Archived Redis persistence files to %s\n' "${DUMP_FILE}"
+REMOTE_SCRIPT
+
+"${kubectl_base[@]}" cp "${REDIS_POD}:${REMOTE_FILE}" "${LOCAL_FILE}" "${container_args[@]}"
+
+printf 'Copied Redis session dump to %s\n' "${LOCAL_FILE}"

--- a/src/PluginRoot.module.css
+++ b/src/PluginRoot.module.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss' important;
 
+:local(.root) {
+  width: 100%;
+  height: 100%;
+}
+
 /* Default CSS custom properties for fallback values (before Grafana theme loads) */
 .ask-o11y-plugin-root {
   /* Light theme fallback values */

--- a/src/PluginRoot.tsx
+++ b/src/PluginRoot.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
+import { cx } from '@emotion/css';
 import { GrafanaThemeProvider } from './theme';
-import './index.css';
+import styles from './PluginRoot.module.css';
 
 export const PLUGIN_ROOT_CLASS = 'ask-o11y-plugin-root';
 
@@ -9,7 +10,7 @@ interface PluginRootProps {
 }
 
 export const PluginRoot = ({ children }: PluginRootProps) => (
-  <GrafanaThemeProvider className={PLUGIN_ROOT_CLASS} style={{ width: '100%', height: '100%' }}>
+  <GrafanaThemeProvider className={cx(PLUGIN_ROOT_CLASS, styles.root)}>
     {children}
   </GrafanaThemeProvider>
 );

--- a/src/components/AppConfig/PromptEditor.test.tsx
+++ b/src/components/AppConfig/PromptEditor.test.tsx
@@ -30,6 +30,14 @@ jest.mock('@grafana/ui', () => ({
       </div>
     ) : null,
   TextArea: ({ invalid, ...props }: MockTextAreaProps) => <textarea {...props} aria-invalid={invalid ? 'true' : 'false'} />,
+  useTheme2: () => ({
+    typography: {
+      bodySmall: {
+        fontSize: '12px',
+      },
+      fontFamilyMonospace: 'monospace',
+    },
+  }),
 }));
 
 describe('PromptEditor', () => {

--- a/src/components/AppConfig/PromptEditor.tsx
+++ b/src/components/AppConfig/PromptEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Button, Modal, TextArea } from '@grafana/ui';
+import { Button, Modal, TextArea, useTheme2 } from '@grafana/ui';
 
 interface PromptEditorProps {
   label: string;
@@ -43,6 +43,7 @@ export function PromptEditor({
   onSave,
   testIdPrefix,
 }: PromptEditorProps) {
+  const theme = useTheme2();
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState(currentValue);
 
@@ -89,7 +90,10 @@ export function PromptEditor({
             rows={16}
             data-testid={`${testIdPrefix}-textarea`}
             invalid={isOverLimit || !!templateError}
-            style={{ fontFamily: 'monospace', fontSize: '13px' }}
+            style={{
+              fontFamily: theme.typography.fontFamilyMonospace,
+              fontSize: theme.typography.bodySmall.fontSize,
+            }}
           />
 
           <div className="flex items-center justify-between mt-2">

--- a/src/types/cssModules.d.ts
+++ b/src/types/cssModules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -36,17 +36,43 @@ const config = async (env: Env): Promise<Configuration> => {
   // Build the rules array with our CSS rule that includes postcss-loader
   // Only apply postcss-loader to CSS files in our src directory (for Tailwind)
   // Other CSS files (like from node_modules) should use the base rule without postcss-loader
+  const sourcePath = path.resolve(process.cwd(), 'src');
+  const cssLoader = {
+    loader: 'css-loader',
+    options: {
+      importLoaders: 1,
+    },
+  };
+  const cssModuleLoader = {
+    loader: 'css-loader',
+    options: {
+      importLoaders: 1,
+      modules: {
+        mode: 'global',
+        exportGlobals: true,
+        localIdentName: isProduction ? '[hash:base64:8]' : '[path][name]__[local]',
+      },
+    },
+  };
   const rules: RuleSetRule[] = [
+    // CSS modules for component-scoped source styles. Global utility selectors
+    // remain scoped by postcss.config.js to the plugin root class.
+    {
+      test: /\.module\.css$/,
+      include: sourcePath,
+      use: ['style-loader', cssModuleLoader, 'postcss-loader'],
+    },
     // CSS rule for our source files (with postcss-loader for Tailwind)
     {
       test: /\.css$/,
-      include: path.resolve(process.cwd(), 'src'),
-      use: ['style-loader', 'css-loader', 'postcss-loader'],
+      include: sourcePath,
+      exclude: /\.module\.css$/,
+      use: ['style-loader', cssLoader, 'postcss-loader'],
     },
     // CSS rule for other files (node_modules, etc.) - without postcss-loader
     {
       test: /\.css$/,
-      exclude: path.resolve(process.cwd(), 'src'),
+      exclude: sourcePath,
       use: ['style-loader', 'css-loader'],
     },
     // Add all other base rules, but modify swc-loader for coverage builds


### PR DESCRIPTION
## Summary
- Fix the release attestation verification step so the `v0.2.26`/`v0.2.27` release flow can complete cleanly
- Replace the global CSS import in `PluginRoot` with a CSS module and keep plugin styles scoped to the app root
- Replace the hardcoded `13px` font size in `PromptEditor` with Grafana theme typography
- Add test and build plumbing for CSS modules and keep generated React 19 sandbox files out of lint

## Testing
- `npm run typecheck`
- `npm run lint` (passes with existing non-blocking deprecation warnings)
- `npm run build:frontend:prod`
- `npm run test:ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly build/styling changes, but it modifies webpack/storybook CSS handling and PostCSS selector scoping, which can affect how styles load and render across the plugin.
> 
> **Overview**
> **Scopes plugin styling more tightly and standardizes typography.** `PluginRoot` now imports `PluginRoot.module.css` and applies a CSS-module `root` class (instead of inline width/height + global CSS import), with Storybook updated to load the module stylesheet.
> 
> **Adds CSS module support across tooling.** Webpack and Storybook now treat `*.module.css` separately (CSS modules with global export + distinct class naming), `postcss.config.js` skips scoping for `:local`/`:global` selectors, and TypeScript gains a `*.module.css` declaration.
> 
> **Misc ops/tooling updates.** `PromptEditor` uses `useTheme2()` for monospace font + size (tests mock the hook), ESLint ignores `**/.react19-*`, `.gitignore` ignores `exports/`, a new `scripts/dump-redis-sessions.sh` is added, and the `docker/graphiti` image is hardened to run as a non-root user with adjusted env and ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e608ea1e497a2a859dd414ad3923991c1fd87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->