### PR TITLE
feat(frontend): support Grafana subpath deployments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10911,9 +10911,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -12545,9 +12545,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14452,9 +14452,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -16412,9 +16412,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -132,10 +132,12 @@
       "dompurify": "^3.3.2"
     },
     "lodash-es": "^4.18.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "undici": "^7.28.0",
     "ws": "^8.21.1",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.3.1",
+    "nanoid": "^3.3.17",
     "@grafana/llm": {
       "@grafana/data": "$@grafana/data",
       "@grafana/runtime": "$@grafana/runtime"

--- a/src/components/Chat/hooks/useEmbeddingAllowed.ts
+++ b/src/components/Chat/hooks/useEmbeddingAllowed.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { withSubpath } from '../../../utils/subpath';
 
 let cachedResult: boolean | null = null;
 let fetchPromise: Promise<boolean> | null = null;
@@ -18,7 +19,7 @@ export function useEmbeddingAllowed(): boolean | null {
     let mounted = true;
 
     if (!fetchPromise) {
-      fetchPromise = fetch(window.location.origin + '/api/health', { method: 'HEAD' })
+      fetchPromise = fetch(withSubpath('/api/health'), { method: 'HEAD' })
         .then((response) => {
           const xFrameOptions = response.headers.get('X-Frame-Options');
           cachedResult = !xFrameOptions || xFrameOptions.toLowerCase() !== 'deny';

--- a/src/services/agentClient.ts
+++ b/src/services/agentClient.ts
@@ -1,3 +1,5 @@
+import { pluginUrl } from '../utils/subpath';
+
 export interface AgentRunRequest {
   message: string;
   type?: 'chat' | 'investigation' | 'performance';
@@ -139,8 +141,8 @@ export interface AgentRunStatus {
   error?: string;
 }
 
-const AGENT_RUN_URL = '/api/plugins/consensys-asko11y-app/resources/api/agent/run';
-const AGENT_RUNS_URL = '/api/plugins/consensys-asko11y-app/resources/api/agent/runs';
+const AGENT_RUN_URL = pluginUrl('/api/agent/run');
+const AGENT_RUNS_URL = pluginUrl('/api/agent/runs');
 
 export const SSE_IDLE_TIMEOUT_MS = 60_000;
 

--- a/src/services/agentTopologyClient.ts
+++ b/src/services/agentTopologyClient.ts
@@ -1,3 +1,5 @@
+import { pluginUrl } from '../utils/subpath';
+
 export interface TopologyNode {
   id: string;
   label: string;
@@ -25,7 +27,7 @@ export interface AgentTopologyOptions {
   maxEdges?: number;
 }
 
-const AGENT_TOPOLOGY_URL = '/api/plugins/consensys-asko11y-app/resources/api/agent/topology';
+const AGENT_TOPOLOGY_URL = pluginUrl('/api/agent/topology');
 
 function orgIdHeaders(orgId?: string): Record<string, string> {
   if (orgId) {

--- a/src/services/backendSessionClient.ts
+++ b/src/services/backendSessionClient.ts
@@ -1,8 +1,9 @@
 import { config } from '@grafana/runtime';
 import type { ChatMessage } from '../components/Chat/types';
+import { pluginUrl } from '../utils/subpath';
 
-const SESSIONS_URL = '/api/plugins/consensys-asko11y-app/resources/api/sessions';
-const GRAPHITI_URL = '/api/plugins/consensys-asko11y-app/resources/api/graphiti';
+const SESSIONS_URL = pluginUrl('/api/sessions');
+const GRAPHITI_URL = pluginUrl('/api/graphiti');
 
 function orgHeaders(): Record<string, string> {
   const orgId = String(config.bootData.user.orgId || '1');

--- a/src/services/llmModels.ts
+++ b/src/services/llmModels.ts
@@ -1,3 +1,5 @@
+import { withSubpath } from '../utils/subpath';
+
 export type LLMModel = 'base' | 'large';
 export type LLMModelSelection = 'auto' | LLMModel;
 
@@ -28,8 +30,8 @@ interface LLMPluginSettingsResponse {
   };
 }
 
-const LLM_MODELS_URL = '/api/plugins/grafana-llm-app/resources/llm/v1/models';
-const LLM_SETTINGS_URL = '/api/plugins/grafana-llm-app/settings';
+const LLM_MODELS_URL = withSubpath('/api/plugins/grafana-llm-app/resources/llm/v1/models');
+const LLM_SETTINGS_URL = withSubpath('/api/plugins/grafana-llm-app/settings');
 const SUPPORTED_MODELS: LLMModel[] = ['base', 'large'];
 
 function isLLMModel(value: string | undefined): value is LLMModel {

--- a/src/utils/__tests__/subpath.test.ts
+++ b/src/utils/__tests__/subpath.test.ts
@@ -1,0 +1,31 @@
+import { config } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  config: { appSubUrl: '' },
+}));
+
+import { getSubpath, withSubpath, pluginUrl } from '../subpath';
+
+describe('subpath', () => {
+  afterEach(() => {
+    (config as { appSubUrl: string }).appSubUrl = '';
+  });
+
+  it('returns empty subpath at root', () => {
+    expect(getSubpath()).toBe('');
+    expect(withSubpath('/api/health')).toBe('/api/health');
+    expect(pluginUrl('/api/sessions')).toBe('/api/plugins/consensys-asko11y-app/resources/api/sessions');
+  });
+
+  it('prefixes urls with the configured subpath', () => {
+    (config as { appSubUrl: string }).appSubUrl = '/grafana';
+
+    expect(getSubpath()).toBe('/grafana');
+    expect(withSubpath('/api/health')).toBe('/grafana/api/health');
+    expect(pluginUrl('/api/sessions')).toBe('/grafana/api/plugins/consensys-asko11y-app/resources/api/sessions');
+  });
+
+  it('normalizes a plugin path without a leading slash', () => {
+    expect(pluginUrl('api/sessions')).toBe('/api/plugins/consensys-asko11y-app/resources/api/sessions');
+  });
+});

--- a/src/utils/subpath.ts
+++ b/src/utils/subpath.ts
@@ -1,0 +1,19 @@
+import { config } from '@grafana/runtime';
+
+const PLUGIN_BASE = '/api/plugins/consensys-asko11y-app/resources';
+
+/** Grafana's sub-path prefix when served behind a reverse proxy (e.g. `/grafana`), or '' at root. */
+export function getSubpath(): string {
+  return config.appSubUrl || '';
+}
+
+/** Prefixes an absolute path with Grafana's sub-path. Use for non-plugin (Grafana core, other plugins) URLs. */
+export function withSubpath(path: string): string {
+  return `${getSubpath()}${path}`;
+}
+
+/** Builds a URL under this plugin's resources route, honoring Grafana's sub-path. */
+export function pluginUrl(path: string): string {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return withSubpath(`${PLUGIN_BASE}${normalized}`);
+}


### PR DESCRIPTION
## Summary
Grafana can be deployed behind a reverse proxy at a sub-path  exposed through `config.appSubUrl`.  This plugin's `fetch()` calls that used hardcoded absolute paths bypassed that sub-path, breaking every request in that deployment topology. Grafana SDK's own `getBackendSrv().fetch()`  already resolves sub-paths correctly, so this only touches the raw `fetch()` call sites. 

  ## Changes
  - Add `src/utils/subpath.ts`: `pluginUrl()` for this plugin's own resource routes, `withSubpath()` for other-origin routes (Grafana core, other plugins).
  - Route `agentClient.ts`, `agentTopologyClient.ts`, `backendSessionClient.ts`     through `pluginUrl()`.
  - Route `llmModels.ts` (grafana-llm-app) and `useEmbeddingAllowed.ts`  (Grafana core `/api/health`) through `withSubpath()` instead — these aren't this plugin's own resource route, so `pluginUrl()` would double the path prefix.
  
  ## Test plan
  - [x] `tsc --noEmit`
  - [x] `eslint` on changed files
  - [x] `jest` — new `subpath.test.ts` plus existing suites for the touched clients (23/23 passing)
  - [x] Manual verification using sub-path based grafana deployment (I tested this locally; happy to share repro steps if
  useful for review)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all frontend HTTP entry points for the agent and sessions; mis-prefixing would break requests in sub-path installs, though behavior at root is covered by unit tests.
> 
> **Overview**
> Fixes broken **raw `fetch()`** calls when Grafana is served under a reverse-proxy sub-path (`config.appSubUrl`).
> 
> Adds **`src/utils/subpath.ts`** with `getSubpath()`, `withSubpath()` for Grafana core and other plugins, and `pluginUrl()` for this plugin’s resource routes. **Agent, topology, session, LLM model, and embedding health** clients now build URLs through those helpers instead of hardcoded absolute paths. **`subpath.test.ts`** covers root and `/grafana` prefix behavior.
> 
> **`package.json` overrides** bump transitive deps (`js-yaml`, `fast-uri`, plus new pins for `ip-address` and `nanoid`); **`package-lock.json`** reflects those versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052db1206ba19ee9d3b3e816077a0b1417529be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->