### PR TITLE
fix(backend): bump Go toolchain and vulnerable deps flagged by catalog scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install Mage
         run: go install github.com/magefile/mage@latest

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Install Mage

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Install Mage

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install Mage
         run: go install github.com/magefile/mage@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./.github/actions/build-plugin
         with:
           node-version: '22'
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           attestation: true # Enable build provenance attestation
           # Plugin signing enabled with Grafana Access Policy token
           # (For more info see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module consensys-asko11y-app
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.294.0

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -475,7 +475,7 @@ var retrySchedule = []time.Duration{
 
 // retryRand seeds jitter; dedicated to retries so we don't perturb the
 // default rand source used elsewhere.
-var retryRand = mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
+var retryRand = mathrand.New(mathrand.NewSource(time.Now().UnixNano())) // #nosec G404 -- retry backoff jitter timing, not security-sensitive
 var retryRandMu sync.Mutex
 
 // jitteredDuration applies symmetric jitter of ±fraction around base.


### PR DESCRIPTION
## Summary

Grafana's catalog scan of v0.3.5 flagged two backend findings:

1. **govulncheck: 8 vulnerabilities** — all genuine Go 1.26.5 standard-library CVEs (`crypto/tls`, `net/http`, `encoding/xml`, `encoding/asn1`, `html/template`, `net/url`, `net`), every one fixed in Go 1.26.6. Confirmed by running `govulncheck -mode=binary` against the actual compiled backend: 8 vulnerabilities before this change, 0 after.
2. **gosec G404 (HIGH)** — flagged `pkg/mcp/client.go`'s `math/rand`-seeded `retryRand`, used only for retry-backoff jitter timing (±30% delay variance so retries don't thunder-herd). Not security-sensitive — no tokens, keys, or nonces involved. Added a `#nosec G404` annotation with justification rather than switching to `crypto/rand`, which would be unnecessary overhead for pure timing jitter. Confirmed with `gosec -severity high ./...`: 1 issue before, 0 after.

Bumped the Go toolchain everywhere it's pinned: `go.mod`'s `go` directive and all 5 `actions/setup-go` workflow steps (`ci.yml`, `e2e.yml`, `is-compatible.yml`, `release.yml`, `docker-release.yml`) — `1.26.5` → `1.26.6`.

(Note: the `react-19-dep-jsxRuntimeImport` finding in the same report is the already-known `@floating-ui/react` false positive — `scripts/validate-react19.js` has it hardcoded as a vetted exception. No action needed there.)

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./pkg/...` — all pass on go1.26.6
- [x] `govulncheck -mode=binary` against the rebuilt backend binary — 0 vulnerabilities (was 8)
- [x] `gosec -severity high ./...` — 0 issues (was 1); full `gosec ./...` confirms zero `G404` matches anywhere
- [x] `npm run typecheck` / `npm run lint` / `npm run test:ci` — 37 suites / 505 tests pass (frontend unaffected, sanity-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level Go bump and a static-analysis annotation on non-cryptographic retry jitter; no application logic or API behavior changes.
> 
> **Overview**
> Addresses Grafana catalog scan findings by **upgrading the Go toolchain from 1.26.5 to 1.26.6** in `go.mod` and in every `actions/setup-go` pin (`ci`, `e2e`, `is-compatible`, `release`, `docker-release`), so CI and release builds compile against the patched standard library.
> 
> In **`pkg/mcp/client.go`**, adds a **`#nosec G404`** comment on the `math/rand`-backed `retryRand` used only for MCP retry backoff jitter, documenting that it is not used for secrets or tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad082bb4556c1a33850d556f499dda92cf675a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->