### PR TITLE
feat(session): add per-session usage stats endpoint

### DIFF
--- a/pkg/agent/llm_client.go
+++ b/pkg/agent/llm_client.go
@@ -140,6 +140,7 @@ func (c *LLMClient) ChatCompletion(ctx context.Context, req ChatCompletionReques
 	}()
 
 	req.Stream = true
+	req.StreamOptions = &StreamOptions{IncludeUsage: true}
 
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -129,6 +129,11 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	truncationRetries := 0
 	pendingTruncationNudge := false
 
+	// Run-level usage/tool-call totals, surfaced on the "done" event so the
+	// caller can persist per-session stats (tokens, turns, tool calls).
+	var promptTokens, completionTokens, totalTokens int64
+	toolCallCount := 0
+
 	for iteration := 0; iteration < maxIter; iteration++ {
 		if ctx.Err() != nil {
 			return
@@ -174,6 +179,12 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 				Data: llmErrorEvent(err),
 			})
 			return
+		}
+
+		if resp.Usage != nil {
+			promptTokens += int64(resp.Usage.PromptTokens)
+			completionTokens += int64(resp.Usage.CompletionTokens)
+			totalTokens += int64(resp.Usage.TotalTokens)
 		}
 
 		msg := resp.Choices[0].Message
@@ -239,7 +250,13 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 			}
 			a.send(ctx, eventCh, SSEEvent{
 				Type: "done",
-				Data: DoneEvent{TotalIterations: iteration + 1},
+				Data: DoneEvent{
+					TotalIterations:  iteration + 1,
+					PromptTokens:     promptTokens,
+					CompletionTokens: completionTokens,
+					TotalTokens:      totalTokens,
+					ToolCallCount:    toolCallCount,
+				},
 			})
 			return
 		}
@@ -251,6 +268,7 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 			if ctx.Err() != nil {
 				return
 			}
+			toolCallCount++
 
 			a.send(ctx, eventCh, SSEEvent{
 				Type: "tool_call_start",

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -977,6 +977,72 @@ func TestAgentLoop_TruncatedToolCall_LastIterationSurfacesCleanError(t *testing.
 	}
 }
 
+func TestAgentLoop_AccumulatesUsageAndToolCallsIntoDoneEvent(t *testing.T) {
+	// Two LLM calls: one with a tool call, one final text response. Each
+	// carries its own token usage — the done event must report the sum across
+	// both calls, plus a count of the one tool call actually executed.
+	loop, serverURL, cleanup := setupTestLoop(t, []ChatCompletionResponse{
+		{
+			ID: "1",
+			Choices: []Choice{{
+				Message: Message{
+					Role: "assistant",
+					ToolCalls: []ToolCall{{
+						ID:   "tc_1",
+						Type: "function",
+						Function: FunctionCall{
+							Name:      "unknown_tool",
+							Arguments: `{"query": "up"}`,
+						},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+			Usage: &Usage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+		},
+		{
+			ID: "2",
+			Choices: []Choice{{
+				Message:      Message{Role: "assistant", Content: "Based on the error..."},
+				FinishReason: "stop",
+			}},
+			Usage: &Usage{PromptTokens: 150, CompletionTokens: 30, TotalTokens: 180},
+		},
+	})
+	defer cleanup()
+
+	eventCh := make(chan SSEEvent, 32)
+	req := LoopRequest{
+		Messages:     []Message{{Role: "user", Content: "query prometheus"}},
+		SystemPrompt: "sys",
+		GrafanaURL:   serverURL,
+		AuthToken:    "test-token",
+		UserRole:     "Admin",
+		OrgID:        "1",
+	}
+
+	go loop.Run(context.Background(), req, eventCh)
+	events := collectEvents(eventCh)
+
+	last := events[len(events)-1]
+	if last.Type != "done" {
+		t.Fatalf("expected last event to be done, got %q", last.Type)
+	}
+	done, ok := last.Data.(DoneEvent)
+	if !ok {
+		t.Fatalf("expected DoneEvent, got %T", last.Data)
+	}
+	if done.PromptTokens != 250 || done.CompletionTokens != 50 || done.TotalTokens != 300 {
+		t.Fatalf("unexpected token totals: %+v", done)
+	}
+	if done.ToolCallCount != 1 {
+		t.Fatalf("expected ToolCallCount 1, got %d", done.ToolCallCount)
+	}
+	if done.TotalIterations != 2 {
+		t.Fatalf("expected TotalIterations 2, got %d", done.TotalIterations)
+	}
+}
+
 func TestAgentLoop_ContextCancellation(t *testing.T) {
 	// Slow server — context will be cancelled
 	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -35,11 +35,19 @@ type OpenAIFunction struct {
 }
 
 type ChatCompletionRequest struct {
-	Model     string       `json:"model,omitempty"`
-	Messages  []Message    `json:"messages"`
-	Tools     []OpenAITool `json:"tools,omitempty"`
-	Stream    bool         `json:"stream,omitempty"`
-	MaxTokens int          `json:"max_tokens,omitempty"`
+	Model         string         `json:"model,omitempty"`
+	Messages      []Message      `json:"messages"`
+	Tools         []OpenAITool   `json:"tools,omitempty"`
+	Stream        bool           `json:"stream,omitempty"`
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
+	MaxTokens     int            `json:"max_tokens,omitempty"`
+}
+
+// StreamOptions.IncludeUsage requests a final usage-bearing chunk on an
+// OpenAI-compatible streaming response — without it, providers omit token
+// counts entirely from the stream.
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type ChatCompletionResponse struct {
@@ -132,7 +140,11 @@ type MCPUnavailableEvent struct {
 }
 
 type DoneEvent struct {
-	TotalIterations int `json:"totalIterations"`
+	TotalIterations  int   `json:"totalIterations"`
+	PromptTokens     int64 `json:"promptTokens"`
+	CompletionTokens int64 `json:"completionTokens"`
+	TotalTokens      int64 `json:"totalTokens"`
+	ToolCallCount    int   `json:"toolCallCount"`
 }
 
 type ErrorEvent struct {

--- a/pkg/plugin/openapi/openapi.json
+++ b/pkg/plugin/openapi/openapi.json
@@ -1527,6 +1527,55 @@
         }
       }
     },
+    "/api/sessions/{sessionId}/stats": {
+      "get": {
+        "summary": "Get session usage stats",
+        "description": "Returns cumulative usage stats (tokens, turns, tool calls) for a session, accumulated across all its agent runs. Only the session owner (same user + org) can access it. Omits the full message history — use GET /api/sessions/{sessionId} for the full transcript.",
+        "operationId": "getSessionStats",
+        "tags": [
+          "Sessions"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "description": "Session ID (base64 URL-safe 32-byte token)",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{43}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/X-Grafana-Org-Id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session usage stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStats"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/api/sessions/share": {
       "post": {
         "summary": "Create share link",
@@ -3100,6 +3149,33 @@
               "large"
             ],
             "description": "LLM app model abstraction locked to this session, if selected"
+          },
+          "runCount": {
+            "type": "integer",
+            "description": "Number of completed agent runs (turns) in this session"
+          },
+          "totalIterations": {
+            "type": "integer",
+            "description": "Sum of agent-loop iterations (LLM round-trips) across all runs"
+          },
+          "toolCallCount": {
+            "type": "integer",
+            "description": "Sum of tool calls executed across all runs"
+          },
+          "promptTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM prompt tokens across all runs"
+          },
+          "completionTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM completion tokens across all runs"
+          },
+          "totalTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM prompt + completion tokens across all runs"
           }
         },
         "required": [
@@ -3154,6 +3230,62 @@
           "createdAt",
           "updatedAt",
           "messageCount"
+        ]
+      },
+      "SessionStats": {
+        "type": "object",
+        "description": "Cumulative usage stats for a session, accumulated across all its agent runs",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session ID (base64 URL-safe 32-byte token)"
+          },
+          "runCount": {
+            "type": "integer",
+            "description": "Number of completed agent runs (turns) in this session"
+          },
+          "totalIterations": {
+            "type": "integer",
+            "description": "Sum of agent-loop iterations (LLM round-trips) across all runs"
+          },
+          "toolCallCount": {
+            "type": "integer",
+            "description": "Sum of tool calls executed across all runs"
+          },
+          "promptTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM prompt tokens across all runs"
+          },
+          "completionTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM completion tokens across all runs"
+          },
+          "totalTokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Sum of LLM prompt + completion tokens across all runs"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "sessionId",
+          "runCount",
+          "totalIterations",
+          "toolCallCount",
+          "promptTokens",
+          "completionTokens",
+          "totalTokens",
+          "createdAt",
+          "updatedAt"
         ]
       }
     }

