### PR TITLE
fix(share): apply Grafana subpath prefix to buildShareUrl()

### DIFF
--- a/src/services/__tests__/sessionShare.test.ts
+++ b/src/services/__tests__/sessionShare.test.ts
@@ -1,0 +1,59 @@
+import { config } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: () => ({ fetch: jest.fn() }),
+  config: {
+    appSubUrl: '',
+    bootData: { user: { orgId: 1 } },
+  },
+}));
+
+import { sessionShareService } from '../sessionShare';
+
+describe('SessionShareService.buildShareUrl', () => {
+  const origin = 'https://host.example.com';
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { origin },
+    });
+    (config as { appSubUrl: string }).appSubUrl = '';
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('builds a root-relative URL when Grafana is served at root', () => {
+    const url = sessionShareService.buildShareUrl('/a/consensys-asko11y-app/shared/abc123?orgId=1');
+
+    expect(url).toBe(`${origin}/a/consensys-asko11y-app/shared/abc123?orgId=1`);
+  });
+
+  it('prefixes the share URL with Grafana appSubUrl under a subpath deployment', () => {
+    (config as { appSubUrl: string }).appSubUrl = '/grafana';
+
+    const url = sessionShareService.buildShareUrl('/a/consensys-asko11y-app/shared/abc123?orgId=1');
+
+    expect(url).toBe(`${origin}/grafana/a/consensys-asko11y-app/shared/abc123?orgId=1`);
+  });
+
+  it('falls back to building the path from a bare shareId, honoring the subpath', () => {
+    (config as { appSubUrl: string }).appSubUrl = '/grafana';
+
+    const url = sessionShareService.buildShareUrl('abc123');
+
+    expect(url).toBe(`${origin}/grafana/a/consensys-asko11y-app/shared/abc123?orgId=1`);
+  });
+
+  it('falls back to building the path from a bare shareId at root', () => {
+    const url = sessionShareService.buildShareUrl('abc123');
+
+    expect(url).toBe(`${origin}/a/consensys-asko11y-app/shared/abc123?orgId=1`);
+  });
+});

--- a/src/services/sessionShare.ts
+++ b/src/services/sessionShare.ts
@@ -2,6 +2,7 @@ import { getBackendSrv, config } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
 import { ChatMessage } from '../components/Chat/types';
 import pluginJson from '../plugin.json';
+import { withSubpath } from '../utils/subpath';
 
 /** Response from creating a share link */
 export interface CreateShareResponse {
@@ -164,11 +165,11 @@ export class SessionShareService {
     // If it's already a full path from backend (starts with /a/), use it as-is
     // Backend already includes orgId query param
     if (shareUrlOrId.startsWith('/a/')) {
-      return `${origin}${shareUrlOrId}`;
+      return `${origin}${withSubpath(shareUrlOrId)}`;
     }
 
     // Fallback for backward compatibility (just shareId)
-    return `${origin}/a/${pluginJson.id}/shared/${shareUrlOrId}?orgId=${orgId}`;
+    return `${origin}${withSubpath(`/a/${pluginJson.id}/shared/${shareUrlOrId}?orgId=${orgId}`)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- `buildShareUrl()` in `src/services/sessionShare.ts` built share links as `${window.location.origin}${path}` without Grafana's `appSubUrl` prefix, so links generated under a subpath deployment (e.g. `root_url = https://host/grafana/`) were missing the `/grafana` segment and would 404 for recipients.
- This is the same root cause fixed in #175 (issues #173, #154), but that PR's diff only covered `fetch()` calls — `buildShareUrl()` produces a user-facing URL that's displayed/copied in `ShareDialog.tsx`, not a network request, so it wasn't touched.
- Fixed by wrapping both the backend-provided `/a/...` path and the shareId-fallback path with `withSubpath()` from `src/utils/subpath.ts` (added in #175).

## Test plan
- [x] Added `src/services/__tests__/sessionShare.test.ts` covering `buildShareUrl()` for both root-relative (`appSubUrl: ''`) and subpath-prefixed (`appSubUrl: '/grafana'`) cases, for both the backend-path and bare-shareId-fallback branches
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing deprecation warnings only, unrelated)
- [x] `npm run test:ci` — 36/36 suites, 498/498 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to client-side URL assembly using an existing subpath helper, with dedicated tests and no auth or data-path changes.
> 
> **Overview**
> **Copied session share links** now include Grafana’s `appSubUrl` when the instance is served under a subpath (e.g. `/grafana`), so recipients no longer get URLs that 404.
> 
> `SessionShareService.buildShareUrl()` wraps both the backend `/a/...` path and the bare `shareId` fallback with `withSubpath()` before joining with `window.location.origin`. New unit tests cover root vs subpath for both input shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56cf8b4bfe176ad93d249e28a64d499935d486c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->