### PR TITLE
fix(backend): add prompt guardrails from feedback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,7 +130,7 @@ jobs:
           docker compose up -d grafana
 
       - name: Wait for Grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@main
+        uses: grafana/plugin-actions/wait-for-grafana@2ecc2ba7168309f04010b5b637530b877d67e4ff # main
         with:
           url: http://localhost:3000/login
 

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -69,7 +69,7 @@ jobs:
           echo "modulets=${MODULETS}" >> $GITHUB_OUTPUT
 
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@main
+        uses: grafana/plugin-actions/is-compatible@2ecc2ba7168309f04010b5b637530b877d67e4ff # main
         with:
           module: ${{ steps.find-module-ts.outputs.modulets }}
           comment-pr: 'no'

--- a/pkg/plugin/prompt_defaults.go
+++ b/pkg/plugin/prompt_defaults.go
@@ -29,6 +29,12 @@ If a parallel call fails, fall back to sequential.
 - Don't call tools to confirm what the user just told you
 - For query syntax questions, answer directly from your knowledge
 
+### Write Actions Require Explicit Intent
+
+- **Default to read-only investigation.** Never create, modify, or delete resources — alerts, silences, alerting rules, dashboards, panels, annotations, or any other configuration — unless the user explicitly asks for that action in the current turn.
+- If a write seems helpful but wasn't requested, **propose it and wait for confirmation** rather than performing it. Describe what you would change and ask the user to confirm.
+- Read/query/list/search tools are always fine to use proactively; only mutating actions need explicit intent.
+
 ---
 
 ## Domain-Specific Workflows
@@ -75,6 +81,7 @@ This keeps each tool call payload small and reliable.
 3. **UIDs come from tools or the snapshot below**: Never hardcode datasource UIDs. If the "Known Datasource UIDs" block below is missing or empty, call ` + "`list_datasources`" + ` before any datasource-bound query.
 4. **Respect truncation notices**: If you see a ` + "`[NOTICE: Conversation history truncated ...]`" + ` system message, treat earlier turns as unknown — re-query tools for any data you intend to cite.
 5. **Transport failures = UNAVAILABLE**: If you see a ` + "`[SYSTEM: MCP transport failure ...]`" + ` tool result, the data is UNAVAILABLE — do not substitute. Either retry once or tell the user the data is currently unavailable.
+6. **Capability honesty**: Only claim a capability you can back with a tool available in this run. If the user asks for something Grafana or your tools cannot do — or no tool exists for it — say so plainly instead of inventing a workflow or assuming a feature exists. Do not describe Grafana behaviour you cannot verify with a tool.
 {{if .DatasourceSnapshot}}
 
 ## Known Datasource UIDs (this run)
@@ -96,6 +103,7 @@ This keeps each tool call payload small and reliable.
 
 - Before any time-bounded investigation, establish the real current time using the time tool
 - Build all time windows relative to that value (e.g., last 1h, last 30min from now) — never use hardcoded dates from training data
+- **Honor the user's time range exactly.** When the user names a range — absolute ("yesterday 14:00–16:00") or relative ("last 24h", "during the incident window") — use precisely that range for every query. Do not silently fall back to a default like last 1h, and do not drift to a different period because it looks more interesting; if you must deviate, state why before doing so.
 - When a query returns no results, the first thing to check is whether the time window actually covers the period of interest
 
 ### Loki Label Discovery

--- a/pkg/plugin/prompts_test.go
+++ b/pkg/plugin/prompts_test.go
@@ -45,6 +45,31 @@ func TestBuildSystemPrompt_AntiHallucinationContractAlwaysPresent(t *testing.T) 
 	}
 }
 
+func TestBuildSystemPrompt_FeedbackGuardrailsPresent(t *testing.T) {
+	r, err := NewPromptRegistry(PluginSettings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := r.BuildSystemPrompt(BuildToolContext("Org1", "Editor"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"no unprompted writes", "Write Actions Require Explicit Intent"},
+		{"capability honesty", "Capability honesty"},
+		{"honor user time range", "Honor the user's time range exactly"},
+	}
+	for _, tc := range cases {
+		if !strings.Contains(out, tc.snippet) {
+			t.Errorf("expected %q guardrail (%q) in system prompt", tc.name, tc.snippet)
+		}
+	}
+}
+
 func TestBuildSystemPrompt_DatasourceSnapshotSlot(t *testing.T) {
 	r, err := NewPromptRegistry(PluginSettings{})
 	if err != nil {


### PR DESCRIPTION
## Summary

Tightens the default system prompt to fix three recurring complaints from the internal Ask O11y feedback round. All changes are in `DefaultSystemPrompt`; `/api/prompt-defaults` returns this constant directly, so the config UI stays in sync (no route/OpenAPI change). Provisioned custom prompts intentionally don't inherit these.

- **No unprompted writes** — default to read-only investigation; propose and confirm before creating/modifying/deleting any resource (alerts, dashboards, silences, rules, annotations).
- **Capability honesty** — only claim capabilities backed by an available tool; say so plainly when something is unsupported instead of inventing a workflow.
- **Honor user-specified time ranges** — use exactly the range the user names, no silent fallback to a default window.

## Testing
- `go test ./pkg/...` ✅ (extended `prompts_test.go` to assert all three guardrails appear in the assembled prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to default prompt text, a unit test, and CI action SHA pins; no auth, data paths, or API contract changes.
> 
> **Overview**
> Strengthens the **default** Ask O11y system prompt (`DefaultSystemPrompt`) to address recurring feedback: mutating Grafana resources only when the user explicitly asks (otherwise propose and confirm), a new **capability honesty** rule in the anti-hallucination contract, and strict use of user-specified time ranges without silent defaults.
> 
> Adds `TestBuildSystemPrompt_FeedbackGuardrailsPresent` so the assembled prompt always includes those three snippets. Custom provisioned prompts still override via settings and do not pick up these defaults automatically; `/api/prompt-defaults` continues to serve the updated constant.
> 
> CI pins `grafana/plugin-actions` **wait-for-grafana** and **is-compatible** to commit `2ecc2ba…` instead of `@main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243444e8a77512b1dd651d66eb51e6e8392b098a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->