### PR TITLE
fix: feedback UX quick wins, run-plan cleanup, and topology improvements

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,8 @@
       "Bash(go test*)",
       "Bash(mage test*)",
       "Bash(nvm use 22 && npx jest*)",
-      "Bash(nvm use 22 && npm run e2e*)"
+      "Bash(nvm use 22 && npm run e2e*)",
+      "Bash(git *)"
     ]
   }
 }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           docker compose up -d grafana
 
       - name: Wait for Grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@main
+        uses: grafana/plugin-actions/wait-for-grafana@2ecc2ba7168309f04010b5b637530b877d67e4ff # main
         with:
           url: http://localhost:3000/login
 

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -69,7 +69,7 @@ jobs:
           echo "modulets=${MODULETS}" >> $GITHUB_OUTPUT
 
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@main
+        uses: grafana/plugin-actions/is-compatible@2ecc2ba7168309f04010b5b637530b877d67e4ff # main
         with:
           module: ${{ steps.find-module-ts.outputs.modulets }}
           comment-pr: 'no'

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ exports/
 
 # Local secrets / prod data extractions (do not commit)
 local/prod-redis-sessions/
+local/asko11y-feedback/
+local/
+docs/

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -110,14 +110,6 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	openAITools := ConvertMCPToolsToOpenAI(mcpTools)
 
 	messages := BuildContextWindow(req.SystemPrompt, req.Messages, req.Summary, req.RecentMessageCount)
-	plan := buildRunPlan(req.ConversationType)
-	a.send(ctx, eventCh, SSEEvent{
-		Type: "run_plan",
-		Data: RunPlanEvent{
-			Objective: planObjective(req.ConversationType),
-			Steps:     plan,
-		},
-	})
 
 	// Per-run state for transport-failure aggregation. We emit at most one
 	// mcp_unavailable event per run, once at least 2 distinct tools have hit
@@ -129,12 +121,6 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	for iteration := 0; iteration < maxIter; iteration++ {
 		if ctx.Err() != nil {
 			return
-		}
-		if iteration == 0 && len(plan) > 0 {
-			a.send(ctx, eventCh, SSEEvent{
-				Type: "step_start",
-				Data: StepEvent{ID: plan[0].ID, Title: plan[0].Title, Status: "running"},
-			})
 		}
 
 		messages = TrimMessagesToTokenLimit(messages, openAITools, promptBudget)
@@ -177,20 +163,14 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 
 		if len(msg.ToolCalls) == 0 {
 			if msg.Content != "" {
-				if len(plan) > 0 {
-					a.send(ctx, eventCh, SSEEvent{
-						Type: "step_done",
-						Data: StepEvent{ID: plan[len(plan)-1].ID, Title: plan[len(plan)-1].Title, Status: "completed"},
-					})
-					a.send(ctx, eventCh, SSEEvent{
-						Type: "final_report",
-						Data: FinalReportEvent{
-							Verdict:    finalReportVerdict(req.ConversationType),
-							Confidence: "medium",
-							Summary:    summarizeFinalContent(msg.Content),
-						},
-					})
-				}
+				a.send(ctx, eventCh, SSEEvent{
+					Type: "final_report",
+					Data: FinalReportEvent{
+						Verdict:    finalReportVerdict(req.ConversationType),
+						Confidence: "medium",
+						Summary:    summarizeFinalContent(msg.Content),
+					},
+				})
 				a.send(ctx, eventCh, SSEEvent{
 					Type: "content",
 					Data: ContentEvent{Content: msg.Content},
@@ -262,7 +242,6 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 					Type: "evidence",
 					Data: EvidenceEvent{
 						ID:       tc.ID,
-						StepID:   currentEvidenceStepID(plan),
 						Title:    evidenceTitle(tc.Function.Name),
 						Summary:  summarizeToolEvidence(toolContent),
 						Source:   "mcp",
@@ -508,52 +487,6 @@ func extractText(result *mcp.CallToolResult) string {
 		}
 	}
 	return out
-}
-
-func buildRunPlan(conversationType string) []PlanStep {
-	switch conversationType {
-	case "investigation":
-		return []PlanStep{
-			{ID: "scope", Title: "Scope incident context", Description: "Identify alert, service, org, and likely time window.", Status: "pending"},
-			{ID: "evidence", Title: "Gather observability evidence", Description: "Query metrics, logs, traces, deploy signals, runbooks, and topology.", Status: "pending"},
-			{ID: "report", Title: "Synthesize RCA report", Description: "Produce a confidence-scored incident report with evidence and gaps.", Status: "pending"},
-		}
-	case "performance":
-		return []PlanStep{
-			{ID: "scope", Title: "Scope performance target", Status: "pending"},
-			{ID: "evidence", Title: "Compare telemetry signals", Status: "pending"},
-			{ID: "report", Title: "Summarize bottlenecks", Status: "pending"},
-		}
-	default:
-		return []PlanStep{
-			{ID: "understand", Title: "Understand request", Status: "pending"},
-			{ID: "evidence", Title: "Gather evidence", Status: "pending"},
-			{ID: "answer", Title: "Answer with citations", Status: "pending"},
-		}
-	}
-}
-
-func planObjective(conversationType string) string {
-	switch conversationType {
-	case "investigation":
-		return "Investigate the incident using live Grafana and MCP evidence."
-	case "performance":
-		return "Analyze performance using live observability evidence."
-	default:
-		return "Answer the request using available Grafana and MCP evidence."
-	}
-}
-
-func currentEvidenceStepID(plan []PlanStep) string {
-	for _, step := range plan {
-		if step.ID == "evidence" {
-			return step.ID
-		}
-	}
-	if len(plan) == 0 {
-		return ""
-	}
-	return plan[0].ID
 }
 
 func evidenceTitle(toolName string) string {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -141,7 +141,7 @@ func TestAgentLoop_SimpleTextResponse(t *testing.T) {
 	go loop.Run(context.Background(), req, eventCh)
 	events := collectEvents(eventCh)
 
-	expectedTypes := []string{"run_plan", "step_start", "step_done", "final_report", "content", "done"}
+	expectedTypes := []string{"final_report", "content", "done"}
 	if len(events) != len(expectedTypes) {
 		t.Fatalf("expected event types %v, got %+v", expectedTypes, events)
 	}
@@ -151,7 +151,7 @@ func TestAgentLoop_SimpleTextResponse(t *testing.T) {
 		}
 	}
 
-	content := events[4].Data.(ContentEvent)
+	content := events[1].Data.(ContentEvent)
 	if content.Content != "Here is your answer." {
 		t.Errorf("unexpected content: %q", content.Content)
 	}
@@ -244,7 +244,7 @@ func TestAgentLoop_FallsBackFromAutoLargeToBaseOnLLM5xx(t *testing.T) {
 	if len(models) != 3 || models[0] != "large" || models[1] != "large" || models[2] != "base" {
 		t.Fatalf("models = %v, want large retry then base fallback", models)
 	}
-	expectedTypes := []string{"run_plan", "step_start", "step_done", "final_report", "content", "done"}
+	expectedTypes := []string{"final_report", "content", "done"}
 	if len(events) != len(expectedTypes) {
 		t.Fatalf("expected event types %v, got %+v", expectedTypes, events)
 	}
@@ -253,7 +253,7 @@ func TestAgentLoop_FallsBackFromAutoLargeToBaseOnLLM5xx(t *testing.T) {
 			t.Errorf("event[%d]: expected %q, got %q", i, expected, events[i].Type)
 		}
 	}
-	if content := events[4].Data.(ContentEvent).Content; content != "base recovered" {
+	if content := events[1].Data.(ContentEvent).Content; content != "base recovered" {
 		t.Fatalf("content = %q, want base recovered", content)
 	}
 }
@@ -284,7 +284,7 @@ func TestAgentLoop_SendsDiagnosticErrorForLLMStatus(t *testing.T) {
 	go loop.Run(context.Background(), req, eventCh)
 	events := collectEvents(eventCh)
 
-	expectedTypes := []string{"run_plan", "step_start", "error"}
+	expectedTypes := []string{"error"}
 	if len(events) != len(expectedTypes) {
 		t.Fatalf("expected event types %v, got %+v", expectedTypes, events)
 	}
@@ -293,7 +293,7 @@ func TestAgentLoop_SendsDiagnosticErrorForLLMStatus(t *testing.T) {
 			t.Errorf("event[%d]: expected %q, got %q", i, expected, events[i].Type)
 		}
 	}
-	errEvent := events[2].Data.(ErrorEvent)
+	errEvent := events[0].Data.(ErrorEvent)
 	if errEvent.Code != "llm_http_500" || errEvent.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("unexpected error event: %+v", errEvent)
 	}
@@ -355,7 +355,7 @@ func TestAgentLoop_ToolCallThenText(t *testing.T) {
 		types[i] = e.Type
 	}
 
-	expected := []string{"run_plan", "step_start", "tool_call_start", "tool_call_result", "step_done", "final_report", "content", "done"}
+	expected := []string{"tool_call_start", "tool_call_result", "final_report", "content", "done"}
 	if len(types) != len(expected) {
 		t.Fatalf("expected event types %v, got %v", expected, types)
 	}
@@ -417,7 +417,7 @@ func TestAgentLoop_ContentWithToolCalls_DropsContent(t *testing.T) {
 	}
 
 	// The "thinking" content from iteration 1 must NOT appear.
-	expected := []string{"run_plan", "step_start", "tool_call_start", "tool_call_result", "step_done", "final_report", "content", "done"}
+	expected := []string{"tool_call_start", "tool_call_result", "final_report", "content", "done"}
 	if len(types) != len(expected) {
 		t.Fatalf("expected event types %v, got %v", expected, types)
 	}
@@ -428,7 +428,7 @@ func TestAgentLoop_ContentWithToolCalls_DropsContent(t *testing.T) {
 	}
 
 	// Verify only the final answer content is sent
-	content := events[6].Data.(ContentEvent)
+	content := events[3].Data.(ContentEvent)
 	if content.Content != "Here are the results." {
 		t.Errorf("expected final answer, got %q", content.Content)
 	}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -87,27 +87,8 @@ type ToolCallResultEvent struct {
 	ErrorKind string `json:"errorKind,omitempty"`
 }
 
-type PlanStep struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description,omitempty"`
-	Status      string `json:"status"`
-}
-
-type RunPlanEvent struct {
-	Objective string     `json:"objective"`
-	Steps     []PlanStep `json:"steps"`
-}
-
-type StepEvent struct {
-	ID     string `json:"id"`
-	Title  string `json:"title,omitempty"`
-	Status string `json:"status"`
-}
-
 type EvidenceEvent struct {
 	ID            string `json:"id"`
-	StepID        string `json:"stepId,omitempty"`
 	Title         string `json:"title"`
 	Summary       string `json:"summary"`
 	Source        string `json:"source,omitempty"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1483,7 +1483,7 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 	orgID := getOrgID(r)
 	query := strings.TrimSpace(r.URL.Query().Get("query"))
 	if query == "" {
-		query = "service topology dependencies incidents upstream downstream"
+		query = graphitiTopologyFactQuery()
 	}
 	result, err := p.mcpProxy.CallToolWithContext(
 		toolName,
@@ -1498,12 +1498,69 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response := parseGraphitiTopology(graphitiToolBody(result))
+	factBodies := []string{graphitiToolBody(result)}
+	nodeBodies := []string{}
+	topologyNodes := []graphitiTopologyNode{}
+	nodeToolName := findGraphitiSearchNodesTool(tools)
+	nodeWarnings := []string{}
+	if nodeToolName == "" {
+		nodeWarnings = append(nodeWarnings, "graphiti_search_nodes tool is not available; falling back to text-only topology parsing")
+	} else {
+		for _, nodeQuery := range graphitiTopologyNodeQueries() {
+			nodeResult, nodeErr := p.mcpProxy.CallToolWithContext(
+				nodeToolName,
+				graphitiSearchNodesArgs(tools, nodeToolName, orgID, nodeQuery.query, hardTopologyMaxNodes, nodeQuery.entityTypes),
+				strconv.FormatInt(orgID, 10),
+				"Org"+strconv.FormatInt(orgID, 10),
+				"",
+			)
+			if nodeErr != nil {
+				p.logger.Warn("Failed to query Graphiti topology nodes", "error", nodeErr, "query", nodeQuery.query)
+				nodeWarnings = append(nodeWarnings, "Graphiti topology node lookup failed; some relationships may be inferred from text")
+				continue
+			}
+			if nodeResult != nil && nodeResult.IsError {
+				nodeWarnings = append(nodeWarnings, "Graphiti topology node lookup returned an error; some relationships may be inferred from text")
+			}
+			if body := graphitiToolBody(nodeResult); body != "" {
+				nodeBodies = append(nodeBodies, body)
+				topologyNodes = append(topologyNodes, extractGraphitiTopologyNodes(body)...)
+			}
+		}
+	}
+
+	if graphitiSearchFactsSupportsCenterNode(tools, toolName) && len(topologyNodes) > 0 {
+		centerNodes := topologyCenterNodes(topologyNodes, maxNodes)
+		centerFactLimit := topologyCenteredFactLimit(maxEdges, len(centerNodes))
+		for _, node := range centerNodes {
+			nodeResult, nodeErr := p.mcpProxy.CallToolWithContext(
+				toolName,
+				graphitiSearchFactsForNodeArgs(tools, toolName, orgID, graphitiTopologyFactQuery(), centerFactLimit, node.UUID),
+				strconv.FormatInt(orgID, 10),
+				"Org"+strconv.FormatInt(orgID, 10),
+				"",
+			)
+			if nodeErr != nil {
+				p.logger.Warn("Failed to query Graphiti centered topology facts", "error", nodeErr, "node", node.Name)
+				nodeWarnings = append(nodeWarnings, "Graphiti centered topology lookup failed; some relationships may be missing")
+				continue
+			}
+			if nodeResult != nil && nodeResult.IsError {
+				nodeWarnings = append(nodeWarnings, "Graphiti centered topology lookup returned an error; some relationships may be missing")
+			}
+			if body := graphitiToolBody(nodeResult); body != "" {
+				factBodies = append(factBodies, body)
+			}
+		}
+	}
+
+	response := parseGraphitiTopologyBodies(factBodies, nodeBodies)
 	response.Enabled = true
 	response.Source = "graphiti"
 	if result != nil && result.IsError {
 		response.Warnings = append(response.Warnings, "Graphiti topology query returned an error")
 	}
+	response.Warnings = append(response.Warnings, uniqueStrings(nodeWarnings)...)
 	response = limitTopologyResponse(response, maxNodes, maxEdges)
 	if len(response.Nodes) == 0 {
 		response.Warnings = append(response.Warnings, "No service topology facts matched the current organization")

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1530,7 +1530,10 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if graphitiSearchFactsSupportsCenterNode(tools, toolName) && len(topologyNodes) > 0 {
-		centerNodes := topologyCenterNodes(topologyNodes, maxNodes)
+		// Bound centered fact lookups to a small cap independent of the display
+		// node limit — each center node is a sequential MCP call, so using
+		// maxNodes (up to 500) here can cause a call storm and gateway timeouts.
+		centerNodes := topologyCenterNodes(topologyNodes, min(maxNodes, maxTopologyCenterFactLookups))
 		centerFactLimit := topologyCenteredFactLimit(maxEdges, len(centerNodes))
 		for _, node := range centerNodes {
 			nodeResult, nodeErr := p.mcpProxy.CallToolWithContext(

--- a/pkg/plugin/runstore.go
+++ b/pkg/plugin/runstore.go
@@ -35,7 +35,6 @@ type AgentRun struct {
 }
 
 type AgentRunTrace struct {
-	Plan        []agent.PlanStep        `json:"plan,omitempty"`
 	Evidence    []agent.EvidenceEvent   `json:"evidence,omitempty"`
 	Approvals   []RunApproval           `json:"approvals,omitempty"`
 	FinalReport *agent.FinalReportEvent `json:"finalReport,omitempty"`
@@ -299,14 +298,6 @@ func applyTraceEvent(run *AgentRun, event agent.SSEEvent) {
 		run.Trace = &AgentRunTrace{}
 	}
 	switch event.Type {
-	case "run_plan":
-		if data, ok := decodeEventData[agent.RunPlanEvent](event.Data); ok {
-			run.Trace.Plan = append([]agent.PlanStep(nil), data.Steps...)
-		}
-	case "step_start", "step_done":
-		if data, ok := decodeEventData[agent.StepEvent](event.Data); ok {
-			updateTraceStep(run.Trace, data)
-		}
 	case "evidence":
 		if data, ok := decodeEventData[agent.EvidenceEvent](event.Data); ok {
 			upsertEvidence(run.Trace, data)
@@ -348,22 +339,6 @@ func decodeEventData[T any](data interface{}) (T, bool) {
 		return out, false
 	}
 	return out, true
-}
-
-func updateTraceStep(trace *AgentRunTrace, event agent.StepEvent) {
-	for i := range trace.Plan {
-		if trace.Plan[i].ID == event.ID {
-			trace.Plan[i].Status = event.Status
-			return
-		}
-	}
-	if event.ID != "" {
-		trace.Plan = append(trace.Plan, agent.PlanStep{
-			ID:     event.ID,
-			Title:  event.Title,
-			Status: event.Status,
-		})
-	}
 }
 
 func upsertEvidence(trace *AgentRunTrace, evidence agent.EvidenceEvent) {
@@ -420,7 +395,6 @@ func copyTrace(trace *AgentRunTrace) *AgentRunTrace {
 		return nil
 	}
 	copied := *trace
-	copied.Plan = append([]agent.PlanStep(nil), trace.Plan...)
 	copied.Evidence = append([]agent.EvidenceEvent(nil), trace.Evidence...)
 	copied.Approvals = append([]RunApproval(nil), trace.Approvals...)
 	if trace.FinalReport != nil {

--- a/pkg/plugin/runstore_test.go
+++ b/pkg/plugin/runstore_test.go
@@ -58,14 +58,6 @@ func TestRunStore_AppendEventBuildsTrace(t *testing.T) {
 	store := NewRunStore(log.DefaultLogger)
 	store.CreateRun("run-1", 100, 1)
 
-	store.AppendEvent("run-1", agent.SSEEvent{Type: "run_plan", Data: agent.RunPlanEvent{
-		Objective: "Investigate",
-		Steps: []agent.PlanStep{{
-			ID:     "evidence",
-			Title:  "Gather evidence",
-			Status: "pending",
-		}},
-	}})
 	store.AppendEvent("run-1", agent.SSEEvent{Type: "approval_request", Data: agent.ApprovalRequestEvent{
 		ApprovalID: "tc_1",
 		ToolCallID: "tc_1",
@@ -90,9 +82,6 @@ func TestRunStore_AppendEventBuildsTrace(t *testing.T) {
 	}
 	if run.Trace == nil {
 		t.Fatal("expected trace")
-	}
-	if len(run.Trace.Plan) != 1 || run.Trace.Plan[0].ID != "evidence" {
-		t.Fatalf("unexpected plan: %+v", run.Trace.Plan)
 	}
 	if len(run.Trace.Approvals) != 1 || run.Trace.Approvals[0].Decision != "approved" {
 		t.Fatalf("unexpected approvals: %+v", run.Trace.Approvals)

--- a/pkg/plugin/topology.go
+++ b/pkg/plugin/topology.go
@@ -39,8 +39,26 @@ const (
 )
 
 type topologyBuilder struct {
-	nodes map[string]TopologyNode
-	edges map[string]TopologyEdge
+	nodes       map[string]TopologyNode
+	edges       map[string]TopologyEdge
+	uuidToNode  map[string]TopologyNode
+	rawFactSeen map[string]struct{}
+}
+
+type graphitiTopologyFact struct {
+	Name           string
+	Fact           string
+	SourceNodeUUID string
+	TargetNodeUUID string
+	SourceNodeName string
+	TargetNodeName string
+}
+
+type graphitiTopologyNode struct {
+	UUID   string
+	Name   string
+	Labels []string
+	Type   string
 }
 
 var (
@@ -48,35 +66,38 @@ var (
 	serviceActionEdgeRe = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:service|app|application|job|workload)\s+(?:calls|uses|queries|depends on|connects to|talks to|sends to)\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\b`)
 	callsEdgeRe         = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:calls|uses|queries|depends on|connects to|talks to|sends to|forwards requests to)\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\b`)
 	calledByRe          = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:is called by|receives from|is used by)\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\b`)
-	deployedInRe        = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:service|app|application|job|workload)\s+is deployed in\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+namespace\b`)
-	runsOnRe            = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:service|app|application|job|workload)\s+runs on\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+cluster\b`)
+	deployedInRe        = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:(?:service|app|application|job|workload)\s+)?is deployed in\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+namespace\b`)
+	runsOnRe            = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:(?:service|app|application|job|workload)\s+)?runs on\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+cluster\b`)
+	emitsSignalRe       = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:(?:service|app|application|job|workload)\s+)?emits\s+(?:metric|metrics|trace|traces|log|logs|signal|signals)?\s*signals?\s+to\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\b`)
 	publishesToQueueRe  = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:service|app|application|job|workload)\s+publishes .* to\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:message queue|queue)\b`)
 	consumesFromQueueRe = regexp.MustCompile(`(?i)\b([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:service|app|application|job|workload)\s+consumes .* from\s+([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})\s+(?:message queue|queue)\b`)