--- a/pkg/plugin/openapi/openapi_test.go
+++ b/pkg/plugin/openapi/openapi_test.go
@@ -109,6 +109,7 @@ func TestSpecHasAllEndpoints(t *testing.T) {
 		"/api/sessions/current",
 		"/api/sessions/{sessionId}",
 		"/api/sessions/{sessionId}/shares",
+		"/api/sessions/{sessionId}/stats",
 		"/api/sessions/share",
 		"/api/sessions/shared/{shareId}",
 		"/api/sessions/share/{shareId}",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -989,6 +989,21 @@ func (p *Plugin) consumeAgentEvents(runID, sessionID string, userID, orgID int64
 	switch lastEvent.Type {
 	case "done":
 		p.runStore.FinishRun(runID, RunStatusCompleted, "")
+		if sessionID != "" {
+			if de, ok := lastEvent.Data.(agent.DoneEvent); ok {
+				delta := SessionStatsDelta{
+					RunCount:         1,
+					TotalIterations:  de.TotalIterations,
+					ToolCallCount:    de.ToolCallCount,
+					PromptTokens:     de.PromptTokens,
+					CompletionTokens: de.CompletionTokens,
+					TotalTokens:      de.TotalTokens,
+				}
+				if err := p.sessionStore.IncrementStats(sessionID, userID, orgID, delta); err != nil {
+					p.logger.Warn("Failed to increment session stats", "error", err, "sessionId", sessionID)
+				}
+			}
+		}
 	case "error":
 		var errMsg string
 		if ee, ok := lastEvent.Data.(agent.ErrorEvent); ok {
@@ -2214,7 +2229,8 @@ func (p *Plugin) handleSessionCurrent(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleSessionRouter dispatches /api/sessions/{id} and /api/sessions/{id}/shares.
+// handleSessionRouter dispatches /api/sessions/{id}, /api/sessions/{id}/shares,
+// and /api/sessions/{id}/stats.
 func (p *Plugin) handleSessionRouter(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 	prefix := "/api/sessions/"
@@ -2238,6 +2254,16 @@ func (p *Plugin) handleSessionRouter(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		p.handleGetSessionShares(w, r, sessionID)
+		return
+	}
+
+	// /api/sessions/{id}/stats → usage stats for session
+	if sessionID, isStats := strings.CutSuffix(remainder, "/stats"); isStats {
+		if !isValidSecureID(sessionID) {
+			http.Error(w, "Invalid session ID format", http.StatusBadRequest)
+			return
+		}
+		p.handleGetSessionStats(w, r, sessionID)
 		return
 	}
 
@@ -2326,6 +2352,39 @@ func (p *Plugin) handleGetSessionShares(w http.ResponseWriter, r *http.Request, 
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(userShares)
+}
+
+// handleGetSessionStats returns cumulative usage stats for a session (tokens,
+// turns, tool calls), accumulated across all agent runs the session has had.
+// Unlike GET /api/sessions/{id}, this omits the full message history so
+// callers tracking usage across many sessions don't have to pull transcripts.
+func (p *Plugin) handleGetSessionStats(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID := getUserID(r)
+	orgID := getOrgID(r)
+
+	session, err := p.sessionStore.GetSession(sessionID, userID, orgID)
+	if err != nil {
+		http.Error(w, "Session not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"sessionId":        session.ID,
+		"runCount":         session.RunCount,
+		"totalIterations":  session.TotalIterations,
+		"toolCallCount":    session.ToolCallCount,
+		"promptTokens":     session.PromptTokens,
+		"completionTokens": session.CompletionTokens,
+		"totalTokens":      session.TotalTokens,
+		"createdAt":        session.CreatedAt,
+		"updatedAt":        session.UpdatedAt,
+	})
 }
 
 func generateSessionTitleFromType(convType, message string) string {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -676,3 +676,164 @@ func TestHandlePromptDefaults(t *testing.T) {
 		}
 	})
 }
+
+func TestConsumeAgentEvents_IncrementsSessionStats(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "", nil)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	p.runStore.CreateRun("run-1", 7, 2, session.ID)
+
+	eventCh := make(chan agent.SSEEvent, 4)
+	eventCh <- agent.SSEEvent{Type: "content", Data: agent.ContentEvent{Content: "hi"}}
+	eventCh <- agent.SSEEvent{
+		Type: "done",
+		Data: agent.DoneEvent{
+			TotalIterations:  2,
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			TotalTokens:      120,
+			ToolCallCount:    3,
+		},
+	}
+	close(eventCh)
+
+	p.consumeAgentEvents("run-1", session.ID, 7, 2, eventCh)
+
+	got, err := p.sessionStore.GetSession(session.ID, 7, 2)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.RunCount != 1 || got.TotalIterations != 2 || got.ToolCallCount != 3 {
+		t.Fatalf("unexpected stats: %+v", got)
+	}
+	if got.PromptTokens != 100 || got.CompletionTokens != 20 || got.TotalTokens != 120 {
+		t.Fatalf("unexpected tokens: %+v", got)
+	}
+}
+
+func TestConsumeAgentEvents_DoesNotIncrementStatsOnError(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "", nil)
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	p.runStore.CreateRun("run-1", 7, 2, session.ID)
+
+	eventCh := make(chan agent.SSEEvent, 2)
+	eventCh <- agent.SSEEvent{Type: "error", Data: agent.ErrorEvent{Message: "boom"}}
+	close(eventCh)
+
+	p.consumeAgentEvents("run-1", session.ID, 7, 2, eventCh)
+
+	got, err := p.sessionStore.GetSession(session.ID, 7, 2)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.RunCount != 0 {
+		t.Fatalf("expected no stats increment on error, got RunCount=%d", got.RunCount)
+	}
+}
+
+func TestHandleGetSessionStats_ReturnsAccumulatedStats(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "", []SessionMessage{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	delta := SessionStatsDelta{
+		RunCount: 1, TotalIterations: 3, ToolCallCount: 2,
+		PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120,
+	}
+	if err := p.sessionStore.IncrementStats(session.ID, 7, 2, delta); err != nil {
+		t.Fatalf("IncrementStats failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+session.ID+"/stats", nil)
+	req.Header.Set("X-Grafana-Org-Id", "2")
+	req.Header.Set("X-Grafana-User-Id", "7")
+	rec := httptest.NewRecorder()
+
+	p.handleGetSessionStats(rec, req, session.ID)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["sessionId"] != session.ID {
+		t.Errorf("sessionId = %v, want %q", body["sessionId"], session.ID)
+	}
+	if body["runCount"].(float64) != 1 || body["toolCallCount"].(float64) != 2 {
+		t.Errorf("unexpected stats body: %+v", body)
+	}
+	if body["totalTokens"].(float64) != 120 {
+		t.Errorf("totalTokens = %v, want 120", body["totalTokens"])
+	}
+}
+
+func TestHandleGetSessionStats_NotFoundForMissingSession(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/does-not-exist/stats", nil)
+	req.Header.Set("X-Grafana-Org-Id", "2")
+	req.Header.Set("X-Grafana-User-Id", "7")
+	rec := httptest.NewRecorder()
+
+	p.handleGetSessionStats(rec, req, "does-not-exist")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleGetSessionStats_NotFoundForWrongOwner(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "", []SessionMessage{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+session.ID+"/stats", nil)
+	req.Header.Set("X-Grafana-Org-Id", "2")
+	req.Header.Set("X-Grafana-User-Id", "999") // different user
+	rec := httptest.NewRecorder()
+
+	p.handleGetSessionStats(rec, req, session.ID)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (ownership must not leak as 403)", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleSessionRouter_DispatchesStats(t *testing.T) {
+	p := newAgentRunTestPlugin(t)
+	session, err := p.sessionStore.CreateSession(7, 2, "", []SessionMessage{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+	if err := p.sessionStore.IncrementStats(session.ID, 7, 2, SessionStatsDelta{RunCount: 1}); err != nil {
+		t.Fatalf("IncrementStats failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+session.ID+"/stats", nil)
+	req.Header.Set("X-Grafana-Org-Id", "2")
+	req.Header.Set("X-Grafana-User-Id", "7")
+	rec := httptest.NewRecorder()
+
+	p.handleSessionRouter(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["runCount"].(float64) != 1 {
+		t.Errorf("unexpected stats body: %+v", body)
+	}
+}

--- a/pkg/plugin/sessionstore.go
+++ b/pkg/plugin/sessionstore.go
@@ -29,6 +29,28 @@ type ChatSession struct {
 	Model        string           `json:"model,omitempty"`
 	UserID       int64            `json:"-"`
 	OrgID        int64            `json:"-"`
+
+	// Usage stats, accumulated from each completed agent run's DoneEvent.
+	// Runs are TTL'd out of Redis after RunMaxAge, so these must be
+	// incremented on-write (see IncrementStats) rather than computed by
+	// summing historical runs.
+	RunCount         int   `json:"runCount"`
+	TotalIterations  int   `json:"totalIterations"`
+	ToolCallCount    int   `json:"toolCallCount"`
+	PromptTokens     int64 `json:"promptTokens"`
+	CompletionTokens int64 `json:"completionTokens"`
+	TotalTokens      int64 `json:"totalTokens"`
+}
+
+// SessionStatsDelta carries the per-run increments applied to a session's
+// cumulative usage stats when an agent run finishes.
+type SessionStatsDelta struct {
+	RunCount         int
+	TotalIterations  int
+	ToolCallCount    int
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
 }
 
 type SessionMetadata struct {
@@ -61,6 +83,7 @@ type SessionStoreInterface interface {
 	ClearCurrentSessionID(userID, orgID int64) error
 	SetActiveRunID(sessionID string, userID, orgID int64, runID string) error
 	ClearActiveRunID(sessionID string, userID, orgID int64) error
+	IncrementStats(sessionID string, userID, orgID int64, delta SessionStatsDelta) error
 }
 
 func sessionOwnerKey(userID, orgID int64) string {
@@ -366,6 +389,29 @@ func (s *SessionStore) ClearActiveRunID(sessionID string, userID, orgID int64) e
 	}
 
 	session.ActiveRunID = ""
+	return nil
+}
+
+func (s *SessionStore) IncrementStats(sessionID string, userID, orgID int64, delta SessionStatsDelta) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	session, exists := s.sessions[sessionID]
+	if !exists {
+		return fmt.Errorf("session not found")
+	}
+	if session.UserID != userID || session.OrgID != orgID {
+		return fmt.Errorf("session not found")
+	}
+
+	session.RunCount += delta.RunCount
+	session.TotalIterations += delta.TotalIterations
+	session.ToolCallCount += delta.ToolCallCount
+	session.PromptTokens += delta.PromptTokens
+	session.CompletionTokens += delta.CompletionTokens
+	session.TotalTokens += delta.TotalTokens
+	session.UpdatedAt = time.Now()
+
 	return nil
 }
 

--- a/pkg/plugin/sessionstore_redis.go
+++ b/pkg/plugin/sessionstore_redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -19,7 +20,14 @@ func sessionCurrentKey(userID, orgID int64) string {
 	return fmt.Sprintf("usersessions:%d:%d:current", userID, orgID)
 }
 
+// sessionStatsKey is a separate hash from the main session blob so
+// IncrementStats can HINCRBY atomically instead of racing with the
+// read-modify-write cycle every other session mutator uses on the blob.
+func sessionStatsKey(id string) string { return fmt.Sprintf("session:%s:stats", id) }
+
 // redisSession is the on-wire format stored in Redis (includes owner fields).
+// Usage-stats fields live in a separate hash (sessionStatsKey) so they never
+// round-trip through this struct's read-modify-write cycle — see IncrementStats.
 type redisSession struct {
 	ID           string           `json:"id"`
 	Title        string           `json:"title"`
@@ -32,13 +40,6 @@ type redisSession struct {
 	Model        string           `json:"model,omitempty"`
 	UserID       int64            `json:"userId"`
 	OrgID        int64            `json:"orgId"`
-
-	RunCount         int   `json:"runCount"`
-	TotalIterations  int   `json:"totalIterations"`
-	ToolCallCount    int   `json:"toolCallCount"`
-	PromptTokens     int64 `json:"promptTokens"`
-	CompletionTokens int64 `json:"completionTokens"`
-	TotalTokens      int64 `json:"totalTokens"`
 }
 
 func toRedis(s *ChatSession) *redisSession {
@@ -47,8 +48,6 @@ func toRedis(s *ChatSession) *redisSession {
 		Summary: s.Summary, CreatedAt: s.CreatedAt, UpdatedAt: s.UpdatedAt,
 		MessageCount: s.MessageCount, ActiveRunID: s.ActiveRunID, Model: s.Model,
 		UserID: s.UserID, OrgID: s.OrgID,
-		RunCount: s.RunCount, TotalIterations: s.TotalIterations, ToolCallCount: s.ToolCallCount,
-		PromptTokens: s.PromptTokens, CompletionTokens: s.CompletionTokens, TotalTokens: s.TotalTokens,
 	}
 }
 
@@ -58,8 +57,6 @@ func fromRedis(rs *redisSession) *ChatSession {
 		Summary: rs.Summary, CreatedAt: rs.CreatedAt, UpdatedAt: rs.UpdatedAt,
 		MessageCount: rs.MessageCount, ActiveRunID: rs.ActiveRunID, Model: rs.Model,
 		UserID: rs.UserID, OrgID: rs.OrgID,
-		RunCount: rs.RunCount, TotalIterations: rs.TotalIterations, ToolCallCount: rs.ToolCallCount,
-		PromptTokens: rs.PromptTokens, CompletionTokens: rs.CompletionTokens, TotalTokens: rs.TotalTokens,
 	}
 }
 
@@ -173,7 +170,35 @@ func (s *RedisSessionStore) GetSession(sessionID string, userID, orgID int64) (*
 	if rs.UserID != userID || rs.OrgID != orgID {
 		return nil, fmt.Errorf("session not found")
 	}
-	return fromRedis(rs), nil
+	session := fromRedis(rs)
+	if err := s.loadStats(session); err != nil {
+		s.logger.Warn("Failed to load session stats", "error", err, "sessionId", sessionID)
+	}
+	return session, nil
+}
+
+// loadStats fills in session's usage-stats fields from the stats hash.
+// Missing/absent fields default to zero (HGetAll returns an empty map for a
+// hash that was never incremented), so this is safe for sessions with no runs.
+func (s *RedisSessionStore) loadStats(session *ChatSession) error {
+	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
+	defer cancel()
+	fields, err := s.client.HGetAll(ctx, sessionStatsKey(session.ID)).Result()
+	if err != nil && err != redis.Nil {
+		return err
+	}
+	session.RunCount = parseStatsField(fields["runCount"])
+	session.TotalIterations = parseStatsField(fields["totalIterations"])
+	session.ToolCallCount = parseStatsField(fields["toolCallCount"])
+	session.PromptTokens = int64(parseStatsField(fields["promptTokens"]))
+	session.CompletionTokens = int64(parseStatsField(fields["completionTokens"]))
+	session.TotalTokens = int64(parseStatsField(fields["totalTokens"]))
+	return nil
+}
+
+func parseStatsField(v string) int {
+	n, _ := strconv.Atoi(v)
+	return n
 }
 
 func (s *RedisSessionStore) ListSessions(userID, orgID int64) ([]SessionMetadata, error) {
@@ -291,7 +316,7 @@ func (s *RedisSessionStore) DeleteSession(sessionID string, userID, orgID int64)
 
 	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
 	defer cancel()
-	s.client.Del(ctx, sessionKey(sessionID))
+	s.client.Del(ctx, sessionKey(sessionID), sessionStatsKey(sessionID))
 
 	ctx2, cancel2 := redisContext(s.ctx, RedisOpTimeout)
 	defer cancel2()
@@ -322,7 +347,7 @@ func (s *RedisSessionStore) DeleteAllSessions(userID, orgID int64) error {
 
 	for _, id := range ids {
 		ctx2, cancel2 := redisContext(s.ctx, RedisOpTimeout)
-		s.client.Del(ctx2, sessionKey(id))
+		s.client.Del(ctx2, sessionKey(id), sessionStatsKey(id))
 		cancel2()
 	}
 
@@ -399,6 +424,11 @@ func (s *RedisSessionStore) ClearActiveRunID(sessionID string, userID, orgID int
 	return s.saveSession(session)
 }
 
+// IncrementStats applies delta via HINCRBY on a hash separate from the main
+// session blob, so it can't race with the read-modify-write cycle every other
+// mutator (AppendMessages, SetActiveRunID, ...) uses — concurrent runs on the
+// same session (e.g. two tabs, or an automation retriggering a run) can't
+// silently drop a delta the way a read-modify-write on the blob would.
 func (s *RedisSessionStore) IncrementStats(sessionID string, userID, orgID int64, delta SessionStatsDelta) error {
 	rs, err := s.getSessionRaw(sessionID)
 	if err != nil {
@@ -408,16 +438,18 @@ func (s *RedisSessionStore) IncrementStats(sessionID string, userID, orgID int64
 		return fmt.Errorf("session not found")
 	}
 
-	session := fromRedis(rs)
-	session.RunCount += delta.RunCount
-	session.TotalIterations += delta.TotalIterations
-	session.ToolCallCount += delta.ToolCallCount
-	session.PromptTokens += delta.PromptTokens
-	session.CompletionTokens += delta.CompletionTokens
-	session.TotalTokens += delta.TotalTokens
-	session.UpdatedAt = time.Now()
-
-	return s.saveSession(session)
+	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
+	defer cancel()
+	statsKey := sessionStatsKey(sessionID)
+	pipe := s.client.Pipeline()
+	pipe.HIncrBy(ctx, statsKey, "runCount", int64(delta.RunCount))
+	pipe.HIncrBy(ctx, statsKey, "totalIterations", int64(delta.TotalIterations))
+	pipe.HIncrBy(ctx, statsKey, "toolCallCount", int64(delta.ToolCallCount))
+	pipe.HIncrBy(ctx, statsKey, "promptTokens", delta.PromptTokens)
+	pipe.HIncrBy(ctx, statsKey, "completionTokens", delta.CompletionTokens)
+	pipe.HIncrBy(ctx, statsKey, "totalTokens", delta.TotalTokens)
+	_, err = pipe.Exec(ctx)
+	return err
 }
 
 func (s *RedisSessionStore) CleanupOld() {

--- a/pkg/plugin/sessionstore_redis.go
+++ b/pkg/plugin/sessionstore_redis.go
@@ -32,6 +32,13 @@ type redisSession struct {
 	Model        string           `json:"model,omitempty"`
 	UserID       int64            `json:"userId"`
 	OrgID        int64            `json:"orgId"`
+
+	RunCount         int   `json:"runCount"`
+	TotalIterations  int   `json:"totalIterations"`
+	ToolCallCount    int   `json:"toolCallCount"`
+	PromptTokens     int64 `json:"promptTokens"`
+	CompletionTokens int64 `json:"completionTokens"`
+	TotalTokens      int64 `json:"totalTokens"`
 }
 
 func toRedis(s *ChatSession) *redisSession {
@@ -40,6 +47,8 @@ func toRedis(s *ChatSession) *redisSession {
 		Summary: s.Summary, CreatedAt: s.CreatedAt, UpdatedAt: s.UpdatedAt,
 		MessageCount: s.MessageCount, ActiveRunID: s.ActiveRunID, Model: s.Model,
 		UserID: s.UserID, OrgID: s.OrgID,
+		RunCount: s.RunCount, TotalIterations: s.TotalIterations, ToolCallCount: s.ToolCallCount,
+		PromptTokens: s.PromptTokens, CompletionTokens: s.CompletionTokens, TotalTokens: s.TotalTokens,
 	}
 }
 
@@ -49,6 +58,8 @@ func fromRedis(rs *redisSession) *ChatSession {
 		Summary: rs.Summary, CreatedAt: rs.CreatedAt, UpdatedAt: rs.UpdatedAt,
 		MessageCount: rs.MessageCount, ActiveRunID: rs.ActiveRunID, Model: rs.Model,
 		UserID: rs.UserID, OrgID: rs.OrgID,
+		RunCount: rs.RunCount, TotalIterations: rs.TotalIterations, ToolCallCount: rs.ToolCallCount,
+		PromptTokens: rs.PromptTokens, CompletionTokens: rs.CompletionTokens, TotalTokens: rs.TotalTokens,
 	}
 }
 
@@ -385,6 +396,27 @@ func (s *RedisSessionStore) ClearActiveRunID(sessionID string, userID, orgID int
 
 	session := fromRedis(rs)
 	session.ActiveRunID = ""
+	return s.saveSession(session)
+}
+
+func (s *RedisSessionStore) IncrementStats(sessionID string, userID, orgID int64, delta SessionStatsDelta) error {
+	rs, err := s.getSessionRaw(sessionID)
+	if err != nil {
+		return err
+	}
+	if rs.UserID != userID || rs.OrgID != orgID {
+		return fmt.Errorf("session not found")
+	}
+
+	session := fromRedis(rs)
+	session.RunCount += delta.RunCount
+	session.TotalIterations += delta.TotalIterations
+	session.ToolCallCount += delta.ToolCallCount
+	session.PromptTokens += delta.PromptTokens
+	session.CompletionTokens += delta.CompletionTokens
+	session.TotalTokens += delta.TotalTokens
+	session.UpdatedAt = time.Now()
+
 	return s.saveSession(session)
 }
 

--- a/pkg/plugin/sessionstore_redis_test.go
+++ b/pkg/plugin/sessionstore_redis_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -73,5 +74,54 @@ func TestRedisSessionStore_IncrementStats(t *testing.T) {
 
 	if err := store.IncrementStats(session.ID, 2, 1, delta); err == nil {
 		t.Fatal("expected error incrementing stats for another user's session")
+	}
+}
+
+// TestRedisSessionStore_IncrementStats_ConcurrentNoLostUpdates guards against
+// the read-modify-write race a naive GET-then-SET on the session blob would
+// have: concurrent runs finishing for the same session (two tabs, or an
+// automation re-triggering a run) must not silently drop each other's delta.
+func TestRedisSessionStore_IncrementStats_ConcurrentNoLostUpdates(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisSessionStore(context.Background(), client, log.DefaultLogger)
+	session, err := store.CreateSession(1, 1, "test", []SessionMessage{{Role: "user", Content: "hello"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	const concurrentRuns = 50
+	delta := SessionStatsDelta{
+		RunCount: 1, TotalIterations: 2, ToolCallCount: 1,
+		PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120,
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, concurrentRuns)
+	for i := 0; i < concurrentRuns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := store.IncrementStats(session.ID, 1, 1, delta); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("IncrementStats failed under concurrency: %v", err)
+	}
+
+	got, err := store.GetSession(session.ID, 1, 1)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.RunCount != concurrentRuns {
+		t.Fatalf("lost updates: RunCount = %d, want %d", got.RunCount, concurrentRuns)
+	}
+	if got.TotalTokens != int64(concurrentRuns)*delta.TotalTokens {
+		t.Fatalf("lost updates: TotalTokens = %d, want %d", got.TotalTokens, int64(concurrentRuns)*delta.TotalTokens)
 	}
 }

--- a/pkg/plugin/sessionstore_redis_test.go
+++ b/pkg/plugin/sessionstore_redis_test.go
@@ -38,3 +38,40 @@ func TestRedisSessionStore_ModelRoundTrip(t *testing.T) {
 		t.Fatalf("expected listed session model large, got %+v", sessions)
 	}
 }
+
+func TestRedisSessionStore_IncrementStats(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisSessionStore(context.Background(), client, log.DefaultLogger)
+	session, err := store.CreateSession(1, 1, "test", []SessionMessage{{Role: "user", Content: "hello"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	delta := SessionStatsDelta{
+		RunCount: 1, TotalIterations: 3, ToolCallCount: 2,
+		PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120,
+	}
+	if err := store.IncrementStats(session.ID, 1, 1, delta); err != nil {
+		t.Fatalf("IncrementStats failed: %v", err)
+	}
+	if err := store.IncrementStats(session.ID, 1, 1, delta); err != nil {
+		t.Fatalf("IncrementStats (second call) failed: %v", err)
+	}
+
+	got, err := store.GetSession(session.ID, 1, 1)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.RunCount != 2 || got.TotalIterations != 6 || got.ToolCallCount != 4 {
+		t.Fatalf("unexpected accumulated counts: %+v", got)
+	}
+	if got.PromptTokens != 200 || got.CompletionTokens != 40 || got.TotalTokens != 240 {
+		t.Fatalf("unexpected accumulated tokens: %+v", got)
+	}
+
+	if err := store.IncrementStats(session.ID, 2, 1, delta); err == nil {
+		t.Fatal("expected error incrementing stats for another user's session")
+	}
+}

--- a/pkg/plugin/sessionstore_test.go
+++ b/pkg/plugin/sessionstore_test.go
@@ -253,6 +253,45 @@ func TestSessionStore_ActiveRunID(t *testing.T) {
 	}
 }
 
+func TestSessionStore_IncrementStats(t *testing.T) {
+	store := newTestSessionStore()
+
+	session, _ := store.CreateSession(1, 1, "", []SessionMessage{{Role: "user", Content: "hello"}})
+
+	delta := SessionStatsDelta{
+		RunCount: 1, TotalIterations: 3, ToolCallCount: 2,
+		PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120,
+	}
+	if err := store.IncrementStats(session.ID, 1, 1, delta); err != nil {
+		t.Fatalf("IncrementStats failed: %v", err)
+	}
+	// A second run's worth of stats should accumulate, not overwrite.
+	if err := store.IncrementStats(session.ID, 1, 1, delta); err != nil {
+		t.Fatalf("IncrementStats (second call) failed: %v", err)
+	}
+
+	got, err := store.GetSession(session.ID, 1, 1)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.RunCount != 2 || got.TotalIterations != 6 || got.ToolCallCount != 4 {
+		t.Fatalf("unexpected accumulated counts: %+v", got)
+	}
+	if got.PromptTokens != 200 || got.CompletionTokens != 40 || got.TotalTokens != 240 {
+		t.Fatalf("unexpected accumulated tokens: %+v", got)
+	}
+}
+
+func TestSessionStore_IncrementStats_WrongOwner(t *testing.T) {
+	store := newTestSessionStore()
+
+	session, _ := store.CreateSession(1, 1, "", []SessionMessage{{Role: "user", Content: "hello"}})
+
+	if err := store.IncrementStats(session.ID, 2, 1, SessionStatsDelta{RunCount: 1}); err == nil {
+		t.Fatal("expected error incrementing stats for another user's session")
+	}
+}
+
 func TestSessionStore_TitleGeneration(t *testing.T) {
 	store := newTestSessionStore()
 

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
@@ -80,6 +80,24 @@ describe('SessionSidebar utilities', () => {
     });
   });
 
+  describe('session stats formatting', () => {
+    const formatStats = (stats: { totalTokens: number; runCount: number; toolCallCount: number }): string =>
+      `${stats.totalTokens.toLocaleString()} tokens · ${stats.runCount} ${stats.runCount === 1 ? 'turn' : 'turns'} · ` +
+      `${stats.toolCallCount} tool ${stats.toolCallCount === 1 ? 'call' : 'calls'}`;
+
+    it('should pluralize turns and tool calls', () => {
+      expect(formatStats({ totalTokens: 1234, runCount: 3, toolCallCount: 5 })).toBe('1,234 tokens · 3 turns · 5 tool calls');
+    });
+
+    it('should use singular turn and tool call for a count of one', () => {
+      expect(formatStats({ totalTokens: 500, runCount: 1, toolCallCount: 1 })).toBe('500 tokens · 1 turn · 1 tool call');
+    });
+
+    it('should format large token counts with separators', () => {
+      expect(formatStats({ totalTokens: 1000000, runCount: 10, toolCallCount: 20 })).toBe('1,000,000 tokens · 10 turns · 20 tool calls');
+    });
+  });
+
   describe('session title generation', () => {
     const generateTitle = (firstMessage: string, maxLength = 50): string => {
       if (!firstMessage) { return 'New Session'; }

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
@@ -3,7 +3,7 @@ import { UseSessionManagerReturn, SessionMetadata } from '../../hooks/useSession
 import { LoadingButton, InlineLoading } from '../../../LoadingOverlay';
 import { ShareDialog } from '../ShareDialog/ShareDialog';
 import { sessionShareService, CreateShareResponse } from '../../../../services/sessionShare';
-import { getSession } from '../../../../services/backendSessionClient';
+import { getSession, getSessionStats, SessionStats } from '../../../../services/backendSessionClient';
 import { Icon, useTheme2 } from '@grafana/ui';
 
 interface SessionSidebarProps {
@@ -22,6 +22,7 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
   const [creatingSession, setCreatingSession] = useState(false);
   const [shareDialogSessionId, setShareDialogSessionId] = useState<string | null>(null);
   const [sessionShares, setSessionShares] = useState<Map<string, CreateShareResponse[]>>(new Map());
+  const [sessionStats, setSessionStats] = useState<Map<string, SessionStats>>(new Map());
   const previousSessionIdsRef = useRef<string>('');
   const isLoadingRef = useRef<boolean>(false);
 
@@ -45,9 +46,10 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
     previousSessionIdsRef.current = sessionIdsString;
     isLoadingRef.current = true;
 
-    const loadAllShares = async () => {
+    const loadSessionExtras = async () => {
       try {
         const sharesMap = new Map<string, CreateShareResponse[]>();
+        const statsMap = new Map<string, SessionStats>();
         for (const session of sessionManager.sessions) {
           try {
             const shares = await sessionShareService.getSessionShares(session.id);
@@ -55,13 +57,20 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
           } catch {
             // Best-effort share loading per session
           }
+          try {
+            const stats = await getSessionStats(session.id);
+            statsMap.set(session.id, stats);
+          } catch {
+            // Best-effort stats loading per session
+          }
         }
         setSessionShares(sharesMap);
+        setSessionStats(statsMap);
       } finally {
         isLoadingRef.current = false;
       }
     };
-    loadAllShares();
+    loadSessionExtras();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, sessionIdsString]); // sessionIdsString is a stable string value, won't cause infinite loops
 
@@ -198,6 +207,7 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
                   isLoading={loadingAction === `loading-${session.id}`}
                   isDeleting={loadingAction === `deleting-${session.id}`}
                   hasShares={(sessionShares.get(session.id)?.length ?? 0) > 0}
+                  stats={sessionStats.get(session.id)}
                   onLoad={() => handleLoadSession(session.id)}
                   onDelete={(e) => handleDeleteClick(session.id, e)}
                   onConfirmDelete={() => confirmDelete(session.id)}
@@ -302,6 +312,7 @@ interface SessionItemProps {
   isLoading?: boolean;
   isDeleting?: boolean;
   hasShares?: boolean;
+  stats?: SessionStats;
   onLoad: () => void;
   onDelete: (e: React.MouseEvent) => void;
   onConfirmDelete: () => void;
@@ -317,6 +328,7 @@ function SessionItem({
   isLoading = false,
   isDeleting = false,
   hasShares = false,
+  stats,
   onLoad,
   onDelete,
   onConfirmDelete,
@@ -377,6 +389,15 @@ function SessionItem({
             <span>{formatDate(session.updatedAt)}</span>
             <span>•</span>
             <span>{session.messageCount} messages</span>
+            {stats && stats.runCount > 0 && (
+              <>
+                <span>•</span>
+                <span data-testid="session-stats">
+                  {stats.totalTokens.toLocaleString()} tokens · {stats.runCount} {stats.runCount === 1 ? 'turn' : 'turns'} ·{' '}
+                  {stats.toolCallCount} tool {stats.toolCallCount === 1 ? 'call' : 'calls'}
+                </span>
+              </>
+            )}
           </div>
         </div>
 

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
@@ -23,11 +23,16 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
   const [shareDialogSessionId, setShareDialogSessionId] = useState<string | null>(null);
   const [sessionShares, setSessionShares] = useState<Map<string, CreateShareResponse[]>>(new Map());
   const [sessionStats, setSessionStats] = useState<Map<string, SessionStats>>(new Map());
-  const previousSessionIdsRef = useRef<string>('');
+  const previousSessionSignatureRef = useRef<string>('');
   const isLoadingRef = useRef<boolean>(false);
 
-  // Create a stable string representation of session IDs for comparison
-  const sessionIdsString = sessionManager.sessions.map((s) => s.id).sort().join(',');
+  // Stable signature that changes when the session set changes OR when any
+  // session's updatedAt changes (e.g. a completed run bumps it) — not just
+  // on creation/deletion — so shares/stats get refetched instead of going stale.
+  const sessionSignature = sessionManager.sessions
+    .map((s) => `${s.id}:${new Date(s.updatedAt).getTime()}`)
+    .sort()
+    .join(',');
 
   // Refresh sessions and load shares when sidebar opens
   useEffect(() => {
@@ -38,12 +43,12 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
     // Refresh sessions list when sidebar opens to ensure it's up to date
     sessionManager.refreshSessions();
 
-    // Only reload shares if session IDs actually changed and we're not already loading
-    if (sessionIdsString === previousSessionIdsRef.current || isLoadingRef.current) {
+    // Only reload shares/stats if the signature actually changed and we're not already loading
+    if (sessionSignature === previousSessionSignatureRef.current || isLoadingRef.current) {
       return;
     }
 
-    previousSessionIdsRef.current = sessionIdsString;
+    previousSessionSignatureRef.current = sessionSignature;
     isLoadingRef.current = true;
 
     const loadSessionExtras = async () => {
@@ -72,7 +77,7 @@ export function SessionSidebar({ sessionManager, currentSessionId, isOpen, onClo
     };
     loadSessionExtras();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, sessionIdsString]); // sessionIdsString is a stable string value, won't cause infinite loops
+  }, [isOpen, sessionSignature]); // sessionSignature is a stable string value, won't cause infinite loops
 
   const formatDate = (date: Date | string) => {
     const d = typeof date === 'string' ? new Date(date) : date;

--- a/src/services/__tests__/backendSessionClient.test.ts
+++ b/src/services/__tests__/backendSessionClient.test.ts
@@ -1,0 +1,48 @@
+import { getSessionStats } from '../backendSessionClient';
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    bootData: {
+      user: { orgId: 1 },
+    },
+  },
+}));
+
+describe('getSessionStats', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('fetches usage stats for a session', async () => {
+    const stats = {
+      sessionId: 'abc',
+      runCount: 2,
+      totalIterations: 5,
+      toolCallCount: 3,
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      createdAt: '2026-08-11T00:00:00Z',
+      updatedAt: '2026-08-11T00:01:00Z',
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(stats),
+    });
+
+    await expect(getSessionStats('abc')).resolves.toEqual(stats);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sessions/abc/stats'),
+      expect.objectContaining({ headers: { 'X-Grafana-Org-Id': '1' } })
+    );
+  });
+
+  it('throws when the request fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(getSessionStats('missing')).rejects.toThrow('Failed to get session stats (404)');
+  });
+});

--- a/src/services/backendSessionClient.ts
+++ b/src/services/backendSessionClient.ts
@@ -30,6 +30,18 @@ export interface SessionUpdate {
   summary?: string;
 }
 
+export interface SessionStats {
+  sessionId: string;
+  runCount: number;
+  totalIterations: number;
+  toolCallCount: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export async function createSession(
   title?: string,
   messages?: ChatMessage[]
@@ -61,6 +73,16 @@ export async function getSession(sessionId: string): Promise<BackendChatSession>
   });
   if (!resp.ok) {
     throw new Error(`Failed to get session (${resp.status})`);
+  }
+  return resp.json();
+}
+
+export async function getSessionStats(sessionId: string): Promise<SessionStats> {
+  const resp = await fetch(`${SESSIONS_URL}/${sessionId}/stats`, {
+    headers: orgHeaders(),
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to get session stats (${resp.status})`);
   }
   return resp.json();
 }

--- a/tests/sessionManagement.spec.ts
+++ b/tests/sessionManagement.spec.ts
@@ -118,4 +118,29 @@ test.describe('Session Management', () => {
 
     await page.locator('button[title="Close"]').click();
   });
+
+  test('should display token/turn/tool-call stats after a completed run', async ({ page }) => {
+    await deleteAllPersistedSessions(page);
+
+    const chatInput = page.getByLabel('Chat input');
+    await chatInput.fill('list your datasources');
+    await page.getByLabel('Send message (Enter)').click();
+
+    await expect(page.locator('[aria-label="User message"]').first()).toBeVisible({ timeout: 30000 });
+    await expect(page.locator('[aria-label="Assistant message"]').first()).toBeVisible({ timeout: 60000 });
+    await expect(page.getByRole('button', { name: 'Stop generating' })).toBeHidden({ timeout: 60000 });
+
+    // Open sidebar
+    await page.getByRole('button', { name: 'Chat history', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Chat History' })).toBeVisible();
+
+    // Stats are fetched lazily per session once the sidebar is open — wait for
+    // the segment to appear rather than asserting immediately.
+    const firstSessionItem = page.locator('.p-1\\.5.rounded.group').first();
+    await expect(firstSessionItem).toBeVisible({ timeout: 15000 });
+    await expect(firstSessionItem.getByTestId('session-stats')).toBeVisible({ timeout: 15000 });
+    await expect(firstSessionItem.getByTestId('session-stats')).toHaveText(/\d+ tokens · \d+ turns? · \d+ tool calls?/);
+
+    await page.locator('button[title="Close"]').click();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `GET /api/sessions/{id}/stats` returning cumulative tokens, run/turn count, and tool-call count for a session — accumulated on-write at run completion, since agent runs TTL out of Redis after an hour and can't be summed retroactively.
- Surfaces the same stats in the session history sidebar (`N tokens · N turns · N tool calls`), lazy-loaded per session alongside the existing shares data.
- Fixes a real bug found during manual verification: the LLM client never set `stream_options.include_usage`, so providers silently omitted token counts from every streaming response — token totals were always 0 until this was added.

**Why:** per the `#l0-status-updates` Slack thread, the team needs per-investigation token cost to compare Ask O11y against the c0 agent before rolling the L0 alert-triage agent out beyond Infura. This is the Ask O11y side of that comparison. [GitHub issue #174](https://github.com/Consensys/ask-o11y-plugin/issues/174) proposes a broader, separate per-user usage-tracking feature (own store, `/api/usage` endpoint, Prometheus metrics, Settings tab) — not built here, but the token-accumulation added to `pkg/agent/loop.go` is reusable groundwork for it.

## Test plan
- [x] `go test ./pkg/...` (incl. new tests for loop accumulation, `IncrementStats` on both in-memory and Redis stores, handler 200/403/404, `consumeAgentEvents` wiring)
- [x] `npm run test:ci` (496 tests, incl. new service-client and sidebar-formatting tests)
- [x] `npm run typecheck` / `npm run lint`
- [x] `npm run validate:openapi`
- [x] `npm run build` (frontend + backend)
- [x] Manual verification against the real dev stack: sent a live chat message, confirmed the sidebar and `GET .../stats` return accurate, non-zero token/turn/tool-call counts after the `stream_options` fix
- [x] New Playwright E2E case (`sessionManagement.spec.ts`) passes against the live dev server
- [x] Plugin-validator run: remaining findings (osv-scanner CVEs, react-resizable React 19 warning, unsigned-plugin manifest checksums) confirmed pre-existing on a clean checkout, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent LLM streaming, session persistence (Redis atomic increments), and new authenticated API surface; behavior is well-tested but stats only update on successful run completion.
> 
> **Overview**
> Adds **per-session usage tracking** (tokens, turns, tool calls) accumulated when agent runs complete, plus a lightweight stats API and sidebar display.
> 
> The agent loop now sums LLM **usage** and **tool-call** counts across iterations and returns them on the SSE `done` event. Streaming chat requests set `stream_options.include_usage` so providers actually emit token counts (previously always zero).
> 
> On successful run completion, `consumeAgentEvents` calls `IncrementStats` on the session store. Redis keeps stats in a separate hash with atomic `HINCRBY` to avoid races with concurrent runs; in-memory store increments in-process. Failed runs do not update stats.
> 
> **New API:** `GET /api/sessions/{sessionId}/stats` returns cumulative stats without loading the full transcript (OpenAPI updated). The chat history sidebar lazy-loads stats per session and shows `N tokens · N turns · N tool calls` when `runCount > 0`, refetching when session `updatedAt` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8af5c87ea0074f357028e0df9c61c7f70cf920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->