### PR TITLE
feat(chat): add model selection for chat runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ ci/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+.playwright-mcp/
 
 # Editor
 .idea

--- a/pkg/agent/llm_client.go
+++ b/pkg/agent/llm_client.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	llmEndpoint    = "/api/plugins/grafana-llm-app/resources/openai/v1/chat/completions"
-	llmModel       = "large"
 	llmTimeout     = 600 * time.Second
 	maxSSELineSize = 1 * 1024 * 1024 // 1 MB — large tool-call payloads (e.g. dashboard JSON) can exceed bufio's 64 KB default
 )
@@ -73,7 +72,6 @@ func (c *LLMClient) ChatCompletion(ctx context.Context, req ChatCompletionReques
 		span.End()
 	}()
 
-	req.Model = llmModel
 	req.Stream = true
 
 	body, err := json.Marshal(req)

--- a/pkg/agent/llm_client_test.go
+++ b/pkg/agent/llm_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -36,12 +37,21 @@ func TestLLMClient_ChatCompletion(t *testing.T) {
 			t.Errorf("expected content-type json, got %q", r.Header.Get("Content-Type"))
 		}
 
-		var req ChatCompletionRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("failed to decode request: %v", err)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
 		}
-		if req.Model != "large" {
-			t.Errorf("expected model 'large', got %q", req.Model)
+		var raw map[string]interface{}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("failed to decode raw request: %v", err)
+		}
+		if _, ok := raw["model"]; ok {
+			t.Errorf("expected model to be omitted when unset, got %v", raw["model"])
+		}
+
+		var req ChatCompletionRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
 		}
 		if !req.Stream {
 			t.Errorf("expected stream=true in request")
@@ -69,6 +79,36 @@ func TestLLMClient_ChatCompletion(t *testing.T) {
 	}
 	if resp.Choices[0].Message.Content != "Hello from the LLM!" {
 		t.Errorf("unexpected content: %q", resp.Choices[0].Message.Content)
+	}
+}
+
+func TestLLMClient_ChatCompletion_UsesRequestedModel(t *testing.T) {
+	receivedModel := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		receivedModel <- req.Model
+
+		writeSSEChunks(w,
+			`{"id":"test-id","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`,
+			`{"id":"test-id","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		)
+	}))
+	defer server.Close()
+
+	client := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
+	_, err := client.ChatCompletion(context.Background(), ChatCompletionRequest{
+		Model:    "base",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	}, server.URL, "token", "1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := <-receivedModel; got != "base" {
+		t.Fatalf("expected model base, got %q", got)
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -45,6 +45,7 @@ type LoopRequest struct {
 	MaxTotalTokens     int
 	RecentMessageCount int
 	MaxIterations      int
+	Model              string
 
 	GrafanaURL string
 	AuthToken  string
@@ -132,6 +133,7 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 		}
 
 		llmReq := ChatCompletionRequest{
+			Model:     req.Model,
 			Messages:  callMessages,
 			Tools:     openAITools,
 			MaxTokens: completionBudget,

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -156,6 +156,47 @@ func TestAgentLoop_SimpleTextResponse(t *testing.T) {
 	}
 }
 
+func TestAgentLoop_ForwardsRequestedModel(t *testing.T) {
+	receivedModel := make(chan string, 1)
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		receivedModel <- req.Model
+		respondAsStream(w, ChatCompletionResponse{
+			ID: "1",
+			Choices: []Choice{{
+				Message:      Message{Role: "assistant", Content: "ok"},
+				FinishReason: "stop",
+			}},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
+	mcpProxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
+	loop := NewAgentLoop(llmClient, mcpProxy, log.DefaultLogger)
+
+	eventCh := make(chan SSEEvent, 32)
+	req := LoopRequest{
+		Messages:     []Message{{Role: "user", Content: "hello"}},
+		SystemPrompt: "sys",
+		Model:        "large",
+		GrafanaURL:   llmServer.URL,
+		AuthToken:    "test-token",
+		UserRole:     "Admin",
+		OrgID:        "1",
+	}
+
+	go loop.Run(context.Background(), req, eventCh)
+	collectEvents(eventCh)
+
+	if got := <-receivedModel; got != "large" {
+		t.Fatalf("expected model large, got %q", got)
+	}
+}
+
 func TestAgentLoop_ToolCallThenText(t *testing.T) {
 	// First response: tool call. Second response: text.
 	// The tool call will fail (no MCP server configured) but the loop should continue.

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -32,7 +32,7 @@ type OpenAIFunction struct {
 }
 
 type ChatCompletionRequest struct {
-	Model     string       `json:"model"`
+	Model     string       `json:"model,omitempty"`
 	Messages  []Message    `json:"messages"`
 	Tools     []OpenAITool `json:"tools,omitempty"`
 	Stream    bool         `json:"stream,omitempty"`

--- a/pkg/plugin/agent_model.go
+++ b/pkg/plugin/agent_model.go
@@ -1,0 +1,22 @@
+package plugin
+
+import "net/http"
+
+const (
+	agentModelBase  = "base"
+	agentModelLarge = "large"
+)
+
+func parseAgentModelParam(r *http.Request) (string, bool) {
+	model := r.URL.Query().Get("model")
+	switch model {
+	case "", agentModelBase, agentModelLarge:
+		return model, true
+	default:
+		return "", false
+	}
+}
+
+func persistSessionModel(store SessionStoreInterface, sessionID string, userID, orgID int64, model string) error {
+	return store.UpdateSession(sessionID, userID, orgID, SessionUpdate{Model: &model})
+}

--- a/pkg/plugin/agent_model_test.go
+++ b/pkg/plugin/agent_model_test.go
@@ -1,0 +1,31 @@
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseAgentModelParam(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+		ok   bool
+	}{
+		{name: "omitted", url: "/api/agent/run", want: "", ok: true},
+		{name: "base", url: "/api/agent/run?model=base", want: "base", ok: true},
+		{name: "large", url: "/api/agent/run?model=large", want: "large", ok: true},
+		{name: "invalid", url: "/api/agent/run?model=opus", want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.url, nil)
+			got, ok := parseAgentModelParam(req)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("parseAgentModelParam() = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/pkg/plugin/openapi/openapi.json
+++ b/pkg/plugin/openapi/openapi.json
@@ -497,6 +497,19 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/X-Grafana-Org-Id"
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "base",
+                "large"
+              ]
+            },
+            "description": "LLM app model abstraction to use for this session. Omit to use the grafana-llm-app default. Once set on a session, later runs must use the same model."
           }
         ],
         "requestBody": {
@@ -2324,6 +2337,14 @@
           "activeRunId": {
             "type": "string",
             "description": "ID of currently active agent run (if any)"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "base",
+              "large"
+            ],
+            "description": "LLM app model abstraction locked to this session, if selected"
           }
         },
         "required": [
@@ -2362,6 +2383,14 @@
           "activeRunId": {
             "type": "string",
             "description": "ID of currently active agent run (if any)"
+          },
+          "model": {
+            "type": "string",
+            "enum": [
+              "base",
+              "large"
+            ],
+            "description": "LLM app model abstraction locked to this session, if selected"
           }
         },
         "required": [

--- a/pkg/plugin/openapi/openapi_test.go
+++ b/pkg/plugin/openapi/openapi_test.go
@@ -192,6 +192,56 @@ func TestSpecHasSSEDocumentation(t *testing.T) {
 	}
 }
 
+func TestSpecDocumentsAgentRunModelSelection(t *testing.T) {
+	spec, err := GetSpec()
+	if err != nil {
+		t.Fatalf("GetSpec() failed: %v", err)
+	}
+
+	paths := spec["paths"].(map[string]interface{})
+	runPath := paths["/api/agent/run"].(map[string]interface{})
+	post := runPath["post"].(map[string]interface{})
+	params := post["parameters"].([]interface{})
+
+	var modelParam map[string]interface{}
+	for _, param := range params {
+		p, ok := param.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if p["name"] == "model" {
+			modelParam = p
+			break
+		}
+	}
+	if modelParam == nil {
+		t.Fatal("agent run endpoint missing model query parameter")
+	}
+	if modelParam["in"] != "query" {
+		t.Fatalf("model parameter in = %v, want query", modelParam["in"])
+	}
+	schema := modelParam["schema"].(map[string]interface{})
+	enum := schema["enum"].([]interface{})
+	if len(enum) != 2 || enum[0] != "base" || enum[1] != "large" {
+		t.Fatalf("model enum = %v, want [base large]", enum)
+	}
+
+	components := spec["components"].(map[string]interface{})
+	schemas := components["schemas"].(map[string]interface{})
+	for _, schemaName := range []string{"ChatSession", "SessionMetadata"} {
+		sessionSchema := schemas[schemaName].(map[string]interface{})
+		properties := sessionSchema["properties"].(map[string]interface{})
+		model, ok := properties["model"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("%s missing model property", schemaName)
+		}
+		modelEnum := model["enum"].([]interface{})
+		if len(modelEnum) != 2 || modelEnum[0] != "base" || modelEnum[1] != "large" {
+			t.Fatalf("%s model enum = %v, want [base large]", schemaName, modelEnum)
+		}
+	}
+}
+
 func TestSpecHasRateLimitingDocumentation(t *testing.T) {
 	spec, err := GetSpec()
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -678,6 +678,12 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	requestedModel, ok := parseAgentModelParam(r)
+	if !ok {
+		http.Error(w, "Invalid model; supported values are 'base' and 'large'", http.StatusBadRequest)
+		return
+	}
+
 	cfg := backend.GrafanaConfigFromContext(r.Context())
 	if cfg == nil {
 		p.logger.Error("Grafana configuration not available in request context")
@@ -736,6 +742,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 
 	var messages []agent.Message
 	var sessionID string
+	runModel := requestedModel
 
 	if req.SessionID != "" {
 		session, err := p.sessionStore.GetSession(req.SessionID, userID, numericOrgID)
@@ -744,6 +751,19 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sessionID = req.SessionID
+		if session.Model != "" {
+			if requestedModel != "" && requestedModel != session.Model {
+				http.Error(w, "Session model cannot be changed", http.StatusBadRequest)
+				return
+			}
+			runModel = session.Model
+		} else if requestedModel != "" {
+			if err := persistSessionModel(p.sessionStore, sessionID, userID, numericOrgID, requestedModel); err != nil {
+				p.logger.Error("Failed to persist session model", "error", err, "sessionId", sessionID)
+				http.Error(w, "Failed to persist session model", http.StatusInternalServerError)
+				return
+			}
+		}
 
 		for _, msg := range session.Messages {
 			messages = append(messages, agent.Message{
@@ -781,6 +801,13 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sessionID = session.ID
+		if runModel != "" {
+			if err := persistSessionModel(p.sessionStore, sessionID, userID, numericOrgID, runModel); err != nil {
+				p.logger.Error("Failed to persist session model", "error", err, "sessionId", sessionID)
+				http.Error(w, "Failed to persist session model", http.StatusInternalServerError)
+				return
+			}
+		}
 
 		if err := p.sessionStore.SetCurrentSessionID(userID, numericOrgID, sessionID); err != nil {
 			p.logger.Warn("Failed to set current session ID", "error", err)
@@ -799,6 +826,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 		"sessionId", sessionID,
 		"messageCount", len(messages),
 		"type", req.Type,
+		"model", runModel,
 	)
 
 	span.SetAttributes(
@@ -815,6 +843,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 		MaxTotalTokens:     p.settings.MaxTotalTokens,
 		RecentMessageCount: p.settings.RecentMessageCount,
 		MaxIterations:      resolveMaxIterations(req.Type, req.Message),
+		Model:              runModel,
 		GrafanaURL:         grafanaURL,
 		AuthToken:          saToken,
 		UserRole:           userRole,
@@ -1679,6 +1708,10 @@ func (p *Plugin) handleSessionRouter(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 			p.logger.Warn("Invalid update-session request body", "error", err)
 			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+		if update.Model != nil {
+			http.Error(w, "Session model can only be set by agent run creation", http.StatusBadRequest)
 			return
 		}
 		if err := p.sessionStore.UpdateSession(sessionID, userID, orgID, update); err != nil {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -2,14 +2,94 @@ package plugin
 
 import (
 	"consensys-asko11y-app/pkg/agent"
+	"consensys-asko11y-app/pkg/mcp"
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
+
+func newAgentRunTestPlugin(t *testing.T) *Plugin {
+	t.Helper()
+
+	logger := log.DefaultLogger
+	proxy := mcp.NewProxy(context.Background(), logger)
+	llmClient := agent.NewLLMClient(logger, http.DefaultClient)
+	promptRegistry, err := NewPromptRegistry(PluginSettings{})
+	if err != nil {
+		t.Fatalf("NewPromptRegistry failed: %v", err)
+	}
+
+	return &Plugin{
+		logger:         logger,
+		mcpProxy:       proxy,
+		agentLoop:      agent.NewAgentLoop(llmClient, proxy, logger),
+		runStore:       NewRunStore(logger),
+		sessionStore:   NewSessionStore(logger),
+		promptRegistry: promptRegistry,
+		settings: PluginSettings{
+			MaxTotalTokens:     agent.DefaultMaxTotalTokens,
+			RecentMessageCount: 10,
+		},
+		runCancels: make(map[string]context.CancelFunc),
+		dsCache:    make(map[string]dsCacheEntry),
+	}
+}
+
+func newAgentRunRequest(t *testing.T, grafanaURL, targetURL, body string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, targetURL, strings.NewReader(body))
+	req.Header.Set("X-Grafana-Org-Id", "2")
+	req.Header.Set("X-Grafana-User-Id", "7")
+	req.Header.Set("X-Grafana-User-Role", "Admin")
+	cfg := backend.NewGrafanaCfg(map[string]string{
+		"GF_APP_URL":                  grafanaURL,
+		"GF_PLUGIN_APP_CLIENT_SECRET": "test-token",
+	})
+	return req.WithContext(backend.WithGrafanaConfig(req.Context(), cfg))
+}
+
+func newAgentRunLLMServer(t *testing.T) (*httptest.Server, <-chan agent.ChatCompletionRequest) {
+	t.Helper()
+
+	received := make(chan agent.ChatCompletionRequest, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/plugins/grafana-llm-app/resources/openai/v1/chat/completions" {
+			t.Errorf("unexpected LLM path %q", r.URL.Path)
+		}
+		var req agent.ChatCompletionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode LLM request: %v", err)
+		}
+		received <- req
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"id\":\"run\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":null}]}\n\n")
+		fmt.Fprint(w, "data: {\"id\":\"run\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+
+	return server, received
+}
+
+func receiveAgentRunLLMRequest(t *testing.T, ch <-chan agent.ChatCompletionRequest) agent.ChatCompletionRequest {
+	t.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for LLM request")
+		return agent.ChatCompletionRequest{}
+	}
+}
 
 func TestBuiltInMCPBaseURL(t *testing.T) {
 	t.Run("default returns localhost:3000", func(t *testing.T) {
@@ -78,6 +158,97 @@ func TestResolveGrafanaURL(t *testing.T) {
 			t.Errorf("url = %q, want %q", url, "https://cloud.grafana.net")
 		}
 	})
+}
+
+func TestHandleAgentRunRejectsInvalidModel(t *testing.T) {
+	p := &Plugin{logger: log.DefaultLogger}
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/run?model=opus", strings.NewReader(`{"message":"hello"}`))
+	rec := httptest.NewRecorder()
+
+	p.handleAgentRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleAgentRunPersistsNewSessionModel(t *testing.T) {
+	llmServer, received := newAgentRunLLMServer(t)
+	defer llmServer.Close()
+
+	p := newAgentRunTestPlugin(t)
+	req := newAgentRunRequest(t, llmServer.URL, "/api/agent/run?model=base", `{"message":"hello","type":"chat"}`)
+	rec := httptest.NewRecorder()
+
+	p.handleAgentRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	session, err := p.sessionStore.GetSession(body.SessionID, 7, 2)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if session.Model != "base" {
+		t.Fatalf("expected session model base, got %q", session.Model)
+	}
+	if got := receiveAgentRunLLMRequest(t, received); got.Model != "base" {
+		t.Fatalf("expected LLM model base, got %q", got.Model)
+	}
+}
+
+func TestHandleAgentRunUsesStoredSessionModelWhenQueryOmitted(t *testing.T) {
+	llmServer, received := newAgentRunLLMServer(t)
+	defer llmServer.Close()
+
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "existing", []SessionMessage{{Role: "user", Content: "previous"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	model := "large"
+	if err := p.sessionStore.UpdateSession(session.ID, 7, 2, SessionUpdate{Model: &model}); err != nil {
+		t.Fatalf("UpdateSession failed: %v", err)
+	}
+
+	req := newAgentRunRequest(t, llmServer.URL, "/api/agent/run", fmt.Sprintf(`{"message":"follow up","sessionId":%q}`, session.ID))
+	rec := httptest.NewRecorder()
+
+	p.handleAgentRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := receiveAgentRunLLMRequest(t, received); got.Model != "large" {
+		t.Fatalf("expected LLM model large, got %q", got.Model)
+	}
+}
+
+func TestHandleAgentRunRejectsConflictingSessionModel(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "existing", []SessionMessage{{Role: "user", Content: "previous"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	model := "base"
+	if err := p.sessionStore.UpdateSession(session.ID, 7, 2, SessionUpdate{Model: &model}); err != nil {
+		t.Fatalf("UpdateSession failed: %v", err)
+	}
+
+	req := newAgentRunRequest(t, "http://grafana.test", "/api/agent/run?model=large", fmt.Sprintf(`{"message":"follow up","sessionId":%q}`, session.ID))
+	rec := httptest.NewRecorder()
+
+	p.handleAgentRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
 }
 
 func TestReconstructAssistantMessage(t *testing.T) {

--- a/pkg/plugin/sessionstore.go
+++ b/pkg/plugin/sessionstore.go
@@ -26,6 +26,7 @@ type ChatSession struct {
 	UpdatedAt    time.Time        `json:"updatedAt"`
 	MessageCount int              `json:"messageCount"`
 	ActiveRunID  string           `json:"activeRunId,omitempty"`
+	Model        string           `json:"model,omitempty"`
 	UserID       int64            `json:"-"`
 	OrgID        int64            `json:"-"`
 }
@@ -37,12 +38,14 @@ type SessionMetadata struct {
 	UpdatedAt    time.Time `json:"updatedAt"`
 	MessageCount int       `json:"messageCount"`
 	ActiveRunID  string    `json:"activeRunId,omitempty"`
+	Model        string    `json:"model,omitempty"`
 }
 
 type SessionUpdate struct {
 	Messages []SessionMessage `json:"messages,omitempty"`
 	Title    *string          `json:"title,omitempty"`
 	Summary  *string          `json:"summary,omitempty"`
+	Model    *string          `json:"model,omitempty"`
 }
 
 type SessionStoreInterface interface {
@@ -79,9 +82,9 @@ func generateSessionTitle(messages []SessionMessage) string {
 
 type SessionStore struct {
 	mu       sync.RWMutex
-	sessions map[string]*ChatSession         // sessionID -> session
-	userIdx  map[string]map[string]struct{}   // ownerKey -> set of sessionIDs
-	current  map[string]string                // ownerKey -> current sessionID
+	sessions map[string]*ChatSession        // sessionID -> session
+	userIdx  map[string]map[string]struct{} // ownerKey -> set of sessionIDs
+	current  map[string]string              // ownerKey -> current sessionID
 	logger   log.Logger
 }
 
@@ -199,6 +202,7 @@ func (s *SessionStore) ListSessions(userID, orgID int64) ([]SessionMetadata, err
 			UpdatedAt:    sess.UpdatedAt,
 			MessageCount: sess.MessageCount,
 			ActiveRunID:  sess.ActiveRunID,
+			Model:        sess.Model,
 		})
 	}
 
@@ -230,6 +234,9 @@ func (s *SessionStore) UpdateSession(sessionID string, userID, orgID int64, upda
 	}
 	if update.Summary != nil {
 		session.Summary = *update.Summary
+	}
+	if update.Model != nil {
+		session.Model = *update.Model
 	}
 	session.UpdatedAt = time.Now()
 

--- a/pkg/plugin/sessionstore_redis.go
+++ b/pkg/plugin/sessionstore_redis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-func sessionKey(id string) string         { return fmt.Sprintf("session:%s", id) }
+func sessionKey(id string) string { return fmt.Sprintf("session:%s", id) }
 func sessionUserIdxKey(userID, orgID int64) string {
 	return fmt.Sprintf("usersessions:%d:%d", userID, orgID)
 }
@@ -29,6 +29,7 @@ type redisSession struct {
 	UpdatedAt    time.Time        `json:"updatedAt"`
 	MessageCount int              `json:"messageCount"`
 	ActiveRunID  string           `json:"activeRunId,omitempty"`
+	Model        string           `json:"model,omitempty"`
 	UserID       int64            `json:"userId"`
 	OrgID        int64            `json:"orgId"`
 }
@@ -37,7 +38,7 @@ func toRedis(s *ChatSession) *redisSession {
 	return &redisSession{
 		ID: s.ID, Title: s.Title, Messages: s.Messages,
 		Summary: s.Summary, CreatedAt: s.CreatedAt, UpdatedAt: s.UpdatedAt,
-		MessageCount: s.MessageCount, ActiveRunID: s.ActiveRunID,
+		MessageCount: s.MessageCount, ActiveRunID: s.ActiveRunID, Model: s.Model,
 		UserID: s.UserID, OrgID: s.OrgID,
 	}
 }
@@ -46,7 +47,7 @@ func fromRedis(rs *redisSession) *ChatSession {
 	return &ChatSession{
 		ID: rs.ID, Title: rs.Title, Messages: rs.Messages,
 		Summary: rs.Summary, CreatedAt: rs.CreatedAt, UpdatedAt: rs.UpdatedAt,
-		MessageCount: rs.MessageCount, ActiveRunID: rs.ActiveRunID,
+		MessageCount: rs.MessageCount, ActiveRunID: rs.ActiveRunID, Model: rs.Model,
 		UserID: rs.UserID, OrgID: rs.OrgID,
 	}
 }
@@ -212,6 +213,7 @@ func (s *RedisSessionStore) ListSessions(userID, orgID int64) ([]SessionMetadata
 			ID: rs.ID, Title: rs.Title, CreatedAt: rs.CreatedAt,
 			UpdatedAt: rs.UpdatedAt, MessageCount: rs.MessageCount,
 			ActiveRunID: rs.ActiveRunID,
+			Model:       rs.Model,
 		})
 	}
 
@@ -241,6 +243,9 @@ func (s *RedisSessionStore) UpdateSession(sessionID string, userID, orgID int64,
 	}
 	if update.Summary != nil {
 		session.Summary = *update.Summary
+	}
+	if update.Model != nil {
+		session.Model = *update.Model
 	}
 	session.UpdatedAt = time.Now()
 

--- a/pkg/plugin/sessionstore_redis_test.go
+++ b/pkg/plugin/sessionstore_redis_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+func TestRedisSessionStore_ModelRoundTrip(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisSessionStore(context.Background(), client, log.DefaultLogger)
+	session, err := store.CreateSession(1, 1, "test", []SessionMessage{{Role: "user", Content: "hello"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	model := "large"
+	if err := store.UpdateSession(session.ID, 1, 1, SessionUpdate{Model: &model}); err != nil {
+		t.Fatalf("UpdateSession failed: %v", err)
+	}
+
+	got, err := store.GetSession(session.ID, 1, 1)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.Model != "large" {
+		t.Fatalf("expected model large, got %q", got.Model)
+	}
+
+	sessions, err := store.ListSessions(1, 1)
+	if err != nil {
+		t.Fatalf("ListSessions failed: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Model != "large" {
+		t.Fatalf("expected listed session model large, got %+v", sessions)
+	}
+}

--- a/pkg/plugin/sessionstore_test.go
+++ b/pkg/plugin/sessionstore_test.go
@@ -89,9 +89,11 @@ func TestSessionStore_UpdateSession(t *testing.T) {
 
 	newTitle := "updated title"
 	newSummary := "a summary"
+	model := "base"
 	err := store.UpdateSession(session.ID, 1, 1, SessionUpdate{
 		Title:   &newTitle,
 		Summary: &newSummary,
+		Model:   &model,
 		Messages: []SessionMessage{
 			{Role: "user", Content: "hello"},
 			{Role: "assistant", Content: "hi there"},
@@ -110,6 +112,17 @@ func TestSessionStore_UpdateSession(t *testing.T) {
 	}
 	if got.MessageCount != 2 {
 		t.Fatalf("expected 2 messages, got %d", got.MessageCount)
+	}
+	if got.Model != "base" {
+		t.Fatalf("expected model base, got %q", got.Model)
+	}
+
+	sessions, err := store.ListSessions(1, 1)
+	if err != nil {
+		t.Fatalf("ListSessions failed: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Model != "base" {
+		t.Fatalf("expected listed session model base, got %+v", sessions)
 	}
 }
 

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { useTheme2 } from '@grafana/ui';
 
 import { useChat } from './hooks/useChat';
@@ -8,12 +8,18 @@ import { useChatScene } from './hooks/useChatScene';
 import { useSidePanelState } from './hooks/useSidePanelState';
 import { ChatInterfaceState } from './scenes/ChatInterfaceScene';
 import { GrafanaPageState } from './scenes/GrafanaPageScene';
-import { SessionSidebar, NewChatButton, HistoryButton, SaveToMemoryButton } from './components';
+import { SessionSidebar, NewChatButton, HistoryButton, SaveToMemoryButton, ModelSelector } from './components';
 import { ChatInputRef } from './components/ChatInput/ChatInput';
 import { ChatErrorBoundary } from '../ErrorBoundary';
 import type { SessionMetadata } from './hooks/useSessionManager';
 import type { ChatMessage } from './types';
 import type { AppPluginSettings } from '../../types/plugin';
+import {
+  formatModelLabel,
+  listLLMModelOptions,
+  type LLMModel,
+  type LLMModelOption,
+} from '../../services/llmModels';
 
 interface ChatProps {
   pluginSettings: AppPluginSettings;
@@ -36,9 +42,31 @@ function ChatComponent({
 }: ChatProps): React.ReactElement | null {
   const theme = useTheme2();
   const allowEmbedding = useEmbeddingAllowed();
+  const [modelOptions, setModelOptions] = useState<LLMModelOption[]>([]);
+  const [selectedModel, setSelectedModel] = useState<LLMModel | undefined>(undefined);
 
   const kioskModeEnabled = pluginSettings?.kioskModeEnabled ?? true;
   const chatPanelPosition = pluginSettings?.chatPanelPosition || 'right';
+
+  useEffect(() => {
+    let cancelled = false;
+    listLLMModelOptions()
+      .then((options) => {
+        if (cancelled) {
+          return;
+        }
+        setModelOptions(options);
+        setSelectedModel((prev) => prev ?? options.find((option) => option.isDefault)?.value);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModelOptions([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const {
     chatHistory,
@@ -61,7 +89,8 @@ function ChatComponent({
     readOnly ? initialSession : undefined,
     readOnly,
     initialMessage,
-    initialMessageType
+    initialMessageType,
+    selectedModel
   );
 
   const chatInputRef = useRef<ChatInputRef>(null);
@@ -95,8 +124,29 @@ function ChatComponent({
 
   const currentSession = sessionManager.sessions.find((s: SessionMetadata) => s.id === sessionManager.currentSessionId);
   const currentSessionTitle = currentSession?.title;
+  const sessionModel = currentSession?.model;
+  const selectedModelOption = modelOptions.find((option) => option.value === selectedModel);
+  const sessionModelOption = modelOptions.find((option) => option.value === sessionModel);
+  const currentModelLabel = sessionModel
+    ? sessionModelOption?.label || formatModelLabel(sessionModel)
+    : chatHistory.length > 0 && selectedModel
+      ? selectedModelOption?.label || formatModelLabel(selectedModel)
+      : undefined;
   const hasMessages = chatHistory.length > 0;
   const graphitiEnabled = pluginSettings.mcpServers?.some((s) => s.id === 'graphiti' && s.enabled) ?? false;
+  const showModelSelector = !readOnly && modelOptions.length > 0 && !sessionModel;
+  const modelSelector = useMemo(
+    () =>
+      showModelSelector ? (
+        <ModelSelector
+          options={modelOptions}
+          value={selectedModel}
+          disabled={isGenerating}
+          onChange={setSelectedModel}
+        />
+      ) : undefined,
+    [showModelSelector, modelOptions, selectedModel, isGenerating]
+  );
 
   const chatInterfaceState: ChatInterfaceState = useMemo(
     () => ({
@@ -104,13 +154,19 @@ function ChatComponent({
       currentInput,
       isGenerating,
       currentSessionTitle,
+      currentModelLabel,
       setCurrentInput,
       sendMessage,
       handleKeyPress,
       chatContainerRef,
       chatInputRef,
       bottomSpacerRef,
-      leftSlot: hasMessages ? <NewChatButton onConfirm={clearChat} isGenerating={isGenerating} /> : undefined,
+      leftSlot: hasMessages ? (
+        <div className="flex items-center gap-2">
+          <NewChatButton onConfirm={clearChat} isGenerating={isGenerating} />
+          {modelSelector}
+        </div>
+      ) : modelSelector,
       rightSlot: (
         <div className="flex items-center gap-1">
           {graphitiEnabled && hasMessages && <SaveToMemoryButton messages={chatHistory} />}
@@ -127,6 +183,7 @@ function ChatComponent({
       currentInput,
       isGenerating,
       currentSessionTitle,
+      currentModelLabel,
       sessionManager.sessions.length,
       setCurrentInput,
       sendMessage,
@@ -135,6 +192,7 @@ function ChatComponent({
       chatInputRef,
       bottomSpacerRef,
       hasMessages,
+      modelSelector,
       graphitiEnabled,
       clearChat,
       openHistory,

--- a/src/components/Chat/components/ChatHeader/ChatHeader.test.tsx
+++ b/src/components/Chat/components/ChatHeader/ChatHeader.test.tsx
@@ -84,4 +84,14 @@ describe('ChatHeader', () => {
       expect(screen.getByText('Test')).toBeInTheDocument();
     });
   });
+
+  describe('model label', () => {
+    it('should render the locked model label when provided', () => {
+      render(<ChatHeader isGenerating={false} currentModelLabel="Large · claude-sonnet-4-6" />);
+
+      const label = screen.getByText('Large · claude-sonnet-4-6');
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute('title', 'Large · claude-sonnet-4-6');
+    });
+  });
 });

--- a/src/components/Chat/components/ChatHeader/ChatHeader.tsx
+++ b/src/components/Chat/components/ChatHeader/ChatHeader.tsx
@@ -4,9 +4,10 @@ import { useTheme2 } from '@grafana/ui';
 interface ChatHeaderProps {
   isGenerating: boolean;
   currentSessionTitle?: string;
+  currentModelLabel?: string;
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ isGenerating, currentSessionTitle }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({ isGenerating, currentSessionTitle, currentModelLabel }) => {
   const theme = useTheme2();
 
   return (
@@ -20,6 +21,15 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ isGenerating, currentSes
             title={currentSessionTitle}
           >
             {currentSessionTitle}
+          </span>
+        )}
+        {currentModelLabel && (
+          <span
+            className="text-xs px-2 py-0.5 rounded border border-weak bg-secondary"
+            style={{ color: theme.colors.text.secondary }}
+            title={currentModelLabel}
+          >
+            {currentModelLabel}
           </span>
         )}
       </div>

--- a/src/components/Chat/components/ModelSelector/ModelSelector.tsx
+++ b/src/components/Chat/components/ModelSelector/ModelSelector.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Combobox } from '@grafana/ui';
+import type { LLMModel, LLMModelOption } from '../../../../services/llmModels';
+
+interface ModelSelectorProps {
+  options: LLMModelOption[];
+  value?: LLMModel;
+  disabled?: boolean;
+  onChange: (model: LLMModel) => void;
+}
+
+export function ModelSelector({ options, value, disabled, onChange }: ModelSelectorProps): React.ReactElement | null {
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="min-w-[180px]" data-testid="chat-model-selector">
+      <span id="chat-model-selector-label" className="sr-only">
+        Chat model
+      </span>
+      <Combobox<LLMModel>
+        aria-labelledby="chat-model-selector-label"
+        width={28}
+        value={value}
+        options={options.map((option) => ({
+          label: option.isDefault ? `${option.label} (default)` : option.label,
+          value: option.value,
+        }))}
+        onChange={(selected) => {
+          onChange(selected.value);
+        }}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/src/components/Chat/components/ModelSelector/index.ts
+++ b/src/components/Chat/components/ModelSelector/index.ts
@@ -1,0 +1,1 @@
+export { ModelSelector } from './ModelSelector';

--- a/src/components/Chat/components/index.ts
+++ b/src/components/Chat/components/index.ts
@@ -6,6 +6,7 @@ export { GraphRenderer } from './GraphRenderer/GraphRenderer';
 export { HistoryButton } from './HistoryButton/HistoryButton';
 export { SaveToMemoryButton } from './SaveToMemoryButton/SaveToMemoryButton';
 export { LogsRenderer } from './LogsRenderer/LogsRenderer';
+export { ModelSelector } from './ModelSelector/ModelSelector';
 export { NewChatButton } from './NewChatButton/NewChatButton';
 export { QuickSuggestions } from './QuickSuggestions/QuickSuggestions';
 export { SessionSidebar } from './SessionSidebar/SessionSidebar';

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../services/agentClient';
 import { getSession } from '../../../services/backendSessionClient';
 import type { AppPluginSettings } from '../../../types/plugin';
+import type { LLMModel } from '../../../services/llmModels';
 
 interface InitialSessionData {
   id?: string;
@@ -38,7 +39,8 @@ export function useChat(
   initialSession?: InitialSessionData,
   readOnly?: boolean,
   initialMessage?: string,
-  initialMessageType?: 'chat' | 'investigation' | 'performance'
+  initialMessageType?: 'chat' | 'investigation' | 'performance',
+  selectedModel?: LLMModel
 ) {
   const orgId = String(config.bootData.user.orgId || '1');
 
@@ -307,12 +309,15 @@ export function useChat(
     if (conversationType !== 'chat') {
       setConversationType('chat');
     }
+    const sessionModel = sessionManager.sessions.find((s) => s.id === sessionManager.currentSessionId)?.model;
+    const runModel = sessionModel || selectedModel;
 
     try {
       const result = await runAgentDetached({
         message: validatedInput,
         type: messageType,
         sessionId: sessionManager.currentSessionId || undefined,
+        model: runModel,
         orgId,
         orgName: config.bootData.user.orgName || '',
         scopeOrgId: config.bootData.user.orgName || '',

--- a/src/components/Chat/hooks/useSessionManager.ts
+++ b/src/components/Chat/hooks/useSessionManager.ts
@@ -122,6 +122,20 @@ export function useSessionManager(
         const session = await getSession(sessionId);
         setCurrentSessionId_(session.id);
         setChatHistory(session.messages as ChatMessage[]);
+        setSessions((prev) => {
+          const metadata = {
+            id: session.id,
+            title: session.title,
+            createdAt: session.createdAt,
+            updatedAt: session.updatedAt,
+            messageCount: session.messageCount,
+            activeRunId: session.activeRunId,
+            model: session.model,
+          };
+          return prev.some((s) => s.id === session.id)
+            ? prev.map((s) => (s.id === session.id ? { ...s, ...metadata } : s))
+            : [metadata, ...prev];
+        });
         onSessionIdChange(session.id);
         await setCurrentSessionId(session.id);
       } catch (error: unknown) {

--- a/src/components/Chat/scenes/ChatInterfaceScene.tsx
+++ b/src/components/Chat/scenes/ChatInterfaceScene.tsx
@@ -18,6 +18,7 @@ function useChatInterface(model: ChatInterfaceScene): ChatInterfaceProps {
     currentInput: state.currentInput,
     isGenerating: state.isGenerating,
     currentSessionTitle: state.currentSessionTitle,
+    currentModelLabel: state.currentModelLabel,
     setCurrentInput: state.setCurrentInput,
     sendMessage: state.sendMessage,
     handleKeyPress: state.handleKeyPress,
@@ -50,6 +51,7 @@ function ChatInterfaceRenderer({ model }: SceneComponentProps<ChatInterfaceScene
     currentInput,
     isGenerating,
     currentSessionTitle,
+    currentModelLabel,
     setCurrentInput,
     sendMessage,
     handleKeyPress,
@@ -76,7 +78,11 @@ function ChatInterfaceRenderer({ model }: SceneComponentProps<ChatInterfaceScene
             className="chat-interface-scroll-container w-full px-4 max-w-4xl mx-auto"
             style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto' }}
           >
-            <ChatHeader isGenerating={isGenerating} currentSessionTitle={currentSessionTitle} />
+            <ChatHeader
+              isGenerating={isGenerating}
+              currentSessionTitle={currentSessionTitle}
+              currentModelLabel={currentModelLabel}
+            />
 
             <div
               className="py-6 rounded-lg"
@@ -134,7 +140,7 @@ function ChatInterfaceRenderer({ model }: SceneComponentProps<ChatInterfaceScene
                 setCurrentInput={setCurrentInput}
                 sendMessage={sendMessage}
                 handleKeyPress={handleKeyPress}
-                leftSlot={undefined}
+                leftSlot={leftSlot}
                 rightSlot={rightSlot}
                 queuedMessageCount={queuedMessageCount}
                 onStopGeneration={onStopGeneration}

--- a/src/components/Chat/types.ts
+++ b/src/components/Chat/types.ts
@@ -53,6 +53,7 @@ export interface ChatInterfaceProps {
   currentInput: string;
   isGenerating: boolean;
   currentSessionTitle?: string;
+  currentModelLabel?: string;
   setCurrentInput: (value: string) => void;
   sendMessage: () => void;
   handleKeyPress: (e: React.KeyboardEvent) => void;

--- a/src/services/__tests__/agentClient.test.ts
+++ b/src/services/__tests__/agentClient.test.ts
@@ -90,6 +90,25 @@ describe('runAgentDetached', () => {
     const body = JSON.parse(fetchOptions.body);
     expect(body.orgId).toBeUndefined();
   });
+
+  it('should append model as a query param and keep it out of the request body', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ runId: 'run-1', sessionId: 'sess-1', status: 'running' }),
+    });
+    global.fetch = mockFetch;
+
+    await runAgentDetached({
+      message: 'test',
+      type: 'chat',
+      model: 'large',
+    });
+
+    const [url, fetchOptions] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/plugins/consensys-asko11y-app/resources/api/agent/run?model=large');
+    const body = JSON.parse(fetchOptions.body);
+    expect(body.model).toBeUndefined();
+  });
 });
 
 describe('reconnectToAgentRun', () => {

--- a/src/services/__tests__/llmModels.test.ts
+++ b/src/services/__tests__/llmModels.test.ts
@@ -1,0 +1,90 @@
+import { formatModelLabel, listLLMModelOptions } from '../llmModels';
+
+describe('llmModels', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('formats labels with provider model IDs', () => {
+    expect(formatModelLabel('base', 'claude-haiku-4-5')).toBe('Base · claude-haiku-4-5');
+    expect(formatModelLabel('large', 'claude-sonnet-4-6')).toBe('Large · claude-sonnet-4-6');
+    expect(formatModelLabel('base')).toBe('Base');
+  });
+
+  it('lists supported model abstractions and maps configured provider IDs', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ data: [{ id: 'base' }, { id: 'large' }, { id: 'custom' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          jsonData: {
+            models: {
+              default: 'large',
+              mapping: {
+                base: 'claude-haiku-4-5',
+                large: 'claude-sonnet-4-6',
+              },
+            },
+          },
+        }),
+      });
+
+    await expect(listLLMModelOptions()).resolves.toEqual([
+      {
+        value: 'base',
+        providerModel: 'claude-haiku-4-5',
+        label: 'Base · claude-haiku-4-5',
+        isDefault: false,
+      },
+      {
+        value: 'large',
+        providerModel: 'claude-sonnet-4-6',
+        label: 'Large · claude-sonnet-4-6',
+        isDefault: true,
+      },
+    ]);
+  });
+
+  it('falls back to base and large when the models endpoint is empty', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ data: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ jsonData: { models: { default: 'base', mapping: {} } } }),
+      });
+
+    const options = await listLLMModelOptions();
+
+    expect(options.map((option) => option.value)).toEqual(['base', 'large']);
+    expect(options[0].isDefault).toBe(true);
+  });
+
+  it('lists available models without provider labels when settings are unavailable', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ data: [{ id: 'base' }, { id: 'large' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      });
+
+    await expect(listLLMModelOptions()).resolves.toEqual([
+      { value: 'base', providerModel: undefined, label: 'Base', isDefault: false },
+      { value: 'large', providerModel: undefined, label: 'Large', isDefault: false },
+    ]);
+  });
+});

--- a/src/services/agentClient.ts
+++ b/src/services/agentClient.ts
@@ -2,6 +2,7 @@ export interface AgentRunRequest {
   message: string;
   type?: 'chat' | 'investigation' | 'performance';
   sessionId?: string;
+  model?: 'base' | 'large';
 
   orgId?: string;
   orgName?: string;
@@ -221,8 +222,13 @@ export interface DetachedRunResult {
 }
 
 export async function runAgentDetached(request: AgentRunRequest): Promise<DetachedRunResult> {
-  const { orgId, ...body } = request;
-  const resp = await fetch(AGENT_RUN_URL, {
+  const { orgId, model, ...body } = request;
+  const url = new URL(AGENT_RUN_URL, window.location.origin);
+  if (model) {
+    url.searchParams.set('model', model);
+  }
+
+  const resp = await fetch(url.pathname + url.search, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/services/backendSessionClient.ts
+++ b/src/services/backendSessionClient.ts
@@ -16,6 +16,7 @@ export interface SessionMetadata {
   updatedAt: string;
   messageCount: number;
   activeRunId?: string;
+  model?: 'base' | 'large';
 }
 
 export interface BackendChatSession extends SessionMetadata {

--- a/src/services/llmModels.ts
+++ b/src/services/llmModels.ts
@@ -1,0 +1,83 @@
+export type LLMModel = 'base' | 'large';
+
+export interface LLMModelOption {
+  value: LLMModel;
+  label: string;
+  providerModel?: string;
+  isDefault: boolean;
+}
+
+interface LLMModelDescriptor {
+  id?: string;
+  name?: string;
+  model?: string;
+}
+
+type LLMModelsResponse = LLMModelDescriptor[] | {
+  data?: LLMModelDescriptor[];
+  models?: LLMModelDescriptor[];
+};
+
+interface LLMPluginSettingsResponse {
+  jsonData?: {
+    models?: {
+      default?: string;
+      mapping?: Record<string, string>;
+    };
+  };
+}
+
+const LLM_MODELS_URL = '/api/plugins/grafana-llm-app/resources/llm/v1/models';
+const LLM_SETTINGS_URL = '/api/plugins/grafana-llm-app/settings';
+const SUPPORTED_MODELS: LLMModel[] = ['base', 'large'];
+
+function isLLMModel(value: string | undefined): value is LLMModel {
+  return value === 'base' || value === 'large';
+}
+
+function modelTitle(model: LLMModel): string {
+  return model === 'base' ? 'Base' : 'Large';
+}
+
+export function formatModelLabel(model: LLMModel, providerModel?: string): string {
+  return providerModel ? `${modelTitle(model)} · ${providerModel}` : modelTitle(model);
+}
+
+function extractModelIDs(response: LLMModelsResponse): Array<string | undefined> {
+  if (Array.isArray(response)) {
+    return response.map((model) => model.id ?? model.name ?? model.model);
+  }
+
+  const models = response.data ?? response.models ?? [];
+  return models.map((model) => model.id ?? model.name ?? model.model);
+}
+
+export async function listLLMModelOptions(): Promise<LLMModelOption[]> {
+  const [modelsResp, settingsResp] = await Promise.all([
+    fetch(LLM_MODELS_URL),
+    fetch(LLM_SETTINGS_URL).catch(() => undefined),
+  ]);
+
+  if (!modelsResp.ok) {
+    throw new Error(`Failed to list LLM models (${modelsResp.status})`);
+  }
+
+  const modelsData = (await modelsResp.json()) as LLMModelsResponse;
+  const settingsData = settingsResp?.ok ? ((await settingsResp.json()) as LLMPluginSettingsResponse) : {};
+  const mapping = settingsData.jsonData?.models?.mapping ?? {};
+  const configuredDefault = settingsData.jsonData?.models?.default;
+  const defaultModel: LLMModel | undefined = isLLMModel(configuredDefault) ? configuredDefault : undefined;
+
+  const available = extractModelIDs(modelsData).filter(isLLMModel);
+  const uniqueModels = Array.from(new Set(available.length > 0 ? available : SUPPORTED_MODELS));
+
+  return uniqueModels.map((model) => {
+    const providerModel = mapping[model];
+    return {
+      value: model,
+      providerModel,
+      label: formatModelLabel(model, providerModel),
+      isDefault: model === defaultModel,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add fixed-per-session Ask O11y model selection using grafana-llm-app base/large abstractions
- persist selected model on sessions and reject conflicting follow-up run params
- discover LLM app model labels in the chat UI and send model as a run query param
- stop forcing large in LLM requests so omitted model uses the LLM app default

## Validation
- go test ./pkg/agent ./pkg/plugin ./pkg/plugin/openapi
- npm run typecheck
- npm run test:ci -- --runTestsByPath src/services/__tests__/agentClient.test.ts src/services/__tests__/llmModels.test.ts src/components/Chat/components/ChatHeader/ChatHeader.test.tsx
- npm run lint -- src/services/agentClient.ts src/services/llmModels.ts src/services/__tests__/agentClient.test.ts src/services/__tests__/llmModels.test.ts src/components/Chat/Chat.tsx src/components/Chat/hooks/useChat.ts src/components/Chat/hooks/useSessionManager.ts src/components/Chat/scenes/ChatInterfaceScene.tsx src/components/Chat/components/ChatHeader/ChatHeader.tsx src/components/Chat/components/ChatHeader/ChatHeader.test.tsx src/components/Chat/components/ModelSelector/ModelSelector.tsx
- npm run validate:openapi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `model` parameter that influences LLM requests and becomes persisted session state, so regressions could affect chat run behavior and session compatibility across runs. Changes span backend API, storage (in-memory and Redis), and UI request wiring.
> 
> **Overview**
> Adds **per-session model selection** for agent runs via a new `model` query param (`base`/`large`) on `POST /api/agent/run`, persists the chosen model on the session, and rejects attempts to change it on subsequent runs.
> 
> Plumbs the selected/locked model through the agent loop into `ChatCompletionRequest` (and stops forcing a default model so omission defers to `grafana-llm-app` defaults). Session APIs now include `model` in `ChatSession`/`SessionMetadata`, with Redis and in-memory stores updated accordingly, and direct session updates are prevented from setting `model`.
> 
> Updates the chat UI to **discover available models** from `grafana-llm-app`, let users pick a model before the first message (then show a locked model label), and sends the selection as a URL query param (not in the JSON body), with added unit tests and OpenAPI spec coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b606ba0304b618c28f4c7fb9b6efa3217e41116f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->