### PR TITLE
fix(deps): revert react-router-dom to v6 for @grafana/scenes compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "marked": "^17.0.6",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "react-router-dom": "^7.0.0",
+        "react-router-dom": "^6.30.3",
         "react-use": "^17.6.1",
         "rxjs": "7.8.2",
         "streamdown": "^2.1.0"
@@ -5990,12 +5990,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -18524,56 +18518,44 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
-      "integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.0.0"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-router-dom/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+    "node_modules/react-router-dom/node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
-      "integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.6.0",
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
+        "react": ">=16.8"
       }
     },
     "node_modules/react-select": {
@@ -19563,12 +19545,6 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -21143,12 +21119,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "marked": "^17.0.6",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "react-router-dom": "^7.0.0",
+    "react-router-dom": "^6.30.3",
     "react-use": "^17.6.1",
     "rxjs": "7.8.2",
     "streamdown": "^2.1.0"


### PR DESCRIPTION
## Summary
- PR #164 bumped `react-router-dom` from `^6.22.0` to `^7.0.0` in `package.json`
- `@grafana/scenes@8.13.3` (added in #156, the Grafana 13.x migration) peer-depends on `react-router-dom@^6.28.0`
- This made `npm ci` fail with `ERESOLVE` on `main` and every open PR - CI, commitlint, E2E, and the Grafana compatibility check have all been red since #164 merged

## Fix
Pin `react-router-dom` back to `^6.30.3` (latest compatible v6). No app code changes needed - nothing in `src/` uses v7-only APIs (only `Route`, `Routes`, `useNavigate`, `useLocation`, `useParams`, all v6-compatible).

## Test plan
- [x] `npm install` resolves without `--legacy-peer-deps`
- [x] `npm run typecheck`
- [x] `npm run lint` (clean on tracked source)
- [x] `npm run test:ci` (491/491 passing)
- [x] `npm run build:frontend:prod`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change aligning with existing v6 router usage; no runtime code changes in the diff.
> 
> **Overview**
> **Downgrades `react-router-dom` from `^7.0.0` to `^6.30.3`** in `package.json` and refreshes `package-lock.json` so installs satisfy `@grafana/scenes@8.13.3`, which peer-requires `react-router-dom@^6.28.0`. The v7 bump had been causing `npm ci` **ERESOLVE** failures across CI.
> 
> There are **no application source changes**; routing in `src/` already uses v6-compatible APIs (`Route`, `Routes`, `useNavigate`, `useLocation`, `useParams`). The lockfile also drops v7-only transitive deps (`cookie`, `set-cookie-parser`, `turbo-stream`, `@types/cookie`) in favor of the v6 `@remix-run/router` stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6203f82a2036932dbf1070382f2966f022e0b30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->