-	serviceRe           = regexp.MustCompile(`(?i)\b(?:service|app|application|job|workload)\s+["']?([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})["']?`)
+	serviceRe           = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9_-])(?:service|app|application|job|workload)\s+["']?([A-Za-z0-9][A-Za-z0-9_.:/-]{1,80})["']?`)
 )
 
 var topologyInfraNames = map[string]struct{}{
-	"alloy":           {},
-	"alertmanager":    {},
-	"grafana":         {},
-	"ingress-nginx":   {},
-	"kube-prometheus": {},
-	"loki":            {},
-	"mimir":           {},
-	"node-exporter":   {},
-	"otel-collector":  {},
-	"prometheus":      {},
-	"pushgateway":     {},
-	"tempo":           {},
+	"alloy":              {},
+	"alertmanager":       {},
+	"grafana":            {},
+	"ingress-nginx":      {},
+	"kube-prometheus":    {},
+	"kube-state-metrics": {},
+	"loki":               {},
+	"mimir":              {},
+	"node-exporter":      {},
+	"otel-collector":     {},
+	"prometheus":         {},
+	"pushgateway":        {},
+	"tempo":              {},
 }
 
 var topologyNoiseNames = map[string]struct{}{
 	"calls":     {},
 	"deployed":  {},
-	"is":        {},
-	"publishes": {},
+	"emits":     {},
 	"for":       {},
 	"from":      {},
+	"is":        {},
+	"publishes": {},
 	"runs":      {},
 	"service":   {},
 	"to":        {},
@@ -84,22 +105,46 @@ var topologyNoiseNames = map[string]struct{}{
 }
 
 func parseGraphitiTopology(body string) AgentTopologyResponse {
-	facts := extractTopologyFacts(body)
+	return parseGraphitiTopologyWithNodes(body)
+}
+
+func parseGraphitiTopologyWithNodes(factBody string, nodeBodies ...string) AgentTopologyResponse {
+	return parseGraphitiTopologyBodies([]string{factBody}, nodeBodies)
+}
+
+func parseGraphitiTopologyBodies(factBodies []string, nodeBodies []string) AgentTopologyResponse {
+	var facts []graphitiTopologyFact
+	var nodes []graphitiTopologyNode
+	for _, factBody := range factBodies {
+		facts = append(facts, extractGraphitiTopologyFacts(factBody)...)
+		nodes = append(nodes, extractGraphitiTopologyNodes(factBody)...)
+	}
+	for _, nodeBody := range nodeBodies {
+		nodes = append(nodes, extractGraphitiTopologyNodes(nodeBody)...)
+	}
+	facts = uniqueTopologyFacts(facts)
+	nodes = uniqueTopologyNodes(nodes)
+
 	builder := topologyBuilder{
-		nodes: make(map[string]TopologyNode),
-		edges: make(map[string]TopologyEdge),
+		nodes:       make(map[string]TopologyNode),
+		edges:       make(map[string]TopologyEdge),
+		uuidToNode:  make(map[string]TopologyNode),
+		rawFactSeen: make(map[string]struct{}),
 	}
 
+	for _, node := range nodes {
+		builder.addResolvedNode(node)
+	}
 	for _, fact := range facts {
-		builder.ingestFact(fact)
+		builder.ingestGraphitiFact(fact)
 	}
 
-	nodes := make([]TopologyNode, 0, len(builder.nodes))
+	responseNodes := make([]TopologyNode, 0, len(builder.nodes))
 	for _, node := range builder.nodes {
-		nodes = append(nodes, node)
+		responseNodes = append(responseNodes, node)
 	}
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Label < nodes[j].Label
+	sort.Slice(responseNodes, func(i, j int) bool {
+		return responseNodes[i].Label < responseNodes[j].Label
 	})
 
 	edges := make([]TopologyEdge, 0, len(builder.edges))
@@ -113,7 +158,7 @@ func parseGraphitiTopology(body string) AgentTopologyResponse {
 	return AgentTopologyResponse{
 		Enabled:      true,
 		Source:       "graphiti",
-		Nodes:        nodes,
+		Nodes:        responseNodes,
 		Edges:        edges,
 		RawFactCount: len(facts),
 	}
@@ -175,7 +220,7 @@ func limitTopologyResponse(response AgentTopologyResponse, maxNodes, maxEdges in
 	return response
 }
 
-func extractTopologyFacts(body string) []string {
+func extractGraphitiTopologyFacts(body string) []graphitiTopologyFact {
 	body = strings.TrimSpace(body)
 	if body == "" {
 		return nil
@@ -183,45 +228,113 @@ func extractTopologyFacts(body string) []string {
 
 	var payload interface{}
 	if err := json.Unmarshal([]byte(body), &payload); err == nil {
-		var facts []string
-		walkTopologyPayload(payload, &facts)
+		var facts []graphitiTopologyFact
+		walkGraphitiFactPayload(payload, &facts)
 		if len(facts) > 0 {
-			return uniqueStrings(facts)
+			return uniqueTopologyFacts(facts)
 		}
 	}
 
 	lines := strings.FieldsFunc(body, func(r rune) bool {
 		return r == '\n' || r == '\r'
 	})
-	facts := make([]string, 0, len(lines))
+	textFacts := make([]string, 0, len(lines))
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line != "" {
-			facts = append(facts, line)
+			textFacts = append(textFacts, line)
 		}
 	}
-	return uniqueStrings(facts)
+	unique := uniqueStrings(textFacts)
+	facts := make([]graphitiTopologyFact, 0, len(unique))
+	for _, fact := range unique {
+		facts = append(facts, graphitiTopologyFact{Fact: fact})
+	}
+	return facts
 }
 
-func walkTopologyPayload(value interface{}, facts *[]string) {
+func walkGraphitiFactPayload(value interface{}, facts *[]graphitiTopologyFact) {
 	switch v := value.(type) {
 	case []interface{}:
 		for _, item := range v {
-			walkTopologyPayload(item, facts)
+			walkGraphitiFactPayload(item, facts)
 		}
 	case map[string]interface{}:
-		if source, sourceOK := stringField(v, "source_node_name", "source", "from"); sourceOK {
-			if target, targetOK := stringField(v, "target_node_name", "target", "to"); targetOK {
-				*facts = append(*facts, fmt.Sprintf("%s -> %s", source, target))
-			}
+		if nestedFacts, ok := v["facts"]; ok {
+			walkGraphitiFactPayload(nestedFacts, facts)
 		}
-		for _, key := range []string{"fact", "name", "summary", "content", "text", "episode_body"} {
-			if text, ok := v[key].(string); ok && strings.TrimSpace(text) != "" {
-				*facts = append(*facts, text)
+		if looksLikeGraphitiFact(v) {
+			fact, _ := stringField(v, "fact", "text", "content", "summary", "episode_body")
+			name, _ := stringField(v, "name", "relationship", "label")
+			sourceUUID, _ := stringField(v, "source_node_uuid", "source_uuid")
+			targetUUID, _ := stringField(v, "target_node_uuid", "target_uuid")
+			sourceName, _ := stringField(v, "source_node_name", "source", "from")
+			targetName, _ := stringField(v, "target_node_name", "target", "to")
+			*facts = append(*facts, graphitiTopologyFact{
+				Name:           name,
+				Fact:           fact,
+				SourceNodeUUID: sourceUUID,
+				TargetNodeUUID: targetUUID,
+				SourceNodeName: sourceName,
+				TargetNodeName: targetName,
+			})
+			return
+		}
+		for _, item := range v {
+			walkGraphitiFactPayload(item, facts)
+		}
+	}
+}
+
+func looksLikeGraphitiFact(v map[string]interface{}) bool {
+	for _, key := range []string{"fact", "source_node_uuid", "target_node_uuid", "source_node_name", "target_node_name"} {
+		if _, ok := v[key].(string); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func extractGraphitiTopologyNodes(body string) []graphitiTopologyNode {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil
+	}
+	var payload interface{}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return nil
+	}
+	var nodes []graphitiTopologyNode
+	walkGraphitiNodePayload(payload, &nodes)
+	return uniqueTopologyNodes(nodes)
+}
+
+func walkGraphitiNodePayload(value interface{}, nodes *[]graphitiTopologyNode) {
+	switch v := value.(type) {
+	case []interface{}:
+		for _, item := range v {
+			walkGraphitiNodePayload(item, nodes)
+		}
+	case map[string]interface{}:
+		if nestedNodes, ok := v["nodes"]; ok {
+			walkGraphitiNodePayload(nestedNodes, nodes)
+		}
+		uuid, uuidOK := stringField(v, "uuid", "id")
+		name, nameOK := stringField(v, "name", "label", "title")
+		labels := stringSliceField(v, "labels")
+		if uuidOK && nameOK {
+			if nodeType, ok := topologyTypeFromLabels(labels); ok {
+				*nodes = append(*nodes, graphitiTopologyNode{
+					UUID:   uuid,
+					Name:   name,
+					Labels: labels,
+					Type:   nodeType,
+				})
+				return
 			}
 		}
 		for _, item := range v {
-			walkTopologyPayload(item, facts)
+			walkGraphitiNodePayload(item, nodes)
 		}
 	}
 }
@@ -235,7 +348,80 @@ func stringField(m map[string]interface{}, keys ...string) (string, bool) {
 	return "", false
 }
 
+func stringSliceField(m map[string]interface{}, key string) []string {
+	raw, ok := m[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []interface{}:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+				values = append(values, text)
+			}
+		}
+		return values
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil
+		}
+		return []string{v}
+	default:
+		return nil
+	}
+}
+
+func topologyTypeFromLabels(labels []string) (string, bool) {
+	for _, label := range labels {
+		switch strings.ToLower(strings.TrimSpace(label)) {
+		case "service":
+			return "service", true
+		case "namespace":
+			return "namespace", true
+		case "kubecluster":
+			return "cluster", true
+		case "database":
+			return "database", true
+		case "queue":
+			return "queue", true
+		}
+	}
+	return "", false
+}
+
+func (b *topologyBuilder) ingestGraphitiFact(fact graphitiTopologyFact) {
+	if fact.SourceNodeName != "" && fact.TargetNodeName != "" {
+		if b.addEdge(fact.SourceNodeName, fact.TargetNodeName, relationLabel(fact.Name, "depends")) {
+			return
+		}
+	}
+
+	if fact.SourceNodeUUID != "" && fact.TargetNodeUUID != "" {
+		sourceNode, sourceOK := b.uuidToNode[fact.SourceNodeUUID]
+		targetNode, targetOK := b.uuidToNode[fact.TargetNodeUUID]
+		if sourceOK && targetOK && b.addEdgeFromNodes(sourceNode, targetNode, relationLabel(fact.Name, "relates to")) {
+			return
+		}
+	}
+
+	if fact.Fact != "" {
+		b.ingestFact(fact.Fact)
+	}
+}
+
 func (b *topologyBuilder) ingestFact(fact string) {
+	fact = strings.TrimSpace(fact)
+	if fact == "" {
+		return
+	}
+	if _, seen := b.rawFactSeen[fact]; seen {
+		return
+	}
+	b.rawFactSeen[fact] = struct{}{}
+
 	matchedStructuredFact := false
 	for _, match := range arrowEdgeRe.FindAllStringSubmatch(fact, -1) {
 		b.addEdge(match[1], match[2], "depends")
@@ -246,19 +432,23 @@ func (b *topologyBuilder) ingestFact(fact string) {
 		matchedStructuredFact = true
 	}
 	for _, match := range deployedInRe.FindAllStringSubmatch(fact, -1) {
-		b.addEdge(match[1], match[2], "deployed in")
+		b.addEdgeWithTypes(match[1], "service", match[2], "namespace", "deployed in")
 		matchedStructuredFact = true
 	}
 	for _, match := range runsOnRe.FindAllStringSubmatch(fact, -1) {
-		b.addEdge(match[1], match[2], "runs on")
+		b.addEdgeWithTypes(match[1], "service", match[2], "cluster", "runs on")
+		matchedStructuredFact = true
+	}
+	for _, match := range emitsSignalRe.FindAllStringSubmatch(fact, -1) {
+		b.addEdgeWithTypes(match[1], "service", match[2], "service", "emits signal")
 		matchedStructuredFact = true
 	}
 	for _, match := range publishesToQueueRe.FindAllStringSubmatch(fact, -1) {
-		b.addEdge(match[1], match[2], "publishes to")
+		b.addEdgeWithTypes(match[1], "service", match[2], "queue", "publishes to")
 		matchedStructuredFact = true
 	}
 	for _, match := range consumesFromQueueRe.FindAllStringSubmatch(fact, -1) {
-		b.addEdge(match[2], match[1], "consumed by")
+		b.addEdgeWithTypes(match[2], "queue", match[1], "service", "consumed by")
 		matchedStructuredFact = true
 	}
 
@@ -275,18 +465,32 @@ func (b *topologyBuilder) ingestFact(fact string) {
 	}
 }
 
-func (b *topologyBuilder) addEdge(source, target, label string) {
-	sourceNode, ok := b.addNode(source)
+func (b *topologyBuilder) addEdge(source, target, label string) bool {
+	return b.addEdgeWithTypes(source, "service", target, "service", label)
+}
+
+func (b *topologyBuilder) addEdgeWithTypes(source, sourceType, target, targetType, label string) bool {
+	sourceNode, ok := b.addNodeWithType(source, sourceType)
 	if !ok {
-		return
+		return false
 	}
-	targetNode, ok := b.addNode(target)
-	if !ok || sourceNode.ID == targetNode.ID {
-		return
+	targetNode, ok := b.addNodeWithType(target, targetType)
+	if !ok {
+		return false
 	}
+	return b.addEdgeFromNodes(sourceNode, targetNode, label)
+}
+
+func (b *topologyBuilder) addEdgeFromNodes(sourceNode, targetNode TopologyNode, label string) bool {
+	if sourceNode.ID == "" || targetNode.ID == "" || sourceNode.ID == targetNode.ID {
+		return false
+	}
+	b.nodes[sourceNode.ID] = sourceNode
+	b.nodes[targetNode.ID] = targetNode
+
 	id := sourceNode.ID + "->" + targetNode.ID
 	if _, exists := b.edges[id]; exists {
-		return
+		return false
 	}
 	b.edges[id] = TopologyEdge{
 		ID:     id,
@@ -294,9 +498,14 @@ func (b *topologyBuilder) addEdge(source, target, label string) {
 		Target: targetNode.ID,
 		Label:  label,
 	}
+	return true
 }
 
 func (b *topologyBuilder) addNode(raw string) (TopologyNode, bool) {
+	return b.addNodeWithType(raw, "service")
+}
+
+func (b *topologyBuilder) addNodeWithType(raw, nodeType string) (TopologyNode, bool) {
 	label := cleanTopologyName(raw)
 	if label == "" || isTopologyInfra(label) || isTopologyNoise(label) {
 		return TopologyNode{}, false
@@ -305,9 +514,23 @@ func (b *topologyBuilder) addNode(raw string) (TopologyNode, bool) {
 	if node, exists := b.nodes[id]; exists {
 		return node, true
 	}
-	node := TopologyNode{ID: id, Label: label, Type: "service"}
+	if nodeType == "" {
+		nodeType = "service"
+	}
+	node := TopologyNode{ID: id, Label: label, Type: nodeType}
 	b.nodes[id] = node
 	return node, true
+}
+
+func (b *topologyBuilder) addResolvedNode(node graphitiTopologyNode) (TopologyNode, bool) {
+	topologyNode, ok := b.addNodeWithType(node.Name, node.Type)
+	if !ok {
+		return TopologyNode{}, false
+	}
+	if node.UUID != "" {
+		b.uuidToNode[node.UUID] = topologyNode
+	}
+	return topologyNode, true
 }
 
 func cleanTopologyName(raw string) string {
@@ -379,6 +602,28 @@ func findGraphitiSearchFactsTool(tools []mcp.Tool) string {
 	return ""
 }
 
+func findGraphitiSearchNodesTool(tools []mcp.Tool) string {
+	candidates := []string{
+		"graphiti_search_nodes",
+		"graphiti_search_memory_nodes",
+		"graphiti_graphiti_search_nodes",
+		"graphiti_graphiti_search_memory_nodes",
+	}
+	for _, candidate := range candidates {
+		for _, tool := range tools {
+			if tool.Name == candidate {
+				return tool.Name
+			}
+		}
+	}
+	for _, tool := range tools {
+		if strings.HasSuffix(tool.Name, "_search_nodes") || strings.HasSuffix(tool.Name, "_search_memory_nodes") {
+			return tool.Name
+		}
+	}
+	return ""
+}
+
 func graphitiSearchFactsArgs(tools []mcp.Tool, toolName string, orgID int64, query string, maxFacts int) map[string]interface{} {
 	args := map[string]interface{}{
 		"query": query,
@@ -398,6 +643,120 @@ func graphitiSearchFactsArgs(tools []mcp.Tool, toolName string, orgID int64, que
 	return args
 }
 
+func graphitiSearchFactsForNodeArgs(tools []mcp.Tool, toolName string, orgID int64, query string, maxFacts int, centerNodeUUID string) map[string]interface{} {
+	args := graphitiSearchFactsArgs(tools, toolName, orgID, query, maxFacts)
+	if _, ok := graphitiToolProperties(tools, toolName)["center_node_uuid"]; ok && strings.TrimSpace(centerNodeUUID) != "" {
+		args["center_node_uuid"] = centerNodeUUID
+	}
+	return args
+}
+
+func graphitiSearchFactsSupportsCenterNode(tools []mcp.Tool, toolName string) bool {
+	_, ok := graphitiToolProperties(tools, toolName)["center_node_uuid"]
+	return ok
+}
+
+func graphitiSearchNodesArgs(tools []mcp.Tool, toolName string, orgID int64, query string, maxNodes int, entityTypes []string) map[string]interface{} {
+	args := map[string]interface{}{
+		"query": query,
+	}
+	properties := graphitiToolProperties(tools, toolName)
+	groupID := orgGroupID(orgID)
+
+	if properties["group_ids"] != nil {
+		args["group_ids"] = []string{groupID}
+	} else {
+		args["group_id"] = groupID
+	}
+	if properties["max_nodes"] != nil && maxNodes > 0 {
+		args["max_nodes"] = maxNodes
+	}
+	if properties["entity_types"] != nil && len(entityTypes) > 0 {
+		args["entity_types"] = entityTypes
+	}
+
+	return args
+}
+
+func graphitiTopologyNodeQueries() []struct {
+	query       string
+	entityTypes []string
+} {
+	return []struct {
+		query       string
+		entityTypes []string
+	}{
+		{query: "service application workload microservice api worker job", entityTypes: []string{"Service"}},
+		{query: "namespace kubernetes deployment topology", entityTypes: []string{"Namespace"}},
+		{query: "cluster kubernetes eks topology", entityTypes: []string{"KubeCluster"}},
+		{query: "database datastore postgres redis mysql elasticsearch", entityTypes: []string{"Database"}},
+		{query: "queue messaging kafka rabbitmq nats sqs", entityTypes: []string{"Queue"}},
+	}
+}
+
+func graphitiTopologyFactQuery() string {
+	return "service topology dependencies deployment signals upstream downstream database queue cluster namespace"
+}
+
+func topologyCenterNodes(nodes []graphitiTopologyNode, maxNodes int) []graphitiTopologyNode {
+	nodes = uniqueTopologyNodes(nodes)
+	sort.SliceStable(nodes, func(i, j int) bool {
+		leftPriority := topologyCenterNodePriority(nodes[i].Type)
+		rightPriority := topologyCenterNodePriority(nodes[j].Type)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		return nodes[i].Name < nodes[j].Name
+	})
+
+	limit := sanitizeTopologyLimit(maxNodes, defaultTopologyMaxNodes, hardTopologyMaxNodes)
+	result := make([]graphitiTopologyNode, 0, min(len(nodes), limit))
+	for _, node := range nodes {
+		if len(result) >= limit {
+			break
+		}
+		if strings.TrimSpace(node.UUID) == "" {
+			continue
+		}
+		label := cleanTopologyName(node.Name)
+		if label == "" || isTopologyInfra(label) || isTopologyNoise(label) {
+			continue
+		}
+		result = append(result, node)
+	}
+	return result
+}
+
+func topologyCenteredFactLimit(maxEdges, centerNodeCount int) int {
+	maxEdges = sanitizeTopologyLimit(maxEdges, defaultTopologyMaxEdges, hardTopologyMaxEdges)
+	if centerNodeCount <= 0 {
+		return maxEdges
+	}
+	limit := (maxEdges / centerNodeCount) + 10
+	if limit < 25 {
+		return 25
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+func topologyCenterNodePriority(nodeType string) int {
+	switch nodeType {
+	case "service":
+		return 0
+	case "database", "queue":
+		return 1
+	case "namespace":
+		return 2
+	case "cluster":
+		return 3
+	default:
+		return 4
+	}
+}
+
 func graphitiToolProperties(tools []mcp.Tool, toolName string) map[string]interface{} {
 	for _, tool := range tools {
 		if tool.Name != toolName {
@@ -409,4 +768,57 @@ func graphitiToolProperties(tools []mcp.Tool, toolName string) map[string]interf
 		}
 	}
 	return map[string]interface{}{}
+}
+
+func uniqueTopologyFacts(facts []graphitiTopologyFact) []graphitiTopologyFact {
+	seen := make(map[string]struct{}, len(facts))
+	result := make([]graphitiTopologyFact, 0, len(facts))
+	for _, fact := range facts {
+		key := strings.Join([]string{
+			fact.Name,
+			fact.Fact,
+			fact.SourceNodeUUID,
+			fact.TargetNodeUUID,
+			fact.SourceNodeName,
+			fact.TargetNodeName,
+		}, "\x00")
+		if strings.Trim(key, "\x00") == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, fact)
+	}
+	return result
+}
+
+func uniqueTopologyNodes(nodes []graphitiTopologyNode) []graphitiTopologyNode {
+	seen := make(map[string]struct{}, len(nodes))
+	result := make([]graphitiTopologyNode, 0, len(nodes))
+	for _, node := range nodes {
+		key := node.UUID
+		if key == "" {
+			key = strings.ToLower(node.Name)
+		}
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, node)
+	}
+	return result
+}
+
+func relationLabel(name, fallback string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fallback
+	}
+	name = strings.ToLower(strings.ReplaceAll(name, "_", " "))
+	return strings.Join(strings.Fields(name), " ")
 }

--- a/pkg/plugin/topology.go
+++ b/pkg/plugin/topology.go
@@ -36,6 +36,11 @@ const (
 	defaultTopologyMaxEdges = 200
 	hardTopologyMaxNodes    = 500
 	hardTopologyMaxEdges    = 1000
+	// maxTopologyCenterFactLookups caps how many per-node centered fact
+	// queries a single topology refresh may issue. This is independent of the
+	// display node limit (maxNodes) to avoid a sequential MCP call storm that
+	// would exceed gateway timeouts.
+	maxTopologyCenterFactLookups = 12
 )
 
 type topologyBuilder struct {

--- a/pkg/plugin/topology_test.go
+++ b/pkg/plugin/topology_test.go
@@ -123,6 +123,157 @@ func TestParseGraphitiTopologyExtractsSearchMemoryFacts(t *testing.T) {
 	}
 }
 
+func TestParseGraphitiTopologyResolvesProductionUUIDFacts(t *testing.T) {
+	factBody := `{
+		"message": "Facts retrieved successfully",
+		"facts": [
+			{
+				"name": "DEPLOYED_IN",
+				"fact": "bridge-api service is deployed in the bridge namespace",
+				"source_node_uuid": "service-bridge",
+				"target_node_uuid": "namespace-bridge"
+			},
+			{
+				"name": "RUNS_ON",
+				"fact": "bridge-api service runs on mmcx-prd cluster",
+				"source_node_uuid": "service-bridge",
+				"target_node_uuid": "cluster-prd"
+			},
+			{
+				"name": "EMITS_SIGNAL",
+				"fact": "bridge-api service emits trace signals to Tempo",
+				"source_node_uuid": "service-bridge",
+				"target_node_uuid": "infra-tempo"
+			}
+		]
+	}`
+	nodeBody := `{
+		"message": "Nodes retrieved successfully",
+		"nodes": [
+			{"uuid": "service-bridge", "name": "bridge-api", "labels": ["Entity", "Service"]},
+			{"uuid": "namespace-bridge", "name": "bridge", "labels": ["Entity", "Namespace"]},
+			{"uuid": "cluster-prd", "name": "mmcx-prd", "labels": ["Entity", "KubeCluster"]},
+			{"uuid": "infra-tempo", "name": "Tempo", "labels": ["Entity", "Service"]}
+		]
+	}`
+
+	topology := parseGraphitiTopologyWithNodes(factBody, nodeBody)
+
+	if len(topology.Nodes) != 3 {
+		t.Fatalf("nodes = %+v, want bridge-api, bridge namespace, and mmcx-prd cluster", topology.Nodes)
+	}
+
+	edgeIDs := map[string]TopologyEdge{}
+	for _, edge := range topology.Edges {
+		edgeIDs[edge.ID] = edge
+	}
+	if edgeIDs["bridge-api->bridge"].Label != "deployed in" {
+		t.Fatalf("missing bridge-api deployment edge in %+v", topology.Edges)
+	}
+	if edgeIDs["bridge-api->mmcx-prd"].Label != "runs on" {
+		t.Fatalf("missing bridge-api cluster edge in %+v", topology.Edges)
+	}
+	if _, ok := edgeIDs["bridge-api->tempo"]; ok {
+		t.Fatalf("infra edge to Tempo should be filtered: %+v", topology.Edges)
+	}
+}
+
+func TestParseGraphitiTopologyBodiesResolvesCenteredFacts(t *testing.T) {
+	nodeBody := `{
+		"nodes": [
+			{"uuid": "service-auth", "name": "auth-service", "labels": ["Entity", "Service"]},
+			{"uuid": "service-api", "name": "api-service", "labels": ["Entity", "Service"]},
+			{"uuid": "queue-events", "name": "events", "labels": ["Entity", "Queue"]}
+		]
+	}`
+	firstFactBody := `{
+		"facts": [
+			{"name":"CALLS","source_node_uuid":"service-auth","target_node_uuid":"service-api","fact":"auth-service calls api-service"}
+		]
+	}`
+	centeredFactBody := `{
+		"facts": [
+			{"name":"PUBLISHES_TO","source_node_uuid":"service-api","target_node_uuid":"queue-events","fact":"api-service publishes events to events queue"}
+		]
+	}`
+
+	topology := parseGraphitiTopologyBodies([]string{firstFactBody, centeredFactBody}, []string{nodeBody})
+
+	if len(topology.Nodes) != 3 {
+		t.Fatalf("nodes = %+v, want typed service and queue nodes", topology.Nodes)
+	}
+	edgeIDs := map[string]string{}
+	for _, edge := range topology.Edges {
+		edgeIDs[edge.ID] = edge.Label
+	}
+	if edgeIDs["auth-service->api-service"] != "calls" {
+		t.Fatalf("missing centered service edge in %+v", topology.Edges)
+	}
+	if edgeIDs["api-service->events"] != "publishes to" {
+		t.Fatalf("missing centered queue edge in %+v", topology.Edges)
+	}
+}
+
+func TestParseGraphitiTopologyHandlesHyphenatedServiceFacts(t *testing.T) {
+	body := `{
+		"facts": [
+			{"name":"EMITS_SIGNAL","fact":"auth-service emits metric signals to custom-metric-store"},
+			{"name":"DEPLOYED_IN","fact":"auth-service is deployed in auth namespace"}
+		]
+	}`
+
+	topology := parseGraphitiTopology(body)
+
+	edgeIDs := map[string]bool{}
+	nodeIDs := map[string]bool{}
+	nodeTypes := map[string]string{}
+	for _, edge := range topology.Edges {
+		edgeIDs[edge.ID] = true
+	}
+	for _, node := range topology.Nodes {
+		nodeIDs[node.ID] = true
+		nodeTypes[node.ID] = node.Type
+	}
+
+	if !edgeIDs["auth-service->custom-metric-store"] {
+		t.Fatalf("missing emits edge in %+v", topology.Edges)
+	}
+	if !edgeIDs["auth-service->auth"] {
+		t.Fatalf("missing deployment edge in %+v", topology.Edges)
+	}
+	if nodeIDs["emits"] {
+		t.Fatalf("parsed hyphenated service suffix as generic emits node: %+v", topology.Nodes)
+	}
+	if nodeTypes["auth"] != "namespace" {
+		t.Fatalf("auth node type = %q, want namespace", nodeTypes["auth"])
+	}
+}
+
+func TestLimitTopologyResponseKeepsTypedEdgesWithinLimits(t *testing.T) {
+	response := AgentTopologyResponse{
+		Enabled: true,
+		Source:  "graphiti",
+		Nodes: []TopologyNode{
+			{ID: "auth-service", Label: "auth-service", Type: "service"},
+			{ID: "auth", Label: "auth", Type: "namespace"},
+			{ID: "mmcx-prd", Label: "mmcx-prd", Type: "cluster"},
+		},
+		Edges: []TopologyEdge{
+			{ID: "auth-service->auth", Source: "auth-service", Target: "auth", Label: "deployed in"},
+			{ID: "auth-service->mmcx-prd", Source: "auth-service", Target: "mmcx-prd", Label: "runs on"},
+		},
+	}
+
+	limited := limitTopologyResponse(response, 3, 2)
+
+	if len(limited.Nodes) != 3 {
+		t.Fatalf("nodes = %+v, want 3", limited.Nodes)
+	}
+	if len(limited.Edges) != 2 {
+		t.Fatalf("edges = %+v, want 2", limited.Edges)
+	}
+}
+
 func TestFindGraphitiSearchFactsTool(t *testing.T) {
 	tools := []mcp.Tool{
 		{Name: "graphiti_add_memory"},
@@ -130,6 +281,15 @@ func TestFindGraphitiSearchFactsTool(t *testing.T) {
 	}
 	if got := findGraphitiSearchFactsTool(tools); got != "graphiti_search_memory_facts" {
 		t.Fatalf("tool = %q, want graphiti_search_memory_facts", got)
+	}
+}
+
+func TestFindGraphitiSearchNodesTool(t *testing.T) {
+	tools := []mcp.Tool{
+		{Name: "graphiti_search_nodes"},
+	}
+	if got := findGraphitiSearchNodesTool(tools); got != "graphiti_search_nodes" {
+		t.Fatalf("tool = %q, want graphiti_search_nodes", got)
 	}
 }
 
@@ -158,5 +318,95 @@ func TestGraphitiSearchFactsArgsUsesPluralScopeWhenAvailable(t *testing.T) {
 	}
 	if got := args["max_facts"]; got != 200 {
 		t.Fatalf("max_facts = %v, want 200", got)
+	}
+}
+
+func TestGraphitiSearchFactsForNodeArgsUsesCenterNodeWhenAvailable(t *testing.T) {
+	tools := []mcp.Tool{
+		{
+			Name: "graphiti_search_memory_facts",
+			InputSchema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"group_ids":        map[string]interface{}{"type": "array"},
+					"max_facts":        map[string]interface{}{"type": "integer"},
+					"center_node_uuid": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	}
+
+	args := graphitiSearchFactsForNodeArgs(tools, "graphiti_search_memory_facts", 24, "topology", 1000, "service-auth")
+
+	if got := args["center_node_uuid"]; got != "service-auth" {
+		t.Fatalf("center_node_uuid = %v, want service-auth", got)
+	}
+	if !graphitiSearchFactsSupportsCenterNode(tools, "graphiti_search_memory_facts") {
+		t.Fatal("expected center_node_uuid support")
+	}
+}
+
+func TestGraphitiSearchNodesArgsUsesTypedNodeFilters(t *testing.T) {
+	tools := []mcp.Tool{
+		{
+			Name: "graphiti_search_nodes",
+			InputSchema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"group_ids":    map[string]interface{}{"type": "array"},
+					"max_nodes":    map[string]interface{}{"type": "integer"},
+					"query":        map[string]interface{}{"type": "string"},
+					"entity_types": map[string]interface{}{"type": "array"},
+				},
+			},
+		},
+	}
+
+	args := graphitiSearchNodesArgs(tools, "graphiti_search_nodes", 24, "service", 500, []string{"Service"})
+
+	groupIDs, ok := args["group_ids"].([]string)
+	if !ok || len(groupIDs) != 1 || groupIDs[0] != "org_24" {
+		t.Fatalf("group_ids = %#v, want [org_24]", args["group_ids"])
+	}
+	if got := args["max_nodes"]; got != 500 {
+		t.Fatalf("max_nodes = %v, want 500", got)
+	}
+	entityTypes, ok := args["entity_types"].([]string)
+	if !ok || len(entityTypes) != 1 || entityTypes[0] != "Service" {
+		t.Fatalf("entity_types = %#v, want [Service]", args["entity_types"])
+	}
+}
+
+func TestTopologyCenterNodesPrioritizesBusinessServicesAndFiltersInfra(t *testing.T) {
+	nodes := []graphitiTopologyNode{
+		{UUID: "cluster-prd", Name: "mmcx-prd", Type: "cluster"},
+		{UUID: "tempo", Name: "Tempo", Type: "service"},
+		{UUID: "service-auth", Name: "auth-service", Type: "service"},
+		{UUID: "queue-events", Name: "events", Type: "queue"},
+		{UUID: "", Name: "nameless-service", Type: "service"},
+	}
+
+	centerNodes := topologyCenterNodes(nodes, 3)
+
+	if len(centerNodes) != 3 {
+		t.Fatalf("center nodes = %+v, want 3 business nodes", centerNodes)
+	}
+	if centerNodes[0].UUID != "service-auth" {
+		t.Fatalf("first center node = %+v, want auth-service service first", centerNodes[0])
+	}
+	for _, node := range centerNodes {
+		if node.UUID == "tempo" || node.UUID == "" {
+			t.Fatalf("center node should filter infra and missing UUID entries: %+v", centerNodes)
+		}
+	}
+}
+
+func TestTopologyCenteredFactLimitScalesWithRequestedEdges(t *testing.T) {
+	if got := topologyCenteredFactLimit(200, 100); got != 25 {
+		t.Fatalf("default dense fact limit = %d, want 25", got)
+	}
+	if got := topologyCenteredFactLimit(1000, 5); got != 100 {
+		t.Fatalf("large sparse fact limit = %d, want capped 100", got)
+	}
+	if got := topologyCenteredFactLimit(200, 0); got != 200 {
+		t.Fatalf("empty center fact limit = %d, want requested edge limit", got)
 	}
 }

--- a/scripts/extract-asko11y-feedback-users.py
+++ b/scripts/extract-asko11y-feedback-users.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Extract recent Ask O11y users from Redis and resolve emails via Grafana.
+
+This script intentionally exports only user/activity metadata. It scans Redis
+session objects but does not write message content, tool payloads, or summaries
+to disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import datetime as dt
+import json
+import os
+import socket
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+
+DEFAULT_RECENT_SINCE = "2026-03-06T00:00:00Z"
+DEFAULT_OUTPUT_DIR = "local/asko11y-feedback"
+
+
+class RedisError(RuntimeError):
+    pass
+
+
+class RedisClient:
+    def __init__(self, redis_url: str, timeout: float = 10.0) -> None:
+        parsed = urllib.parse.urlparse(redis_url)
+        if parsed.scheme not in {"redis", "rediss"}:
+            raise ValueError("redis URL must use redis:// or rediss://")
+
+        self.host = parsed.hostname or "localhost"
+        self.port = parsed.port or 6379
+        self.timeout = timeout
+        self.username = urllib.parse.unquote(parsed.username) if parsed.username else None
+        self.password = urllib.parse.unquote(parsed.password) if parsed.password else None
+        self.db = int(parsed.path.lstrip("/") or "0")
+        self.sock: socket.socket | ssl.SSLSocket | None = None
+        self.use_tls = parsed.scheme == "rediss"
+
+    def __enter__(self) -> "RedisClient":
+        raw_sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        self.sock = ssl.create_default_context().wrap_socket(raw_sock, server_hostname=self.host) if self.use_tls else raw_sock
+        if self.password:
+            if self.username:
+                self.command("AUTH", self.username, self.password)
+            else:
+                self.command("AUTH", self.password)
+        if self.db:
+            self.command("SELECT", str(self.db))
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        if self.sock is not None:
+            self.sock.close()
+
+    def command(self, *parts: str) -> Any:
+        if self.sock is None:
+            raise RedisError("Redis socket is not connected")
+        payload = self._encode(parts)
+        self.sock.sendall(payload)
+        return self._read_response()
+
+    def scan(self, match: str, count: int = 1000) -> list[str]:
+        cursor = "0"
+        keys: list[str] = []
+        while True:
+            response = self.command("SCAN", cursor, "MATCH", match, "COUNT", str(count))
+            if not isinstance(response, list) or len(response) != 2:
+                raise RedisError(f"unexpected SCAN response: {response!r}")
+            cursor = decode_redis(response[0])
+            batch = response[1]
+            if not isinstance(batch, list):
+                raise RedisError(f"unexpected SCAN key batch: {batch!r}")
+            keys.extend(decode_redis(key) for key in batch)
+            if cursor == "0":
+                return keys
+
+    @staticmethod
+    def _encode(parts: tuple[str, ...]) -> bytes:
+        chunks = [f"*{len(parts)}\r\n".encode()]
+        for part in parts:
+            encoded = part.encode()
+            chunks.append(f"${len(encoded)}\r\n".encode())
+            chunks.append(encoded)
+            chunks.append(b"\r\n")
+        return b"".join(chunks)
+
+    def _read_line(self) -> bytes:
+        if self.sock is None:
+            raise RedisError("Redis socket is not connected")
+        chunks = []
+        while True:
+            char = self.sock.recv(1)
+            if not char:
+                raise RedisError("Redis connection closed")
+            chunks.append(char)
+            if len(chunks) >= 2 and chunks[-2:] == [b"\r", b"\n"]:
+                return b"".join(chunks[:-2])
+
+    def _read_exact(self, length: int) -> bytes:
+        if self.sock is None:
+            raise RedisError("Redis socket is not connected")
+        chunks = []
+        remaining = length
+        while remaining > 0:
+            chunk = self.sock.recv(remaining)
+            if not chunk:
+                raise RedisError("Redis connection closed")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _read_response(self) -> Any:
+        prefix = self._read_exact(1)
+        if prefix == b"+":
+            return self._read_line().decode()
+        if prefix == b"-":
+            raise RedisError(self._read_line().decode())
+        if prefix == b":":
+            return int(self._read_line())
+        if prefix == b"$":
+            length = int(self._read_line())
+            if length == -1:
+                return None
+            data = self._read_exact(length)
+            self._read_exact(2)
+            return data
+        if prefix == b"*":
+            length = int(self._read_line())
+            if length == -1:
+                return None
+            return [self._read_response() for _ in range(length)]
+        raise RedisError(f"unknown Redis response prefix: {prefix!r}")
+
+
+@dataclass
+class UsageAggregate:
+    asko11y_user_id: int
+    org_id: int
+    first_seen_at: dt.datetime
+    last_activity_at: dt.datetime
+    session_count: int = 0
+    total_messages: int = 0
+    model_set: set[str] = field(default_factory=set)
+
+    def add_session(self, session: dict[str, Any]) -> None:
+        created_at = parse_datetime(session.get("createdAt")) or self.first_seen_at
+        updated_at = parse_datetime(session.get("updatedAt")) or created_at
+        self.first_seen_at = min(self.first_seen_at, created_at)
+        self.last_activity_at = max(self.last_activity_at, updated_at)
+        self.session_count += 1
+        self.total_messages += int_or_zero(session.get("messageCount")) or len(session.get("messages") or [])
+        model = str(session.get("model") or "").strip()
+        if model:
+            self.model_set.add(model)
+
+
+@dataclass
+class GrafanaUser:
+    grafana_user_id: int | None = None
+    login: str = ""
+    email: str = ""
+    name: str = ""
+    org_id: int | None = None
+    org_name: str = ""
+
+
+def decode_redis(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def parse_datetime(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def isoformat_z(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def int_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def fnv1a_login_hash(login: str) -> int:
+    h = 14695981039346656037
+    for byte in login.encode():
+        h ^= byte
+        h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return h & 0x7FFFFFFFFFFFFFFF
+
+
+def collect_recent_usage(redis_url: str, recent_since: dt.datetime) -> tuple[dict[tuple[int, int], UsageAggregate], dict[str, int]]:
+    stats = {
+        "session_keys_seen": 0,
+        "session_json_seen": 0,
+        "recent_session_json_seen": 0,
+        "malformed_sessions": 0,
+    }
+    usage: dict[tuple[int, int], UsageAggregate] = {}
+
+    with RedisClient(redis_url) as client:
+        for key in sorted(client.scan("session:*")):
+            if key.endswith(":shares"):
+                continue
+            stats["session_keys_seen"] += 1
+            raw = client.command("GET", key)
+            if raw is None:
+                continue
+            try:
+                session = json.loads(decode_redis(raw))
+            except json.JSONDecodeError:
+                stats["malformed_sessions"] += 1
+                continue
+            if not isinstance(session, dict):
+                stats["malformed_sessions"] += 1
+                continue
+
+            user_id = int_or_zero(session.get("userId"))
+            org_id = int_or_zero(session.get("orgId"))
+            updated_at = parse_datetime(session.get("updatedAt"))
+            created_at = parse_datetime(session.get("createdAt")) or updated_at
+            if user_id <= 0 or org_id <= 0 or updated_at is None or created_at is None:
+                stats["malformed_sessions"] += 1
+                continue
+
+            stats["session_json_seen"] += 1
+            if updated_at < recent_since:
+                continue
+
+            stats["recent_session_json_seen"] += 1
+            aggregate_key = (user_id, org_id)
+            if aggregate_key not in usage:
+                usage[aggregate_key] = UsageAggregate(
+                    asko11y_user_id=user_id,
+                    org_id=org_id,
+                    first_seen_at=created_at,
+                    last_activity_at=updated_at,
+                )
+            usage[aggregate_key].add_session(session)
+
+    return usage, stats
+
+
+class GrafanaClient:
+    def __init__(self, base_url: str, token: str | None, basic_auth: str | None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.basic_auth = basic_auth
+
+    def get_json(self, path: str) -> Any:
+        request = urllib.request.Request(f"{self.base_url}{path}")
+        request.add_header("Accept", "application/json")
+        if self.token:
+            request.add_header("Authorization", f"Bearer {self.token}")
+        elif self.basic_auth:
+            encoded = base64.b64encode(self.basic_auth.encode()).decode()
+            request.add_header("Authorization", f"Basic {encoded}")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode())
+
+    def try_get_json(self, path: str) -> Any | None:
+        try:
+            return self.get_json(path)
+        except urllib.error.HTTPError as exc:
+            print(f"warning: Grafana API {path} returned HTTP {exc.code}", file=sys.stderr)
+            return None
+        except urllib.error.URLError as exc:
+            print(f"warning: Grafana API {path} failed: {exc}", file=sys.stderr)
+            return None
+
+
+def normalize_user(payload: dict[str, Any], org_id: int | None = None, org_name: str = "") -> GrafanaUser | None:
+    login = str(payload.get("login") or "").strip()
+    email = str(payload.get("email") or "").strip()
+    user_id = int_or_zero(payload.get("id") or payload.get("userId"))
+    if not login and not email and user_id <= 0:
+        return None
+    return GrafanaUser(
+        grafana_user_id=user_id if user_id > 0 else None,
+        login=login,
+        email=email,
+        name=str(payload.get("name") or "").strip(),
+        org_id=org_id,
+        org_name=org_name,
+    )
+
+
+def list_from_grafana_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("users", "items", "result"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def fetch_grafana_users(grafana_url: str, token: str | None, basic_auth: str | None, org_ids: set[int]) -> tuple[list[GrafanaUser], dict[int, str]]:
+    client = GrafanaClient(grafana_url, token, basic_auth)
+    users: list[GrafanaUser] = []
+    org_names: dict[int, str] = {}
+
+    page = 1
+    while True:
+        payload = client.try_get_json(f"/api/users/search?perpage=1000&page={page}")
+        if payload is None:
+            break
+        page_users = list_from_grafana_payload(payload)
+        users.extend(user for item in page_users if (user := normalize_user(item)) is not None)
+        total_count = int_or_zero(payload.get("totalCount") if isinstance(payload, dict) else None)
+        if not page_users or total_count <= page * 1000:
+            break
+        page += 1
+
+    org_payload = client.try_get_json("/api/orgs")
+    for item in list_from_grafana_payload(org_payload):
+        org_id = int_or_zero(item.get("id"))
+        if org_id > 0:
+            org_names[org_id] = str(item.get("name") or "").strip()
+
+    for org_id in sorted(org_ids):
+        org_name = org_names.get(org_id, "")
+        org_user_payload = client.try_get_json(f"/api/orgs/{org_id}/users")
+        if org_user_payload is None and org_id == 1:
+            org_user_payload = client.try_get_json("/api/org/users")
+        for item in list_from_grafana_payload(org_user_payload):
+            if user := normalize_user(item, org_id=org_id, org_name=org_name):
+                users.append(user)
+
+    return users, org_names
+
+
+def load_grafana_users_csv(path: str) -> tuple[list[GrafanaUser], dict[int, str]]:
+    users: list[GrafanaUser] = []
+    org_names: dict[int, str] = {}
+    with open(path, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            org_id = int_or_zero(row.get("org_id"))
+            org_name = str(row.get("org_name") or "").strip()
+            if org_id > 0 and org_name:
+                org_names[org_id] = org_name
+            users.append(
+                GrafanaUser(
+                    grafana_user_id=int_or_zero(row.get("grafana_user_id")) or None,
+                    login=str(row.get("login") or "").strip(),
+                    email=str(row.get("email") or "").strip(),
+                    org_id=org_id if org_id > 0 else None,
+                    org_name=org_name,
+                )
+            )
+    return users, org_names
+
+
+def resolve_user(aggregate: UsageAggregate, users: list[GrafanaUser], org_names: dict[int, str]) -> tuple[GrafanaUser | None, str]:
+    org_users = [user for user in users if user.org_id == aggregate.org_id]
+    global_users = [user for user in users if user.org_id is None]
+
+    for scope_users, prefix in ((org_users, "org"), (global_users, "global")):
+        for user in scope_users:
+            if user.login and fnv1a_login_hash(user.login) == aggregate.asko11y_user_id:
+                if not user.org_name:
+                    user.org_name = org_names.get(aggregate.org_id, "")
+                return user, f"{prefix}_fnv_login_hash"
+
+    for scope_users, prefix in ((org_users, "org"), (global_users, "global")):
+        for user in scope_users:
+            if user.grafana_user_id == aggregate.asko11y_user_id:
+                if not user.org_name:
+                    user.org_name = org_names.get(aggregate.org_id, "")
+                return user, f"{prefix}_numeric_user_id"
+
+    return None, "unresolved"
+
+
+def write_outputs(
+    output_dir: str,
+    usage: dict[tuple[int, int], UsageAggregate],
+    users: list[GrafanaUser],
+    org_names: dict[int, str],
+    stats: dict[str, int],
+) -> tuple[str, str, str]:
+    os.makedirs(output_dir, exist_ok=True)
+    recipients_path = os.path.join(output_dir, "asko11y-feedback-recipients.csv")
+    unresolved_path = os.path.join(output_dir, "asko11y-feedback-unresolved-users.csv")
+    stats_path = os.path.join(output_dir, "asko11y-feedback-extraction-summary.json")
+
+    resolved_rows: dict[tuple[str, int], dict[str, str]] = {}
+    unresolved_rows: list[dict[str, str]] = []
+
+    for aggregate in sorted(usage.values(), key=lambda item: item.last_activity_at, reverse=True):
+        resolved_user, method = resolve_user(aggregate, users, org_names)
+        model_set = ";".join(sorted(aggregate.model_set))
+        base = {
+            "asko11y_user_id": str(aggregate.asko11y_user_id),
+            "org_id": str(aggregate.org_id),
+            "org_name": (resolved_user.org_name if resolved_user else org_names.get(aggregate.org_id, "")) or "",
+            "first_seen_at": isoformat_z(aggregate.first_seen_at),
+            "last_activity_at": isoformat_z(aggregate.last_activity_at),
+            "session_count": str(aggregate.session_count),
+            "total_messages": str(aggregate.total_messages),
+            "model_set": model_set,
+        }
+        if resolved_user and resolved_user.email:
+            dedupe_key = (resolved_user.email.lower(), aggregate.org_id)
+            row = {
+                "email": resolved_user.email,
+                "login": resolved_user.login,
+                "grafana_user_id": str(resolved_user.grafana_user_id or ""),
+                **base,
+                "resolution_method": method,
+            }
+            if dedupe_key in resolved_rows:
+                row = merge_recipient_rows(resolved_rows[dedupe_key], row)
+            resolved_rows[dedupe_key] = row
+        else:
+            unresolved_rows.append({**base, "resolution_method": method})
+
+    recipient_fields = [
+        "email",
+        "login",
+        "grafana_user_id",
+        "asko11y_user_id",
+        "org_id",
+        "org_name",
+        "first_seen_at",
+        "last_activity_at",
+        "session_count",
+        "total_messages",
+        "model_set",
+        "resolution_method",
+    ]
+    with open(recipients_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=recipient_fields)
+        writer.writeheader()
+        writer.writerows(sorted(resolved_rows.values(), key=lambda row: row["last_activity_at"], reverse=True))
+
+    unresolved_fields = [
+        "asko11y_user_id",
+        "org_id",
+        "org_name",
+        "first_seen_at",
+        "last_activity_at",
+        "session_count",
+        "total_messages",
+        "model_set",
+        "resolution_method",
+    ]
+    with open(unresolved_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=unresolved_fields)
+        writer.writeheader()
+        writer.writerows(unresolved_rows)
+
+    summary = {
+        **stats,
+        "recent_user_org_pairs": len(usage),
+        "resolved_recipients": len(resolved_rows),
+        "unresolved_user_org_pairs": len(unresolved_rows),
+        "unresolved_rate": (len(unresolved_rows) / len(usage)) if usage else 0,
+    }
+    with open(stats_path, "w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    return recipients_path, unresolved_path, stats_path
+
+
+def merge_recipient_rows(existing: dict[str, str], new: dict[str, str]) -> dict[str, str]:
+    merged = dict(existing)
+    merged["asko11y_user_id"] = ";".join(sorted(set(filter(None, [*existing["asko11y_user_id"].split(";"), *new["asko11y_user_id"].split(";")]))))
+    merged["first_seen_at"] = min(existing["first_seen_at"], new["first_seen_at"])
+    merged["last_activity_at"] = max(existing["last_activity_at"], new["last_activity_at"])
+    merged["session_count"] = str(int_or_zero(existing["session_count"]) + int_or_zero(new["session_count"]))
+    merged["total_messages"] = str(int_or_zero(existing["total_messages"]) + int_or_zero(new["total_messages"]))
+    merged["model_set"] = ";".join(sorted(set(filter(None, [*existing["model_set"].split(";"), *new["model_set"].split(";")]))))
+    merged["resolution_method"] = ";".join(sorted(set(filter(None, [*existing["resolution_method"].split(";"), new["resolution_method"]]))))
+    return merged
+
+
+def write_form_draft(output_dir: str) -> str:
+    path = os.path.join(output_dir, "asko11y-feedback-google-form.md")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(FORM_DRAFT)
+    return path
+
+
+FORM_DRAFT = """# Ask O11y Feedback Form
+
+## Form Settings
+- Collect email addresses, or make the first question required if automatic collection is unavailable.
+- Keep responses editable after submission.
+- Do not collect chat transcript content in this form.
+
+## Questions
+1. Email
+   - Type: Short answer
+   - Required: Yes
+
+2. How often have you used Ask O11y?
+   - Type: Multiple choice
+   - Options: Once, A few times, Weekly, Daily or almost daily
+   - Required: Yes
+
+3. What were you mainly trying to do with Ask O11y?
+   - Type: Multiple choice
+   - Options: Investigate an incident, Debug a service or query, Understand metrics/logs/traces, Build or improve a dashboard, Investigate an alert, Learn observability concepts, Explore the product, Other
+   - Required: Yes
+
+4. Did Ask O11y help you complete that task?
+   - Type: Multiple choice
+   - Options: Yes, Partially, No, I was just exploring
+   - Required: Yes
+
+5. What would you have used instead of Ask O11y?
+   - Type: Multiple choice
+   - Options: Grafana manually, PromQL/LogQL directly, A teammate or Slack channel, Documentation or a runbook, Another AI tool, I would not have done the task, Other
+   - Required: No
+
+6. Accuracy rating
+   - Type: Linear scale
+   - Scale: 1 to 5
+   - Labels: 1 = Often incorrect, 5 = Consistently accurate
+   - Required: Yes
+
+7. Where was Ask O11y correct or incorrect?
+   - Type: Paragraph
+   - Required: No
+
+8. When Ask O11y was not helpful, what went wrong?
+   - Type: Checkboxes
+   - Options: Wrong answer, Missing data access, Tool or permission error, Did not understand my request, Response was unclear, Too slow, Too much back-and-forth, I did not know what to ask, Other
+   - Required: No
+
+9. How often did you verify Ask O11y's answer somewhere else?
+   - Type: Multiple choice
+   - Options: Always, Often, Sometimes, Rarely, Never, Not applicable
+   - Required: Yes
+
+10. Usability rating
+   - Type: Linear scale
+   - Scale: 1 to 5
+   - Labels: 1 = Hard to use, 5 = Easy to use
+   - Required: Yes
+
+11. What felt confusing, missing, or smooth?
+   - Type: Paragraph
+   - Required: No
+
+12. Performance rating
+   - Type: Linear scale
+   - Scale: 1 to 5
+   - Labels: 1 = Too slow, 5 = Fast enough
+   - Required: Yes
+
+13. Where did it feel slow or responsive?
+   - Type: Paragraph
+   - Required: No
+
+14. Which workflows have been most useful?
+   - Type: Checkboxes
+   - Options: Metrics queries, Logs investigation, Trace investigation, Dashboard help, Alert investigation, Incident/root cause analysis, Learning observability concepts, Other
+   - Required: No
+
+15. What workflows or capabilities are missing?
+    - Type: Paragraph
+    - Required: No
+
+16. Would you keep using Ask O11y if it were available by default?
+    - Type: Multiple choice
+    - Options: Yes, Probably, Not sure, Probably not, No
+    - Required: Yes
+
+17. What should we improve first?
+    - Type: Paragraph
+    - Required: Yes
+
+18. Can we review your Ask O11y usage metadata to understand your feedback?
+    - Type: Multiple choice
+    - Options: Yes, No
+    - Required: Yes
+
+19. Can we follow up with you about your feedback?
+    - Type: Multiple choice
+    - Options: Yes, No
+    - Required: Yes
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--redis-url", required=True, help="Redis URL for the restored Ask O11y dump, for example redis://localhost:6380/0")
+    parser.add_argument("--grafana-url", help="Grafana base URL, for example https://grafana.example.com")
+    parser.add_argument("--grafana-token", default=os.getenv("GRAFANA_SERVICE_ACCOUNT_TOKEN") or os.getenv("GRAFANA_TOKEN"))
+    parser.add_argument("--grafana-basic-auth", default=os.getenv("GRAFANA_BASIC_AUTH"), help="Basic auth as user:password; used only when no token is provided")
+    parser.add_argument("--grafana-users-csv", help="CSV with grafana_user_id,login,email,org_id,org_name; skips Grafana API calls")
+    parser.add_argument("--recent-since", default=DEFAULT_RECENT_SINCE, help=f"UTC cutoff for recent users; default {DEFAULT_RECENT_SINCE}")
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--write-form-draft", action="store_true", help="Also write the Google Form draft into the output directory")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    recent_since = parse_datetime(args.recent_since)
+    if recent_since is None:
+        print(f"error: invalid --recent-since value: {args.recent_since}", file=sys.stderr)
+        return 2
+    if not args.grafana_users_csv and not args.grafana_url:
+        print("error: set --grafana-users-csv or --grafana-url", file=sys.stderr)
+        return 2
+
+    usage, stats = collect_recent_usage(args.redis_url, recent_since)
+    if args.grafana_users_csv:
+        users, org_names = load_grafana_users_csv(args.grafana_users_csv)
+    else:
+        if not args.grafana_token and not args.grafana_basic_auth:
+            print("error: set --grafana-token, GRAFANA_TOKEN, GRAFANA_SERVICE_ACCOUNT_TOKEN, or GRAFANA_BASIC_AUTH", file=sys.stderr)
+            return 2
+        users, org_names = fetch_grafana_users(args.grafana_url, args.grafana_token, args.grafana_basic_auth, {org_id for _, org_id in usage})
+    recipients_path, unresolved_path, stats_path = write_outputs(args.output_dir, usage, users, org_names, stats)
+    form_path = write_form_draft(args.output_dir) if args.write_form_draft else ""
+
+    print(f"Recipients CSV: {recipients_path}")
+    print(f"Unresolved CSV: {unresolved_path}")
+    print(f"Summary JSON: {stats_path}")
+    if form_path:
+        print(f"Google Form draft: {form_path}")
+    with open(stats_path, encoding="utf-8") as handle:
+        resolved_recipients = json.load(handle)["resolved_recipients"]
+    print(f"Resolved {resolved_recipients} recipients from {len(usage)} recent user/org pairs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/restore-redis-dump.sh
+++ b/scripts/restore-redis-dump.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restores an Ask O11y Redis persistence archive into a disposable local Redis
+# container. The archive should be produced by scripts/dump-redis-sessions.sh.
+
+if [[ $# -lt 1 ]]; then
+  printf 'Usage: %s /path/to/ask-o11y-redis-sessions.tar [port]\n' "$0" >&2
+  exit 2
+fi
+
+DUMP_ARCHIVE="$1"
+REDIS_PORT="${2:-6380}"
+CONTAINER_NAME="${CONTAINER_NAME:-asko11y-feedback-redis}"
+WORK_DIR="${WORK_DIR:-local/asko11y-feedback/redis-restore}"
+
+if [[ ! -f "${DUMP_ARCHIVE}" ]]; then
+  printf 'Dump archive not found: %s\n' "${DUMP_ARCHIVE}" >&2
+  exit 1
+fi
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}"
+tar -xf "${DUMP_ARCHIVE}" -C "${WORK_DIR}"
+
+case "${WORK_DIR}" in
+  /*) ABS_WORK_DIR="${WORK_DIR}" ;;
+  *) ABS_WORK_DIR="$(pwd)/${WORK_DIR}" ;;
+esac
+
+redis_args=()
+if [[ -d "${WORK_DIR}/appendonlydir" ]] || compgen -G "${WORK_DIR}/*.aof" >/dev/null; then
+  redis_args=(--appendonly yes)
+fi
+
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  -p "127.0.0.1:${REDIS_PORT}:6379" \
+  -v "${ABS_WORK_DIR}:/data" \
+  redis:7-alpine \
+  redis-server "${redis_args[@]}" >/dev/null
+
+printf 'Restored Redis dump into container %s\n' "${CONTAINER_NAME}"
+printf 'Redis URL: redis://127.0.0.1:%s/0\n' "${REDIS_PORT}"

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -52,6 +52,7 @@ function StatusBadge({ status }: { status?: ServerStatusKind }) {
   if (!status) {
     return <span className="text-xs text-secondary">Status unknown</span>;
   }
+
   return (
     <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE_CLASSES[status]}`}>
       {STATUS_LABELS[status]}
@@ -971,6 +972,9 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
     });
   }
 
+  const topologyServiceCount = topology?.nodes.filter((node) => node.type === 'service').length ?? 0;
+  const topologyHasTypedNodes = topology ? topologyServiceCount !== topology.nodes.length : false;
+
   return (
     <div>
       <TabsBar>
@@ -1587,7 +1591,10 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
                   data-testid={testIds.appConfig.serviceGraphSummary}
                 >
                   <Badge text={topology.source} color="blue" />
-                  <span className="text-sm text-secondary">{topology.nodes.length} services</span>
+                  <span className="text-sm text-secondary">{topologyServiceCount} services</span>
+                  {topologyHasTypedNodes && (
+                    <span className="text-sm text-secondary">{topology.nodes.length} nodes</span>
+                  )}
                   <span className="text-sm text-secondary">{topology.edges.length} links</span>
                 </div>
               )}

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -76,6 +76,7 @@ function ChatComponent({
     chatContainerRef,
     setCurrentInput,
     sendMessage,
+    retryLastMessage,
     handleKeyPress,
     clearChat,
     sessionManager,
@@ -96,7 +97,9 @@ function ChatComponent({
   );
 
   const chatInputRef = useRef<ChatInputRef>(null);
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  // Docked history panel is shown by default in the interactive chat so past
+  // conversations are discoverable; hidden in read-only/shared views.
+  const [isHistoryOpen, setIsHistoryOpen] = useState(!readOnly);
 
   const {
     visiblePageRefs,
@@ -180,6 +183,7 @@ function ChatComponent({
       queuedMessageCount: messageQueue.length,
       onStopGeneration: stopGeneration,
       onResolveApproval: resolveApproval,
+      onRetry: retryLastMessage,
     }),
     [
       chatHistory,
@@ -204,6 +208,7 @@ function ChatComponent({
       messageQueue.length,
       stopGeneration,
       resolveApproval,
+      retryLastMessage,
     ]
   );
 
@@ -230,18 +235,19 @@ function ChatComponent({
         backgroundColor: theme.colors.background.canvas,
       }}
     >
-      {chatScene && (
-        <div data-plugin-split-layout style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-          <chatScene.Component model={chatScene} />
-        </div>
-      )}
-
       <SessionSidebar
         sessionManager={sessionManager}
         currentSessionId={sessionManager.currentSessionId}
         isOpen={isHistoryOpen}
         onClose={() => setIsHistoryOpen(false)}
+        docked={!readOnly}
       />
+
+      {chatScene && (
+        <div data-plugin-split-layout style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+          <chatScene.Component model={chatScene} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Chat/components/ChatHistory/ChatHistory.tsx
+++ b/src/components/Chat/components/ChatHistory/ChatHistory.tsx
@@ -11,9 +11,15 @@ interface ChatHistoryProps {
     decision: 'approved' | 'rejected',
     approvalScope?: 'once' | 'always'
   ) => Promise<void>;
+  onRetry?: () => void;
 }
 
-export const ChatHistory: React.FC<ChatHistoryProps> = ({ chatHistory, isGenerating, onResolveApproval }) => (
+export const ChatHistory: React.FC<ChatHistoryProps> = ({
+  chatHistory,
+  isGenerating,
+  onResolveApproval,
+  onRetry,
+}) => (
   <div>
     {chatHistory.map((message, index) => (
       <ChatMessage
@@ -22,6 +28,7 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ chatHistory, isGenerat
         isGenerating={isGenerating}
         isLastMessage={index === chatHistory.length - 1}
         onResolveApproval={onResolveApproval}
+        onRetry={onRetry}
       />
     ))}
   </div>

--- a/src/components/Chat/components/ChatMessage/ChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/ChatMessage.test.tsx
@@ -195,51 +195,6 @@ describe('ChatMessage', () => {
       expect(screen.queryByText('Reject')).not.toBeInTheDocument();
     });
 
-    it('should collapse run plan details behind progress by default', () => {
-      const message: ChatMessageType = {
-        role: 'assistant',
-        content: '',
-        runPlan: {
-          objective: 'Answer the request using available Grafana and MCP evidence.',
-          steps: [
-            { id: 'plan', title: 'Plan', status: 'completed' },
-            { id: 'evidence', title: 'Gather evidence', status: 'running' },
-          ],
-        },
-      };
-
-      render(<ChatMessage message={message} />);
-
-      expect(screen.getByText('Run progress')).toBeInTheDocument();
-      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '50');
-      expect(
-        screen.queryByText('Answer the request using available Grafana and MCP evidence.')
-      ).not.toBeInTheDocument();
-    });
-
-    it('should show completed progress when a final report exists', () => {
-      const message: ChatMessageType = {
-        role: 'assistant',
-        content: 'Done',
-        runPlan: {
-          objective: 'Answer the request using available Grafana and MCP evidence.',
-          steps: [
-            { id: 'understand', title: 'Understand request', status: 'completed' },
-            { id: 'evidence', title: 'Gather evidence', status: 'running' },
-            { id: 'answer', title: 'Answer with citations', status: 'pending' },
-          ],
-        },
-        finalReport: {
-          summary: 'Complete',
-        },
-      };
-
-      render(<ChatMessage message={message} />);
-
-      expect(screen.getByText('3/3')).toBeInTheDocument();
-      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
-    });
-
     it('should collapse evidence details by default', () => {
       const message: ChatMessageType = {
         role: 'assistant',

--- a/src/components/Chat/components/ChatMessage/ChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/ChatMessage.test.tsx
@@ -18,12 +18,17 @@ jest.mock('@grafana/ui', () => ({
       primary: { main: '#7c3aed' },
     },
   }),
-  Button: ({ children, disabled, onClick }: any) => (
-    <button disabled={disabled} onClick={onClick}>
+  Button: ({ children, disabled, onClick, 'data-testid': dataTestId }: any) => (
+    <button disabled={disabled} onClick={onClick} data-testid={dataTestId}>
       {children}
     </button>
   ),
   Icon: ({ name }: any) => <span data-testid={`icon-${name}`} />,
+  Alert: ({ children, title }: any) => (
+    <div role="alert" aria-label={title}>
+      {children}
+    </div>
+  ),
 }));
 
 // Mock child components to simplify testing
@@ -449,6 +454,47 @@ describe('ChatMessage', () => {
       render(<ChatMessage message={message} />);
 
       expect(screen.getByText('Assistant message', { selector: '.sr-only' })).toBeInTheDocument();
+    });
+  });
+
+  describe('error and retry', () => {
+    it('should render the error message when message.error is set', () => {
+      const message: ChatMessageType = {
+        role: 'assistant',
+        content: '',
+        error: 'The data is currently unavailable',
+      };
+
+      render(<ChatMessage message={message} />);
+
+      expect(screen.getByText('The data is currently unavailable')).toBeInTheDocument();
+    });
+
+    it('should render a Retry button for the last message and invoke onRetry', () => {
+      const message: ChatMessageType = {
+        role: 'assistant',
+        content: '',
+        error: 'Run failed',
+      };
+      const onRetry = jest.fn();
+
+      render(<ChatMessage message={message} isLastMessage={true} onRetry={onRetry} />);
+
+      const retryButton = screen.getByTestId('data-testid chat-retry-button');
+      fireEvent.click(retryButton);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not render a Retry button for non-last messages', () => {
+      const message: ChatMessageType = {
+        role: 'assistant',
+        content: '',
+        error: 'Run failed',
+      };
+
+      render(<ChatMessage message={message} isLastMessage={false} onRetry={jest.fn()} />);
+
+      expect(screen.queryByTestId('data-testid chat-retry-button')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Chat/components/ChatMessage/ChatMessage.tsx
+++ b/src/components/Chat/components/ChatMessage/ChatMessage.tsx
@@ -83,20 +83,11 @@ function AgentTraceSummary({
   ) => Promise<void>;
 }): React.ReactElement | null {
   const theme = useTheme2();
-  const hasPlan = Boolean(message.runPlan?.steps?.length);
   const hasEvidence = Boolean(message.evidence?.length);
   const hasApprovals = Boolean(message.approvals?.length);
-  const [isPlanOpen, setIsPlanOpen] = React.useState(false);
   const [isEvidenceOpen, setIsEvidenceOpen] = React.useState(false);
-  const planSteps = message.runPlan?.steps || [];
-  const isRunComplete = Boolean(message.finalReport);
-  const completedSteps = isRunComplete
-    ? planSteps.length
-    : planSteps.filter((step) => step.status === 'completed').length;
-  const runningSteps = isRunComplete ? 0 : planSteps.filter((step) => step.status === 'running').length;
-  const planProgress = planSteps.length > 0 ? Math.round((completedSteps / planSteps.length) * 100) : 0;
 
-  if (!hasPlan && !hasEvidence && !hasApprovals && !message.finalReport) {
+  if (!hasEvidence && !hasApprovals) {
     return null;
   }
 
@@ -108,76 +99,6 @@ function AgentTraceSummary({
         border: `1px solid ${theme.colors.border.weak}`,
       }}
     >
-      {hasPlan && (
-        <div className="px-3 py-2 border-b border-weak">
-          <button
-            type="button"
-            className="flex w-full items-center gap-3 text-left"
-            aria-expanded={isPlanOpen}
-            onClick={() => setIsPlanOpen((open) => !open)}
-            style={{
-              background: 'transparent',
-              border: 0,
-              color: 'inherit',
-              cursor: 'pointer',
-              padding: 0,
-            }}
-          >
-            <Icon name={isPlanOpen ? 'angle-down' : 'angle-right'} size="sm" />
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center justify-between gap-3">
-                <div className="text-xs font-medium truncate" style={{ color: theme.colors.text.secondary }}>
-                  Run progress
-                </div>
-                <div className="text-xs" style={{ color: theme.colors.text.secondary }}>
-                  {completedSteps}/{planSteps.length}
-                  {runningSteps > 0 ? ' running' : ''}
-                </div>
-              </div>
-              <div
-                className="mt-2 h-1.5 overflow-hidden rounded"
-                style={{ backgroundColor: theme.colors.background.primary }}
-                role="progressbar"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={planProgress}
-              >
-                <div
-                  className="h-full rounded"
-                  style={{ width: `${planProgress}%`, backgroundColor: theme.colors.primary.main }}
-                />
-              </div>
-            </div>
-          </button>
-          {isPlanOpen && (
-            <div className="mt-3">
-              <div className="text-xs font-medium mb-2" style={{ color: theme.colors.text.secondary }}>
-                {message.runPlan?.objective}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {planSteps.map((step) => (
-                  <span
-                    key={step.id}
-                    className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs"
-                    style={{
-                      backgroundColor: theme.colors.background.primary,
-                      color: theme.colors.text.primary,
-                      border: `1px solid ${theme.colors.border.weak}`,
-                    }}
-                  >
-                    <Icon
-                      name={step.status === 'completed' ? 'check' : step.status === 'running' ? 'spinner' : 'circle'}
-                      size="xs"
-                    />
-                    {step.title}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
       {hasApprovals && (
         <div className="px-3 py-2 border-b border-weak">
           {message.approvals?.map((approval) => (

--- a/src/components/Chat/components/ChatMessage/ChatMessage.tsx
+++ b/src/components/Chat/components/ChatMessage/ChatMessage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
-import { Button, Icon, useTheme2 } from '@grafana/ui';
+import { Alert, Button, Icon, useTheme2 } from '@grafana/ui';
+import { testIds } from '../../../testIds';
 import { ToolCallsSection } from '../ToolCallsSection/ToolCallsSection';
 import { GraphRenderer } from '../GraphRenderer/GraphRenderer';
 import { LogsRenderer } from '../LogsRenderer/LogsRenderer';
@@ -18,6 +19,7 @@ interface ChatMessageProps {
     decision: 'approved' | 'rejected',
     approvalScope?: 'once' | 'always'
   ) => Promise<void>;
+  onRetry?: () => void;
 }
 
 function buildTimeRange(query: ContentSection['query']): { from: string; to: string } | undefined {
@@ -285,6 +287,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   isGenerating = false,
   isLastMessage = false,
   onResolveApproval,
+  onRetry,
 }) => {
   const theme = useTheme2();
   const showThinking = message.role === 'assistant' && isGenerating && isLastMessage && !message.content;
@@ -370,6 +373,27 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
         {!showThinking && contentSections.length === 0 && (
           <div className="text-sm leading-relaxed whitespace-normal break-words prose prose-sm max-w-none text-primary">
             <MarkdownContent content={message.content} />
+          </div>
+        )}
+
+        {message.error && (
+          <div className="mt-3">
+            <Alert title="Something went wrong" severity="error">
+              <div className="flex flex-col items-start gap-2">
+                <span className="break-words">{message.error}</span>
+                {isLastMessage && onRetry && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    icon="sync"
+                    onClick={onRetry}
+                    data-testid={testIds.chat.retryButton}
+                  >
+                    Retry
+                  </Button>
+                )}
+              </div>
+            </Alert>
           </div>
         )}
       </div>

--- a/src/components/Chat/components/GraphRenderer/GraphRenderer.tsx
+++ b/src/components/Chat/components/GraphRenderer/GraphRenderer.tsx
@@ -45,6 +45,7 @@ const GraphRendererComponent: React.FC<GraphRendererProps> = ({
   const [currentVizType, setCurrentVizType] = useState(visualizationType);
   const [isExpanded, setIsExpanded] = useState(false);
   const [datasourceError, setDatasourceError] = useState<string | null>(null);
+  const [isCopied, setIsCopied] = useState(false);
 
   const vizTypeOptions = [
     { label: 'Time Series', value: 'timeseries' },
@@ -60,6 +61,19 @@ const GraphRendererComponent: React.FC<GraphRendererProps> = ({
   const handleVizTypeChange = useCallback((value: string) => {
     setCurrentVizType(value as typeof visualizationType);
   }, []);
+
+  const handleCopyQuery = useCallback(() => {
+    navigator.clipboard.writeText(query.query).catch(() => {});
+    setIsCopied(true);
+  }, [query.query]);
+
+  useEffect(() => {
+    if (!isCopied) {
+      return;
+    }
+    const timer = setTimeout(() => setIsCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [isCopied]);
 
   useEffect(() => {
     setIsLoading(true);
@@ -312,16 +326,17 @@ const GraphRendererComponent: React.FC<GraphRendererProps> = ({
           borderTop: `1px solid ${theme.colors.border.weak}`,
         }}
       >
-        <code className="text-xs flex-1" style={{ color: theme.colors.text.secondary }}>
+        <code
+          className="text-xs flex-1 min-w-0 whitespace-pre-wrap break-all max-h-24 overflow-y-auto"
+          style={{ color: theme.colors.text.secondary }}
+        >
           {query.query}
         </code>
-        <Tooltip content="Copy query">
+        <Tooltip content={isCopied ? 'Copied!' : 'Copy query'}>
           <IconButton
-            name="copy"
+            name={isCopied ? 'check' : 'copy'}
             size="sm"
-            onClick={() => {
-              navigator.clipboard.writeText(query.query);
-            }}
+            onClick={handleCopyQuery}
             aria-label="Copy query to clipboard"
           />
         </Tooltip>

--- a/src/components/Chat/components/LogsRenderer/LogsRenderer.tsx
+++ b/src/components/Chat/components/LogsRenderer/LogsRenderer.tsx
@@ -197,7 +197,10 @@ export const LogsRenderer: React.FC<LogsRendererProps> = ({
         }}
       >
         <div className="flex items-center justify-between">
-          <code className="text-xs flex-1" style={{ color: theme.colors.text.secondary }}>
+          <code
+            className="text-xs flex-1 min-w-0 whitespace-pre-wrap break-all max-h-24 overflow-y-auto"
+            style={{ color: theme.colors.text.secondary }}
+          >
             {query.query}
           </code>
           <span className="text-xs ml-4" style={{ color: theme.colors.text.secondary }}>

--- a/src/components/Chat/components/NewChatButton/NewChatButton.tsx
+++ b/src/components/Chat/components/NewChatButton/NewChatButton.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, useStyles2, useTheme2 } from '@grafana/ui';
 import { cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { getHoverButtonStyle } from '../../../../theme';
+import { testIds } from '../../../testIds';
 
 interface NewChatButtonProps {
   onConfirm: () => void;
@@ -39,27 +40,17 @@ export function NewChatButton({ onConfirm, isGenerating }: NewChatButtonProps): 
 
   return (
     <div className="relative">
-      <button
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        icon="plus"
         onClick={() => setIsOpen(!isOpen)}
-        className={cx('p-2 rounded-md transition-colors', styles.hoverButton)}
         aria-label="New chat"
-        title="New chat"
-        style={{ color: theme.colors.text.secondary }}
+        data-testid={testIds.chat.newChatButton}
       >
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <line x1="12" y1="5" x2="12" y2="19"></line>
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg>
-      </button>
+        New chat
+      </Button>
 
       {isOpen && (
         <div

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
@@ -11,9 +11,11 @@ interface SessionSidebarProps {
   currentSessionId: string | null;
   isOpen: boolean;
   onClose: () => void;
+  /** When true, render as a persistent panel docked beside the chat instead of a modal overlay. */
+  docked?: boolean;
 }
 
-export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClose }: SessionSidebarProps) {
+export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClose, docked = false }: SessionSidebarProps) {
   const theme = useTheme2();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
   const [loadingAction, setLoadingAction] = useState<string | null>(null);
@@ -85,7 +87,9 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
     try {
       await new Promise((resolve) => setTimeout(resolve, 300)); // Small delay for UX
       await sessionManager.loadSession(sessionId);
-      onClose();
+      if (!docked) {
+        onClose();
+      }
     } finally {
       setLoadingAction(null);
     }
@@ -112,16 +116,18 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex">
-      {/* Backdrop - theme-aware overlay */}
-      <div 
-        className="absolute inset-0" 
-        onClick={onClose}
-        style={{ 
-          backgroundColor: theme.colors.background.canvas,
-          opacity: theme.isDark ? 0.9 : 0.8
-        }}
-      />
+    <div className={docked ? 'flex h-full' : 'fixed inset-0 z-50 flex'}>
+      {/* Backdrop - theme-aware overlay (modal mode only) */}
+      {!docked && (
+        <div
+          className="absolute inset-0"
+          onClick={onClose}
+          style={{
+            backgroundColor: theme.colors.background.canvas,
+            opacity: theme.isDark ? 0.9 : 0.8,
+          }}
+        />
+      )}
 
       {/* Sidebar */}
       <div 
@@ -150,7 +156,9 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
                 setCreatingSession(true);
                 try {
                   await sessionManager.createNewSession();
-                  onClose();
+                  if (!docked) {
+                    onClose();
+                  }
                 } catch {
                   // Session creation is best-effort; UI resets on next interaction
                 } finally {

--- a/src/components/Chat/components/TracesRenderer/TracesRenderer.tsx
+++ b/src/components/Chat/components/TracesRenderer/TracesRenderer.tsx
@@ -273,7 +273,10 @@ export const TracesRenderer: React.FC<TracesRendererProps> = ({
         }}
       >
         <div className="flex items-center justify-between">
-          <code className="text-xs flex-1" style={{ color: theme.colors.text.secondary }}>
+          <code
+            className="text-xs flex-1 min-w-0 whitespace-pre-wrap break-all max-h-24 overflow-y-auto"
+            style={{ color: theme.colors.text.secondary }}
+          >
             {query.query}
           </code>
           <span className="text-xs ml-4" style={{ color: theme.colors.text.secondary }}>

--- a/src/components/Chat/hooks/__tests__/useChat.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChat.test.ts
@@ -1,12 +1,7 @@
 import { act } from 'react';
 import { renderHook } from '@testing-library/react';
 import { useChat } from '../useChat';
-import {
-  reconnectToAgentRun,
-  resolveAgentApproval,
-  getAgentRunStatus,
-  runAgentDetached,
-} from '../../../../services/agentClient';
+import { resolveAgentApproval, getAgentRunStatus } from '../../../../services/agentClient';
 import type { AgentApprovalItem, ChatMessage } from '../../types';
 
 jest.mock('@grafana/runtime', () => ({
@@ -38,8 +33,6 @@ jest.mock('../../../../services/agentClient', () => ({
 
 const resolveAgentApprovalMock = resolveAgentApproval as jest.MockedFunction<typeof resolveAgentApproval>;
 const getAgentRunStatusMock = getAgentRunStatus as jest.MockedFunction<typeof getAgentRunStatus>;
-const runAgentDetachedMock = runAgentDetached as jest.MockedFunction<typeof runAgentDetached>;
-const reconnectToAgentRunMock = reconnectToAgentRun as jest.MockedFunction<typeof reconnectToAgentRun>;
 
 describe('useChat approval handling', () => {
   beforeEach(() => {
@@ -173,34 +166,5 @@ describe('useChat approval handling', () => {
     expect(updatedApproval?.decision).toBe('approved');
     expect(updatedApproval?.error).toBeUndefined();
     expect(updatedApproval?.resolving).toBe(false);
-  });
-
-  it('marks all non-failed plan steps complete when the run finishes', async () => {
-    runAgentDetachedMock.mockResolvedValueOnce({ runId: 'run-1', sessionId: 'session-1', status: 'running' });
-    reconnectToAgentRunMock.mockImplementationOnce(async (_runId, callbacks) => {
-      callbacks.onRunPlan?.({
-        objective: 'Answer the request using available Grafana and MCP evidence.',
-        steps: [
-          { id: 'understand', title: 'Understand request', status: 'completed' },
-          { id: 'evidence', title: 'Gather evidence', status: 'running' },
-          { id: 'answer', title: 'Answer with citations', status: 'pending' },
-        ],
-      });
-      callbacks.onContent({ content: 'Done' });
-      callbacks.onDone({ totalIterations: 2 });
-    });
-
-    const { result } = renderHook(() => useChat({}, null, jest.fn()));
-
-    await act(async () => {
-      result.current.setCurrentInput('Investigate alerts');
-    });
-    await act(async () => {
-      await result.current.sendMessage();
-    });
-
-    const assistantMessages = result.current.chatHistory.filter((message) => message.role === 'assistant');
-    const assistant = assistantMessages[assistantMessages.length - 1];
-    expect(assistant?.runPlan?.steps.map((step) => step.status)).toEqual(['completed', 'completed', 'completed']);
   });
 });

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -278,7 +278,7 @@ export function useChat(
         setChatHistory((prev) =>
           updateLastAssistantMessage(prev, (msg) => ({
             ...msg,
-            content: msg.content ? msg.content + '\n\n**Error:** ' + message : message,
+            error: message,
           }))
         );
       },
@@ -592,7 +592,7 @@ export function useChat(
       setChatHistory((prev) =>
         updateLastAssistantMessage(prev, (msg) => ({
           ...msg,
-          content: error instanceof Error ? error.message : 'An unexpected error occurred',
+          error: error instanceof Error ? error.message : 'An unexpected error occurred',
         }))
       );
       setRetryCount((prev) => prev + 1);
@@ -602,6 +602,20 @@ export function useChat(
         abortControllerRef.current = null;
       }
     }
+  };
+
+  // Re-send the most recent user prompt after a failed run. Appends a fresh
+  // turn rather than mutating the failed one, avoiding stale-closure issues
+  // with sendMessage's history handling.
+  const retryLastMessage = (): void => {
+    if (isGenerating) {
+      return;
+    }
+    const lastUserMessage = [...chatHistory].reverse().find((message) => message.role === 'user');
+    if (!lastUserMessage?.content) {
+      return;
+    }
+    void sendMessage(lastUserMessage.content);
   };
 
   useEffect(() => {
@@ -817,6 +831,7 @@ export function useChat(
     setConversationType,
     setCurrentInput,
     sendMessage,
+    retryLastMessage,
     handleKeyPress,
     clearChat,
     getRunningToolCallsCount,

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -632,8 +632,7 @@ export function useChat(
           setChatHistory((prev) =>
             updateLastAssistantMessage(prev, (msg) => ({
               ...msg,
-              content:
-                msg.content || 'Failed to reconnect to the previous response. Please try sending your message again.',
+              error: err instanceof Error ? err.message : 'Failed to reconnect to the previous response.',
             }))
           );
         }

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -17,8 +17,6 @@ import {
   type EvidenceEvent,
   type FinalReportEvent,
   type MCPUnavailableEvent,
-  type RunPlanEvent,
-  type StepEvent,
   type ToolCallStartEvent,
   type ToolCallResultEvent,
 } from '../../../services/agentClient';
@@ -246,22 +244,7 @@ export function useChat(
         });
       },
       onDone: () => {
-        if (abortController.signal.aborted) {
-          return;
-        }
-        setChatHistory((prev) =>
-          updateLastAssistantMessage(prev, (msg) => ({
-            ...msg,
-            runPlan: msg.runPlan
-              ? {
-                  ...msg.runPlan,
-                  steps: msg.runPlan.steps.map((step) =>
-                    step.status === 'failed' ? step : { ...step, status: 'completed' }
-                  ),
-                }
-              : msg.runPlan,
-          }))
-        );
+        // Terminal event; stream completion is handled by the reconnect loop.
       },
       onReconnect: () => {
         setChatHistory((prev) =>
@@ -284,35 +267,6 @@ export function useChat(
       },
       onMCPUnavailable: (event: MCPUnavailableEvent) => {
         setMcpUnavailable(event.message);
-      },
-      onRunPlan: (event: RunPlanEvent) => {
-        if (abortController.signal.aborted) {
-          return;
-        }
-        setChatHistory((prev) =>
-          updateLastAssistantMessage(prev, (msg) => ({
-            ...msg,
-            runPlan: event,
-          }))
-        );
-      },
-      onStep: (event: StepEvent) => {
-        if (abortController.signal.aborted) {
-          return;
-        }
-        setChatHistory((prev) =>
-          updateLastAssistantMessage(prev, (msg) => ({
-            ...msg,
-            runPlan: msg.runPlan
-              ? {
-                  ...msg.runPlan,
-                  steps: msg.runPlan.steps.map((step) =>
-                    step.id === event.id ? { ...step, status: event.status } : step
-                  ),
-                }
-              : msg.runPlan,
-          }))
-        );
       },
       onEvidence: (event: EvidenceEvent) => {
         if (abortController.signal.aborted) {
@@ -375,14 +329,6 @@ export function useChat(
           updateLastAssistantMessage(prev, (msg) => ({
             ...msg,
             finalReport: event,
-            runPlan: msg.runPlan
-              ? {
-                  ...msg.runPlan,
-                  steps: msg.runPlan.steps.map((step) =>
-                    step.status === 'failed' ? step : { ...step, status: 'completed' }
-                  ),
-                }
-              : msg.runPlan,
           }))
         );
       },

--- a/src/components/Chat/hooks/useSessionManager.ts
+++ b/src/components/Chat/hooks/useSessionManager.ts
@@ -5,7 +5,6 @@ import {
   getSession,
   deleteSession as deleteBackendSession,
   deleteAllSessions as deleteAllBackendSessions,
-  getCurrentSessionId,
   setCurrentSessionId,
   type SessionMetadata,
 } from '../../../services/backendSessionClient';
@@ -35,16 +34,6 @@ export function useSessionManager(
   const [sessions, setSessions] = useState<SessionMetadata[]>([]);
 
   const lastInitializedOrgIdRef = useRef<string | null>(null);
-  const initialChatHistoryLengthRef = useRef<number>(chatHistory.length);
-
-  useEffect(() => {
-    if (chatHistory.length === 0) {
-      initialChatHistoryLengthRef.current = 0;
-    } else if (initialChatHistoryLengthRef.current === 0) {
-      initialChatHistoryLengthRef.current = chatHistory.length;
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId]);
 
   useEffect(() => {
     if (sessionIdFromUrl !== null && sessionIdFromUrl !== currentSessionId) {
@@ -61,7 +50,10 @@ export function useSessionManager(
     }
   }, []);
 
-  // On org change: list sessions and restore last-active session if no URL session
+  // On org change: populate the history sidebar. We intentionally do NOT
+  // restore the last-active session — opening Ask O11y always starts a fresh
+  // chat with past conversations available in the sidebar. URL-driven loading
+  // (shared links, alert investigations) is handled separately in useChat.
   useEffect(() => {
     if (lastInitializedOrgIdRef.current === orgId) {
       return;
@@ -77,22 +69,9 @@ export function useSessionManager(
         if (!cancelled) {
           setSessions(loaded);
         }
-
-        if (initialChatHistoryLengthRef.current === 0 && !sessionIdFromUrl) {
-          const id = await getCurrentSessionId();
-          if (!cancelled && id) {
-            const session = await getSession(id);
-            if (!cancelled) {
-              setCurrentSessionId_(session.id);
-              setChatHistory(session.messages as ChatMessage[]);
-            }
-          }
-        }
       } catch {
-        if (!cancelled) {
-          if (lastInitializedOrgIdRef.current === orgId) {
-            lastInitializedOrgIdRef.current = null;
-          }
+        if (!cancelled && lastInitializedOrgIdRef.current === orgId) {
+          lastInitializedOrgIdRef.current = null;
         }
       }
     };
@@ -102,8 +81,7 @@ export function useSessionManager(
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId, sessionIdFromUrl]);
+  }, [orgId]);
 
   const createNewSession = useCallback(async () => {
     setChatHistory([]);

--- a/src/components/Chat/scenes/ChatInterfaceScene.tsx
+++ b/src/components/Chat/scenes/ChatInterfaceScene.tsx
@@ -32,6 +32,7 @@ function useChatInterface(model: ChatInterfaceScene): ChatInterfaceProps {
     queuedMessageCount: state.queuedMessageCount,
     onStopGeneration: state.onStopGeneration,
     onResolveApproval: state.onResolveApproval,
+    onRetry: state.onRetry,
   };
 }
 
@@ -66,6 +67,7 @@ function ChatInterfaceRenderer({ model }: SceneComponentProps<ChatInterfaceScene
     queuedMessageCount,
     onStopGeneration,
     onResolveApproval,
+    onRetry,
   } = props;
 
   const hasMessages = chatHistory.length > 0;
@@ -98,7 +100,12 @@ function ChatInterfaceRenderer({ model }: SceneComponentProps<ChatInterfaceScene
               }}
             >
               <div className="px-4">
-                <ChatHistory chatHistory={chatHistory} isGenerating={isGenerating} onResolveApproval={onResolveApproval} />
+                <ChatHistory
+                  chatHistory={chatHistory}
+                  isGenerating={isGenerating}
+                  onResolveApproval={onResolveApproval}
+                  onRetry={onRetry}
+                />
                 <div ref={bottomSpacerRef} className="h-16" style={{ scrollMarginBottom: '100px' }} />
               </div>
             </div>

--- a/src/components/Chat/types.ts
+++ b/src/components/Chat/types.ts
@@ -90,6 +90,8 @@ export interface ChatMessage {
   finalReport?: AgentFinalReport;
   pageRefs?: GrafanaPageRef[];
   timestamp?: Date;
+  /** Set when the agent run for this assistant turn failed; surfaced as a retryable error in the UI. */
+  error?: string;
 }
 
 /** Content section returned by splitContentByPromQL */
@@ -123,6 +125,8 @@ export interface ChatInterfaceProps {
     decision: 'approved' | 'rejected',
     approvalScope?: 'once' | 'always'
   ) => Promise<void>;
+  /** Re-send the most recent user prompt after a failed run. */
+  onRetry?: () => void;
 }
 
 /** Props for the Grafana page panel */

--- a/src/components/Chat/types.ts
+++ b/src/components/Chat/types.ts
@@ -23,21 +23,8 @@ export interface RenderedToolCall {
   response?: ToolCallResponse;
 }
 
-export interface AgentPlanStep {
-  id: string;
-  title: string;
-  description?: string;
-  status: string;
-}
-
-export interface AgentRunPlan {
-  objective: string;
-  steps: AgentPlanStep[];
-}
-
 export interface AgentEvidenceItem {
   id: string;
-  stepId?: string;
   title: string;
   summary: string;
   source?: string;
@@ -84,7 +71,6 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   toolCalls?: RenderedToolCall[];
-  runPlan?: AgentRunPlan;
   evidence?: AgentEvidenceItem[];
   approvals?: AgentApprovalItem[];
   finalReport?: AgentFinalReport;

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -47,7 +47,10 @@ export const testIds = {
   home: {
     container: 'data-testid home-container',
   },
-  chat: {},
+  chat: {
+    newChatButton: 'data-testid chat-new-chat-button',
+    retryButton: 'data-testid chat-retry-button',
+  },
   investigation: {
     error: 'data-testid investigation-error',
   },

--- a/src/services/__tests__/agentClient.test.ts
+++ b/src/services/__tests__/agentClient.test.ts
@@ -26,7 +26,6 @@ function createMockCallbacks(): jest.Mocked<AgentCallbacks> {
     onDone: jest.fn(),
     onError: jest.fn(),
     onMCPUnavailable: jest.fn(),
-    onRunPlan: jest.fn(),
     onEvidence: jest.fn(),
     onApprovalRequest: jest.fn(),
     onApprovalResolved: jest.fn(),
@@ -228,8 +227,6 @@ describe('reconnectToAgentRun', () => {
   it('should dispatch progressive agent events to callbacks', async () => {
     const callbacks = createMockCallbacks();
     const sseLines = [
-      'data: {"type":"run_plan","data":{"objective":"Investigate","steps":[{"id":"evidence","title":"Gather evidence","status":"pending"}]}}',
-      '',
       'data: {"type":"evidence","data":{"id":"tc_1","title":"Prometheus","summary":"up is 1"}}',
       '',
       'data: {"type":"approval_request","data":{"approvalId":"tc_2","toolCallId":"tc_2","toolName":"delete_dashboard","risk":"destructive","reason":"write","arguments":"{}"}}',
@@ -249,10 +246,6 @@ describe('reconnectToAgentRun', () => {
 
     await reconnectToAgentRun('run-1', callbacks);
 
-    expect(callbacks.onRunPlan).toHaveBeenCalledWith({
-      objective: 'Investigate',
-      steps: [{ id: 'evidence', title: 'Gather evidence', status: 'pending' }],
-    });
     expect(callbacks.onEvidence).toHaveBeenCalledWith({ id: 'tc_1', title: 'Prometheus', summary: 'up is 1' });
     expect(callbacks.onApprovalRequest).toHaveBeenCalledWith({
       approvalId: 'tc_2',

--- a/src/services/agentClient.ts
+++ b/src/services/agentClient.ts
@@ -56,27 +56,8 @@ export interface MCPUnavailableEvent {
   message: string;
 }
 
-export interface PlanStep {
-  id: string;
-  title: string;
-  description?: string;
-  status: 'pending' | 'running' | 'completed' | 'failed' | string;
-}
-
-export interface RunPlanEvent {
-  objective: string;
-  steps: PlanStep[];
-}
-
-export interface StepEvent {
-  id: string;
-  title?: string;
-  status: string;
-}
-
 export interface EvidenceEvent {
   id: string;
-  stepId?: string;
   title: string;
   summary: string;
   source?: string;
@@ -119,9 +100,6 @@ export type SSEEvent =
   | { type: 'error'; data: ErrorEvent; sequence: number }
   | { type: 'run_started'; data: RunStartedEvent; sequence: number }
   | { type: 'mcp_unavailable'; data: MCPUnavailableEvent; sequence: number }
-  | { type: 'run_plan'; data: RunPlanEvent; sequence: number }
-  | { type: 'step_start'; data: StepEvent; sequence: number }
-  | { type: 'step_done'; data: StepEvent; sequence: number }
   | { type: 'evidence'; data: EvidenceEvent; sequence: number }
   | { type: 'approval_request'; data: ApprovalRequestEvent; sequence: number }
   | { type: 'approval_resolved'; data: ApprovalResolvedEvent; sequence: number }
@@ -136,8 +114,6 @@ export interface AgentCallbacks {
   onRunStarted?: (event: RunStartedEvent) => void;
   onReconnect?: () => void;
   onMCPUnavailable?: (event: MCPUnavailableEvent) => void;
-  onRunPlan?: (event: RunPlanEvent) => void;
-  onStep?: (event: StepEvent) => void;
   onEvidence?: (event: EvidenceEvent) => void;
   onApprovalRequest?: (event: ApprovalRequestEvent) => void;
   onApprovalResolved?: (event: ApprovalResolvedEvent) => void;
@@ -154,7 +130,6 @@ export interface AgentRunStatus {
   updatedAt: string;
   events: SSEEvent[];
   trace?: {
-    plan?: PlanStep[];
     evidence?: EvidenceEvent[];
     approvals?: Array<
       ApprovalRequestEvent & { decision?: string; comment?: string; createdAt?: string; resolvedAt?: string }
@@ -295,13 +270,6 @@ function dispatchEvent(event: SSEEvent, callbacks: AgentCallbacks): void {
       break;
     case 'mcp_unavailable':
       callbacks.onMCPUnavailable?.(event.data);
-      break;
-    case 'run_plan':
-      callbacks.onRunPlan?.(event.data);
-      break;
-    case 'step_start':
-    case 'step_done':
-      callbacks.onStep?.(event.data);
       break;
     case 'evidence':
       callbacks.onEvidence?.(event.data);

--- a/tests/serviceGraph.spec.ts
+++ b/tests/serviceGraph.spec.ts
@@ -22,13 +22,15 @@ test.describe('Service Graph settings', () => {
           nodes: [
             { id: 'checkout', label: 'checkout', type: 'service' },
             { id: 'payments', label: 'payments', type: 'service' },
-            { id: 'ledger', label: 'ledger', type: 'service' },
+            { id: 'checkout-ns', label: 'checkout-ns', type: 'namespace' },
+            { id: 'mmcx-prod-us', label: 'mmcx-prod-us', type: 'cluster' },
           ],
           edges: [
             { id: 'checkout->payments', source: 'checkout', target: 'payments', label: 'calls' },
-            { id: 'payments->ledger', source: 'payments', target: 'ledger', label: 'depends' },
+            { id: 'checkout->checkout-ns', source: 'checkout', target: 'checkout-ns', label: 'deployed in' },
+            { id: 'checkout->mmcx-prod-us', source: 'checkout', target: 'mmcx-prod-us', label: 'runs on' },
           ],
-          rawFactCount: 2,
+          rawFactCount: 3,
         }),
       });
     });
@@ -36,8 +38,9 @@ test.describe('Service Graph settings', () => {
     await openSettingsTab(page, 'service-graph');
 
     await expect(page.getByRole('group', { name: /service graph/i })).toBeVisible();
-    await expect(page.locator('[data-testid="data-testid ac-service-graph-summary"]')).toContainText('3 services');
-    await expect(page.locator('[data-testid="data-testid ac-service-graph-summary"]')).toContainText('2 links');
+    await expect(page.locator('[data-testid="data-testid ac-service-graph-summary"]')).toContainText('2 services');
+    await expect(page.locator('[data-testid="data-testid ac-service-graph-summary"]')).toContainText('4 nodes');
+    await expect(page.locator('[data-testid="data-testid ac-service-graph-summary"]')).toContainText('3 links');
     await expect(page.getByTestId('service-graph-scene')).toBeVisible();
     await expect
       .poll(() => topologyRequests.some((url) => url.includes('maxNodes=100') && url.includes('maxEdges=200')))


### PR DESCRIPTION
## Summary

Addresses the top friction points from the internal Ask O11y feedback round (14 respondents), plus related cleanup.

### Feedback UX quick wins
- **Fresh chat by default + docked history.** Stop auto-restoring the last session on open; the history sidebar is now a persistent **docked side panel** (was a modal) so past conversations are discoverable. Hidden in read-only/shared views.
- **Discoverable New Chat button.** Replaced the easy-to-miss plus icon with a labeled "New chat" button.
- **Query blocks no longer truncate.** Long PromQL/LogQL/TraceQL wrap + scroll instead of being clipped; the graph copy button gained the same "Copied!" feedback as logs/traces.
- **Retryable errors.** Agent-run errors now surface as an `Alert` with a **Retry** button that re-sends the last prompt, instead of appending raw error text.

### Cleanup
- **Removed the "Run progress" block** from assistant messages (a static, canned step scaffold that added noise).
- **Removed the dead run-plan pipeline end-to-end** (frontend types/events/callbacks + backend `buildRunPlan`/events/runstore). `final_report` behaviour is unchanged. Real progress is still shown via the tool-calls section.

### Also included
- `fix: dead code` — Graphiti/topology query improvements (`pkg/plugin/topology.go`, `plugin.go`), supporting scripts, and minor config/test updates. Bundled here per request.

## Testing
- `npm run build` ✅, `npm run typecheck` ✅, `eslint ./src` 0 errors ✅
- `npm run test:ci` — 491 unit tests pass ✅ (added coverage for error/retry)
- `go build ./pkg/...` ✅, `go test ./pkg/agent/... ./pkg/plugin/...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default session behavior and agent SSE surface area (run_plan removed); topology refresh issues more sequential MCP calls, though bounded to reduce timeout risk.
> 
> **Overview**
> Improves Ask O11y chat UX from internal feedback and **removes the canned run-plan/progress pipeline** end-to-end (agent SSE, run trace, and UI), while keeping **`final_report`**, tool calls, evidence, and approvals.
> 
> **Chat:** Opens on a **fresh conversation** (no auto-restore of last session); **session history is a docked sidebar** by default. **Labeled “New chat”**, **retryable agent errors** via `Alert` + Retry, and **query footers** that wrap/scroll with copy feedback on graphs.
> 
> **Service graph:** Graphiti topology refresh now **searches typed nodes** and optional **center-node fact lookups** (capped), with **richer fact/node parsing** (UUIDs, namespaces/clusters/queues) and settings summary showing **service vs total node counts**.
> 
> **Tooling:** Adds local scripts to **restore Redis dumps** and **export recent Ask O11y user metadata** (gitignored); minor Claude/git allowlist updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e9c1aff88711e5e6e410601cf6c36f1f86bc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->