### PR TITLE
fix(chat): improve session sidebar stats readability

### DIFF
--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
@@ -89,7 +89,8 @@ describe('SessionSidebar utilities', () => {
         return `${(tokens / 1000).toFixed(1)}k`;
       }
       if (tokens < 1000000) {
-        return `${Math.round(tokens / 1000)}k`;
+        const rounded = Math.round(tokens / 1000);
+        return rounded >= 1000 ? `${(tokens / 1000000).toFixed(1)}M` : `${rounded}k`;
       }
       return `${(tokens / 1000000).toFixed(1)}M`;
     };
@@ -112,6 +113,10 @@ describe('SessionSidebar utilities', () => {
 
     it('should abbreviate token counts in the millions with an "M" suffix', () => {
       expect(formatStats({ totalTokens: 1000000, runCount: 10, toolCallCount: 20 })).toBe('1.0M tokens · 10 turns · 20 tool calls');
+    });
+
+    it('should promote to the "M" suffix when rounding would otherwise reach "1000k"', () => {
+      expect(formatStats({ totalTokens: 999600, runCount: 2, toolCallCount: 4 })).toBe('1.0M tokens · 2 turns · 4 tool calls');
     });
   });
 

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.test.tsx
@@ -81,20 +81,37 @@ describe('SessionSidebar utilities', () => {
   });
 
   describe('session stats formatting', () => {
+    const formatTokenCount = (tokens: number): string => {
+      if (tokens < 1000) {
+        return tokens.toString();
+      }
+      if (tokens < 10000) {
+        return `${(tokens / 1000).toFixed(1)}k`;
+      }
+      if (tokens < 1000000) {
+        return `${Math.round(tokens / 1000)}k`;
+      }
+      return `${(tokens / 1000000).toFixed(1)}M`;
+    };
+
     const formatStats = (stats: { totalTokens: number; runCount: number; toolCallCount: number }): string =>
-      `${stats.totalTokens.toLocaleString()} tokens · ${stats.runCount} ${stats.runCount === 1 ? 'turn' : 'turns'} · ` +
+      `${formatTokenCount(stats.totalTokens)} tokens · ${stats.runCount} ${stats.runCount === 1 ? 'turn' : 'turns'} · ` +
       `${stats.toolCallCount} tool ${stats.toolCallCount === 1 ? 'call' : 'calls'}`;
 
     it('should pluralize turns and tool calls', () => {
-      expect(formatStats({ totalTokens: 1234, runCount: 3, toolCallCount: 5 })).toBe('1,234 tokens · 3 turns · 5 tool calls');
+      expect(formatStats({ totalTokens: 1234, runCount: 3, toolCallCount: 5 })).toBe('1.2k tokens · 3 turns · 5 tool calls');
     });
 
     it('should use singular turn and tool call for a count of one', () => {
       expect(formatStats({ totalTokens: 500, runCount: 1, toolCallCount: 1 })).toBe('500 tokens · 1 turn · 1 tool call');
     });
 
-    it('should format large token counts with separators', () => {
-      expect(formatStats({ totalTokens: 1000000, runCount: 10, toolCallCount: 20 })).toBe('1,000,000 tokens · 10 turns · 20 tool calls');
+    it('should abbreviate large token counts with a "k" suffix', () => {
+      expect(formatStats({ totalTokens: 47015, runCount: 1, toolCallCount: 3 })).toBe('47k tokens · 1 turn · 3 tool calls');
+    });
+
+    it('should abbreviate token counts in the millions with an "M" suffix', () => {
+      expect(formatStats({ totalTokens: 1000000, runCount: 10, toolCallCount: 20 })).toBe('1.0M tokens · 10 turns · 20 tool calls');
     });
   });
 

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
@@ -310,6 +310,19 @@ function ShareDialogWrapper({
   );
 }
 
+function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) {
+    return tokens.toString();
+  }
+  if (tokens < 10000) {
+    return `${(tokens / 1000).toFixed(1)}k`;
+  }
+  if (tokens < 1000000) {
+    return `${Math.round(tokens / 1000)}k`;
+  }
+  return `${(tokens / 1000000).toFixed(1)}M`;
+}
+
 interface SessionItemProps {
   session: SessionMetadata;
   isActive: boolean;
@@ -392,18 +405,27 @@ function SessionItem({
           </div>
           <div className="flex items-center gap-1.5 mt-0.5 text-xs text-secondary">
             <span>{formatDate(session.updatedAt)}</span>
-            <span>•</span>
+            <span>·</span>
             <span>{session.messageCount} messages</span>
-            {stats && stats.runCount > 0 && (
-              <>
-                <span>•</span>
-                <span data-testid="session-stats">
-                  {stats.totalTokens.toLocaleString()} tokens · {stats.runCount} {stats.runCount === 1 ? 'turn' : 'turns'} ·{' '}
-                  {stats.toolCallCount} tool {stats.toolCallCount === 1 ? 'call' : 'calls'}
-                </span>
-              </>
-            )}
           </div>
+          {stats && stats.runCount > 0 && (
+            <div data-testid="session-stats" className="flex items-center gap-1.5 mt-1 text-xs text-secondary">
+              <span className="flex items-center gap-0.5" title={`${stats.totalTokens.toLocaleString()} tokens`}>
+                <Icon name="bolt" size="xs" />
+                {formatTokenCount(stats.totalTokens)} tokens
+              </span>
+              <span>·</span>
+              <span className="flex items-center gap-0.5">
+                <Icon name="repeat" size="xs" />
+                {stats.runCount} {stats.runCount === 1 ? 'turn' : 'turns'}
+              </span>
+              <span>·</span>
+              <span className="flex items-center gap-0.5">
+                <Icon name="cog" size="xs" />
+                {stats.toolCallCount} tool {stats.toolCallCount === 1 ? 'call' : 'calls'}
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/src/components/Chat/components/SessionSidebar/SessionSidebar.tsx
@@ -318,7 +318,9 @@ function formatTokenCount(tokens: number): string {
     return `${(tokens / 1000).toFixed(1)}k`;
   }
   if (tokens < 1000000) {
-    return `${Math.round(tokens / 1000)}k`;
+    const rounded = Math.round(tokens / 1000);
+    // Rounding can push values like 999,600 up to "1000k" — promote those to the M tier.
+    return rounded >= 1000 ? `${(tokens / 1000000).toFixed(1)}M` : `${rounded}k`;
   }
   return `${(tokens / 1000000).toFixed(1)}M`;
 }
@@ -403,24 +405,24 @@ function SessionItem({
             {isActive && <Icon name="arrow-right" size="xs" className="text-primary flex-shrink-0" />}
             <h3 className={`font-medium text-xs truncate ${isActive ? 'text-primary font-semibold' : 'text-primary'}`}>{session.title}</h3>
           </div>
-          <div className="flex items-center gap-1.5 mt-0.5 text-xs text-secondary">
+          <div className="flex items-center flex-wrap mt-0.5 text-xs text-secondary">
             <span>{formatDate(session.updatedAt)}</span>
-            <span>·</span>
+            {' · '}
             <span>{session.messageCount} messages</span>
           </div>
           {stats && stats.runCount > 0 && (
-            <div data-testid="session-stats" className="flex items-center gap-1.5 mt-1 text-xs text-secondary">
-              <span className="flex items-center gap-0.5" title={`${stats.totalTokens.toLocaleString()} tokens`}>
+            <div data-testid="session-stats" className="flex items-center flex-wrap mt-1 text-xs text-secondary">
+              <span className="inline-flex items-center gap-0.5" title={`${stats.totalTokens.toLocaleString()} tokens`}>
                 <Icon name="bolt" size="xs" />
                 {formatTokenCount(stats.totalTokens)} tokens
               </span>
-              <span>·</span>
-              <span className="flex items-center gap-0.5">
+              {' · '}
+              <span className="inline-flex items-center gap-0.5">
                 <Icon name="repeat" size="xs" />
                 {stats.runCount} {stats.runCount === 1 ? 'turn' : 'turns'}
               </span>
-              <span>·</span>
-              <span className="flex items-center gap-0.5">
+              {' · '}
+              <span className="inline-flex items-center gap-0.5">
                 <Icon name="cog" size="xs" />
                 {stats.toolCallCount} tool {stats.toolCallCount === 1 ? 'call' : 'calls'}
               </span>

--- a/tests/sessionManagement.spec.ts
+++ b/tests/sessionManagement.spec.ts
@@ -139,7 +139,7 @@ test.describe('Session Management', () => {
     const firstSessionItem = page.locator('.p-1\\.5.rounded.group').first();
     await expect(firstSessionItem).toBeVisible({ timeout: 15000 });
     await expect(firstSessionItem.getByTestId('session-stats')).toBeVisible({ timeout: 15000 });
-    await expect(firstSessionItem.getByTestId('session-stats')).toHaveText(/\d+ tokens · \d+ turns? · \d+ tool calls?/);
+    await expect(firstSessionItem.getByTestId('session-stats')).toHaveText(/[\d.,]+[kM]? tokens · \d+ turns? · \d+ tool calls?/);
 
     await page.locator('button[title="Close"]').click();
   });


### PR DESCRIPTION
## Summary
- Split the cramped single-line session meta row (date, message count, and run stats mixing `•`/`·` separators) into two rows: date/message-count on one line, run stats on their own line below.
- Run stats now use a single consistent `·` separator, small `@grafana/ui` `Icon`s (`bolt` for tokens, `repeat` for turns, `cog` for tool calls — matching the `cog` used elsewhere for tool calls) to cut text density, and abbreviated token counts (`47015` → `47k`, `1000000` → `1.0M`) with the exact count preserved in a hover tooltip.
- No changes to `SessionStats`/`getSessionStats` fetching logic — this is purely a rendering change in `SessionItem`. The existing zero-runs / not-yet-loaded graceful-degradation behavior is unchanged.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (only pre-existing, unrelated deprecation warnings)
- [x] `npm run test:ci` passes (504/504), including updated `SessionSidebar.test.tsx` coverage for the new `formatTokenCount` abbreviation logic
- [x] Updated `tests/sessionManagement.spec.ts` regex to match the new abbreviated/labeled stats text
- [x] Manually verified in a local Grafana dev environment (`npm run server`): sent a real chat message and confirmed the sidebar renders `⚡ 28k tokens · ↻ 1 turn · ⚙ 1 tool call` on its own row with a `28,214 tokens` tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/rendering change in the session sidebar with no auth, data, or fetching logic changes.
> 
> **Overview**
> Improves chat history sidebar readability by splitting the cramped session meta into **two rows** (date/messages, then run stats) and abbreviating token counts (`47k`, `1.0M`) via a new `formatTokenCount` helper, with the exact count kept in a hover tooltip.
> 
> Run stats now use consistent `·` separators plus small icons (`bolt`, `repeat`, `cog`). Stats fetching is unchanged — this is display-only. Unit and E2E assertions are updated for the new format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24df80009a4812047623f4c8c03cd52177375bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->