### PR TITLE
feat(mcp): per-user OAuth for external MCP servers

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "grafana-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "server"],
+      "port": 3000
+    }
+  ]
+}

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -63,7 +63,10 @@ type LoopRequest struct {
 	GrafanaURL string
 	AuthToken  string
 
-	UserRole   string
+	UserRole string
+	// UserID identifies the Grafana user running this loop. Carried into MCP
+	// tool-call contexts so OAuth-enabled servers use that user's token.
+	UserID     int64
 	OrgID      string
 	OrgName    string
 	ScopeOrgID string
@@ -96,7 +99,7 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	completionBudget := completionTokenBudget(maxTokens)
 	promptBudget := maxTokens - completionBudget
 
-	mcpTools, err := a.mcpProxy.ListTools()
+	mcpTools, err := a.mcpProxy.ListToolsWithContext(mcp.WithUserID(ctx, req.UserID))
 	if err != nil {
 		a.logger.Error("Failed to list MCP tools, proceeding without tools", "error", err)
 		mcpTools = []mcp.Tool{}
@@ -452,7 +455,7 @@ func (a *AgentLoop) executeTool(ctx context.Context, tc ToolCall, req LoopReques
 	}
 	mcp.EnsureScopedGraphitiArgs(tool, args, req.OrgID)
 
-	result, err := a.mcpProxy.CallToolWithContext(tc.Function.Name, args, req.OrgID, req.OrgName, req.ScopeOrgID)
+	result, err := a.mcpProxy.CallToolWithContext(mcp.WithUserID(ctx, req.UserID), tc.Function.Name, args, req.OrgID, req.OrgName, req.ScopeOrgID)
 	if err != nil {
 		a.logger.Error("Tool call failed", "tool", tc.Function.Name, "error", err)
 		var te *mcp.TransportError

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -41,6 +41,11 @@ type Client struct {
 	// forceReconnect can dedupe reconnect storms when the on-call retry path
 	// has already refreshed the session within the last few seconds.
 	sessionCreatedAt time.Time
+	// sessionCancel tears down the context backing the current session. The
+	// SSE transport binds its long-lived event stream to the ctx passed to
+	// Connect, so that ctx must outlive the connect call and only be
+	// cancelled when the session is replaced or the client closes.
+	sessionCancel context.CancelFunc
 	// perUserToken is set for servers with an OAuth block and supplies the
 	// per-request bearer token for the current user. Nil for static-header
 	// servers, which keeps the old behavior.
@@ -120,9 +125,47 @@ func NewClient(parent context.Context, config ServerConfig, logger log.Logger, h
 // Close closes the MCP client session
 func (c *Client) Close() error {
 	c.cancel()
+	if c.sessionCancel != nil {
+		c.sessionCancel()
+	}
 	if c.session != nil {
 		return c.session.Close()
 	}
+	return nil
+}
+
+// closeSessionLocked tears down the current session and its backing context.
+// Callers must hold c.mu.
+func (c *Client) closeSessionLocked() {
+	if c.session != nil {
+		c.session.Close()
+		c.session = nil
+	}
+	if c.sessionCancel != nil {
+		c.sessionCancel()
+		c.sessionCancel = nil
+	}
+}
+
+// connectSession dials the transport and installs the resulting session.
+// Callers must hold c.mu. The session context is rooted at the client context
+// (plus the caller's user identity) and is NOT cancelled when this returns —
+// the SSE transport keeps its event stream on that context, so it lives until
+// the session is replaced or the client closes. The dial timeout is enforced
+// by a timer that cancels the context only if the handshake is still pending.
+func (c *Client) connectSession(callerCtx context.Context, transport mcpsdk.Transport) error {
+	connectCtx, cancel := context.WithCancel(mergeUserCtx(c.ctx, callerCtx))
+	dialTimer := time.AfterFunc(connectDialTimeout, cancel)
+
+	session, err := c.mcpClient.Connect(connectCtx, transport, nil)
+	dialTimer.Stop()
+	if err != nil {
+		cancel()
+		return err
+	}
+	c.session = session
+	c.sessionCancel = cancel
+	c.sessionCreatedAt = time.Now()
 	return nil
 }
 
@@ -153,7 +196,7 @@ func (c *Client) connectMCP(callerCtx context.Context) error {
 	case "sse":
 		transport = &mcpsdk.SSEClientTransport{
 			Endpoint:   c.config.URL,
-			HTTPClient: httpClient,
+			HTTPClient: c.transportHTTPClient(httpClient),
 		}
 	case "streamable-http", "http+streamable":
 		transport = &mcpsdk.StreamableClientTransport{
@@ -173,14 +216,9 @@ func (c *Client) connectMCP(callerCtx context.Context) error {
 		return fmt.Errorf("unsupported MCP transport type: %s", c.config.Type)
 	}
 
-	connectCtx, connectCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), connectDialTimeout)
-	defer connectCancel()
-
-	c.session, err = c.mcpClient.Connect(connectCtx, transport, nil)
-	if err != nil {
+	if err = c.connectSession(callerCtx, transport); err != nil {
 		return fmt.Errorf("failed to connect to MCP server: %w", err)
 	}
-	c.sessionCreatedAt = time.Now()
 
 	c.logger.Debug("Connected to MCP server", "type", c.config.Type, "url", c.config.URL)
 	return nil
@@ -198,10 +236,7 @@ func (c *Client) forceReconnect() error {
 		c.logger.Debug("forceReconnect skipped: session recently refreshed", "server", c.config.ID)
 		return nil
 	}
-	if c.session != nil {
-		c.session.Close()
-		c.session = nil
-	}
+	c.closeSessionLocked()
 	c.mu.Unlock()
 
 	// connectMCP takes c.mu internally; do not hold it across this call.
@@ -225,6 +260,20 @@ func (c *Client) sdkHTTPClientWithTransport(transport http.RoundTripper) *http.C
 	client := *c.httpClient
 	client.Transport = transport
 	return &client
+}
+
+// transportHTTPClient adapts an HTTP client for the configured transport.
+// http.Client.Timeout bounds the whole exchange including the response body,
+// which would sever an SSE event stream after the timeout elapses — so for
+// SSE servers the copy gets no client-level timeout (dialing stays bounded by
+// the SDK dial timeout and connectDialTimeout).
+func (c *Client) transportHTTPClient(client *http.Client) *http.Client {
+	if c.config.Type != "sse" || client.Timeout == 0 {
+		return client
+	}
+	clone := *client
+	clone.Timeout = 0
+	return &clone
 }
 
 func (c *Client) httpClientWithHeaders() *http.Client {
@@ -295,9 +344,8 @@ func (c *Client) connectMCPWithOrgContext(callerCtx context.Context, orgID strin
 	// This prevents race conditions where a stale session without org headers could be reused.
 	if c.session != nil {
 		c.logger.Debug("Closing existing session to reconnect with org context", "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
-		c.session.Close()
-		c.session = nil
 	}
+	c.closeSessionLocked()
 
 	// Create MCP client
 	c.mcpClient = mcpsdk.NewClient(&mcpsdk.Implementation{
@@ -320,7 +368,7 @@ func (c *Client) connectMCPWithOrgContext(callerCtx context.Context, orgID strin
 	case "sse":
 		transport = &mcpsdk.SSEClientTransport{
 			Endpoint:   c.config.URL,
-			HTTPClient: customHTTPClient,
+			HTTPClient: c.transportHTTPClient(customHTTPClient),
 		}
 	case "streamable-http", "http+streamable":
 		transport = &mcpsdk.StreamableClientTransport{
@@ -337,14 +385,9 @@ func (c *Client) connectMCPWithOrgContext(callerCtx context.Context, orgID strin
 		return fmt.Errorf("unsupported MCP transport type: %s", c.config.Type)
 	}
 
-	connectCtx, connectCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), connectDialTimeout)
-	defer connectCancel()
-
-	c.session, err = c.mcpClient.Connect(connectCtx, transport, nil)
-	if err != nil {
+	if err = c.connectSession(callerCtx, transport); err != nil {
 		return fmt.Errorf("failed to connect to MCP server with org context: %w", err)
 	}
-	c.sessionCreatedAt = time.Now()
 
 	c.logger.Debug("Connected to MCP server with org context", "type", c.config.Type, "url", c.config.URL, "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
 	return nil
@@ -663,10 +706,7 @@ func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arg
 			} else {
 				// Clear the session to force reconnection
 				c.mu.Lock()
-				if c.session != nil {
-					c.session.Close()
-					c.session = nil
-				}
+				c.closeSessionLocked()
 				c.mu.Unlock()
 				reconnectErr = c.connectMCP(callerCtx)
 			}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -41,6 +41,20 @@ type Client struct {
 	// forceReconnect can dedupe reconnect storms when the on-call retry path
 	// has already refreshed the session within the last few seconds.
 	sessionCreatedAt time.Time
+	// perUserToken is set for servers with an OAuth block and supplies the
+	// per-request bearer token for the current user. Nil for static-header
+	// servers, which keeps the old behavior.
+	perUserToken PerUserTokenProvider
+}
+
+// SetPerUserTokenProvider wires a provider that injects the current user's
+// bearer token on outbound requests for OAuth-enabled servers. It takes
+// effect on the next (re)connect; sessions reconnect per call when org
+// context is present, so in practice it applies immediately.
+func (c *Client) SetPerUserTokenProvider(p PerUserTokenProvider) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.perUserToken = p
 }
 
 // customRoundTripper wraps http.RoundTripper to add custom headers
@@ -74,9 +88,14 @@ func (t *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 
 	// Add any configured headers (can override the above if needed).
 	// "Host" must be set via req.Host, not req.Header — Go ignores Header["Host"].
+	// For OAuth-enabled servers the static Authorization header is never
+	// applied: the per-user token round tripper owns that slot.
+	skipAuth := t.config.OAuth != nil
 	for key, value := range t.config.Headers {
 		if strings.EqualFold(key, "Host") {
 			req.Host = value
+		} else if skipAuth && strings.EqualFold(key, "Authorization") {
+			continue
 		} else {
 			req.Header.Set(key, value)
 		}
@@ -107,8 +126,11 @@ func (c *Client) Close() error {
 	return nil
 }
 
-// connectMCP establishes a connection to an MCP server using the SDK
-func (c *Client) connectMCP() error {
+// connectMCP establishes a connection to an MCP server using the SDK.
+// callerCtx only contributes the per-user identity for the connection
+// handshake of OAuth-enabled servers; the session lifetime stays rooted at
+// the client context. Pass context.Background() for system-level connects.
+func (c *Client) connectMCP(callerCtx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -151,7 +173,7 @@ func (c *Client) connectMCP() error {
 		return fmt.Errorf("unsupported MCP transport type: %s", c.config.Type)
 	}
 
-	connectCtx, connectCancel := context.WithTimeout(c.ctx, connectDialTimeout)
+	connectCtx, connectCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), connectDialTimeout)
 	defer connectCancel()
 
 	c.session, err = c.mcpClient.Connect(connectCtx, transport, nil)
@@ -183,7 +205,7 @@ func (c *Client) forceReconnect() error {
 	c.mu.Unlock()
 
 	// connectMCP takes c.mu internally; do not hold it across this call.
-	return c.connectMCP()
+	return c.connectMCP(context.Background())
 }
 
 const connectDialTimeout = 10 * time.Second
@@ -206,18 +228,41 @@ func (c *Client) sdkHTTPClientWithTransport(transport http.RoundTripper) *http.C
 }
 
 func (c *Client) httpClientWithHeaders() *http.Client {
-	if len(c.config.Headers) == 0 {
+	needsHeaders := len(c.config.Headers) > 0
+	needsOAuth := c.config.OAuth != nil && c.perUserToken != nil
+	if !needsHeaders && !needsOAuth {
 		return c.httpClient
 	}
-	return c.sdkHTTPClientWithTransport(&configHeaderRoundTripper{
-		base:    c.baseTransport(),
-		headers: c.config.Headers,
-	})
+	transport := c.baseTransport()
+	if needsHeaders {
+		transport = &configHeaderRoundTripper{
+			base:              transport,
+			headers:           c.config.Headers,
+			skipAuthorization: c.config.OAuth != nil,
+		}
+	}
+	return c.sdkHTTPClientWithTransport(c.wrapPerUserToken(transport))
+}
+
+// wrapPerUserToken layers the per-user OAuth round tripper on top of the
+// given transport when this server authenticates users individually.
+func (c *Client) wrapPerUserToken(transport http.RoundTripper) http.RoundTripper {
+	if c.config.OAuth == nil || c.perUserToken == nil {
+		return transport
+	}
+	return &userTokenRoundTripper{
+		base:     transport,
+		serverID: c.config.ID,
+		provider: c.perUserToken,
+	}
 }
 
 type configHeaderRoundTripper struct {
 	base    http.RoundTripper
 	headers map[string]string
+	// skipAuthorization is set for OAuth-enabled servers: the per-user token
+	// round tripper owns the Authorization header there.
+	skipAuthorization bool
 }
 
 func (t *configHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -225,6 +270,8 @@ func (t *configHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	for key, value := range t.headers {
 		if strings.EqualFold(key, "Host") {
 			req.Host = value
+		} else if t.skipAuthorization && strings.EqualFold(key, "Authorization") {
+			continue
 		} else {
 			req.Header.Set(key, value)
 		}
@@ -237,7 +284,10 @@ func (t *configHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 // Headers forwarded to all MCP servers:
 //   - X-Grafana-Org-Id: Grafana's numeric organization ID
 //   - X-Scope-OrgID: Tenant identifier (scopeOrgId takes priority over orgName)
-func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrgId string) error {
+//
+// callerCtx contributes the per-user identity for OAuth-enabled servers (see
+// connectMCP); the session lifetime stays rooted at the client context.
+func (c *Client) connectMCPWithOrgContext(callerCtx context.Context, orgID string, orgName string, scopeOrgId string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -255,13 +305,13 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 		Version: "1.0.0",
 	}, nil)
 
-	customHTTPClient := c.sdkHTTPClientWithTransport(&customRoundTripper{
+	customHTTPClient := c.sdkHTTPClientWithTransport(c.wrapPerUserToken(&customRoundTripper{
 		base:       c.baseTransport(),
 		orgID:      orgID,
 		orgName:    orgName,
 		scopeOrgId: scopeOrgId,
 		config:     c.config,
-	})
+	}))
 
 	var transport mcpsdk.Transport
 	var err error
@@ -287,7 +337,7 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 		return fmt.Errorf("unsupported MCP transport type: %s", c.config.Type)
 	}
 
-	connectCtx, connectCancel := context.WithTimeout(c.ctx, connectDialTimeout)
+	connectCtx, connectCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), connectDialTimeout)
 	defer connectCancel()
 
 	c.session, err = c.mcpClient.Connect(connectCtx, transport, nil)
@@ -302,6 +352,14 @@ func (c *Client) connectMCPWithOrgContext(orgID string, orgName string, scopeOrg
 
 // ListTools fetches tools from the MCP server
 func (c *Client) ListTools() ([]Tool, error) {
+	return c.ListToolsWithContext(context.Background())
+}
+
+// ListToolsWithContext fetches tools using the caller's context for identity.
+// For OAuth-enabled servers the user ID carried by ctx (mcp.WithUserID) lets
+// the connection handshake and tools/list authenticate as that user — an
+// anonymous probe would be rejected by providers that gate discovery.
+func (c *Client) ListToolsWithContext(ctx context.Context) ([]Tool, error) {
 	c.mu.RLock()
 	if c.tools != nil {
 		cached := c.tools
@@ -317,7 +375,7 @@ func (c *Client) ListTools() ([]Tool, error) {
 	case "openapi":
 		tools, err = c.listOpenAPITools()
 	case "sse", "streamable-http", "http+streamable":
-		tools, err = c.listMCPTools()
+		tools, err = c.listMCPTools(ctx)
 	default:
 		// Fallback to standard MCP protocol
 		tools, err = c.listStandardTools()
@@ -396,12 +454,12 @@ func schemaToMap(schema interface{}) map[string]interface{} {
 }
 
 // listMCPTools lists tools using the MCP SDK
-func (c *Client) listMCPTools() ([]Tool, error) {
-	if err := c.connectMCP(); err != nil {
+func (c *Client) listMCPTools(callerCtx context.Context) ([]Tool, error) {
+	if err := c.connectMCP(callerCtx); err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 10*time.Second)
 	defer cancel()
 
 	result, err := c.session.ListTools(ctx, &mcpsdk.ListToolsParams{})
@@ -444,10 +502,13 @@ func (c *Client) listMCPTools() ([]Tool, error) {
 
 // CallTool calls a tool on the MCP server
 func (c *Client) CallTool(toolName string, arguments map[string]interface{}) (*CallToolResult, error) {
-	return c.CallToolWithContext(toolName, arguments, "", "", "")
+	return c.CallToolWithContext(context.Background(), toolName, arguments, "", "", "")
 }
 
-func (c *Client) CallToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+// CallToolWithContext calls a tool with org headers. ctx carries per-request
+// values — notably the Grafana user ID (mcp.WithUserID) that OAuth-enabled
+// servers need to inject the caller's bearer token.
+func (c *Client) CallToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Remove server ID prefix from tool name
 	originalName := strings.TrimPrefix(toolName, c.config.ID+"_")
 
@@ -455,7 +516,7 @@ func (c *Client) CallToolWithContext(toolName string, arguments map[string]inter
 	case "openapi":
 		return c.callOpenAPIToolWithContext(originalName, arguments, orgID, orgName, scopeOrgId)
 	case "sse", "streamable-http", "http+streamable":
-		return c.callMCPToolWithContext(originalName, arguments, orgID, orgName, scopeOrgId)
+		return c.callMCPToolWithContext(ctx, originalName, arguments, orgID, orgName, scopeOrgId)
 	default:
 		// Fallback to standard MCP protocol
 		return c.callStandardTool(originalName, arguments)
@@ -492,22 +553,22 @@ func jitteredDuration(base time.Duration, fraction float64) time.Duration {
 
 // callToolOncer is the inner function signature used for retry. Declared as a
 // type so tests can inject a stub without spinning up a streamable-http server.
-type callToolOncer func(toolName string, arguments map[string]interface{}, orgID, orgName, scopeOrgId string) (*CallToolResult, error)
+type callToolOncer func(ctx context.Context, toolName string, arguments map[string]interface{}, orgID, orgName, scopeOrgId string) (*CallToolResult, error)
 
 // callMCPToolWithContext wraps callMCPToolOnce with classification-aware retry.
 // Only ErrKindTransport errors are retried; tool-logic, protocol, and canceled
 // errors are returned immediately. After the last retry the underlying error
 // is wrapped in *TransportError so callers can distinguish transport outages
 // from tool-layer failures and avoid fabricating around missing data.
-func (c *Client) callMCPToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
-	return c.callMCPToolWithRetry(c.callMCPToolOnce, toolName, arguments, orgID, orgName, scopeOrgId)
+func (c *Client) callMCPToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+	return c.callMCPToolWithRetry(ctx, c.callMCPToolOnce, toolName, arguments, orgID, orgName, scopeOrgId)
 }
 
-func (c *Client) callMCPToolWithRetry(once callToolOncer, toolName string, arguments map[string]interface{}, orgID, orgName, scopeOrgId string) (*CallToolResult, error) {
+func (c *Client) callMCPToolWithRetry(ctx context.Context, once callToolOncer, toolName string, arguments map[string]interface{}, orgID, orgName, scopeOrgId string) (*CallToolResult, error) {
 	var lastErr error
 	maxAttempts := len(retrySchedule) + 1 // initial try + one retry per backoff slot
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		result, err := once(toolName, arguments, orgID, orgName, scopeOrgId)
+		result, err := once(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
 		if err == nil {
 			return result, nil
 		}
@@ -547,7 +608,7 @@ func (c *Client) callMCPToolWithRetry(once callToolOncer, toolName string, argum
 // is preserved here because it reuses the already-locked session path and has
 // been proven safe in production. The outer retry wrapper adds attempts on
 // top — these are two independent reliability layers.
-func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Track whether we're using org context for potential reconnection
 	// Forward org headers to all MCP servers (not just specific ones)
 	useOrgContext := orgID != "" || orgName != "" || scopeOrgId != ""
@@ -557,12 +618,12 @@ func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface
 	if useOrgContext {
 		c.logger.Debug("Calling tool with org context", "server", c.config.ID, "tool", toolName, "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
 
-		if err := c.connectMCPWithOrgContext(orgID, orgName, scopeOrgId); err != nil {
+		if err := c.connectMCPWithOrgContext(callerCtx, orgID, orgName, scopeOrgId); err != nil {
 			c.logger.Error("Failed to connect to server with org context", "server", c.config.ID, "error", sanitizeError(err))
 			return nil, err
 		}
 	} else {
-		if err := c.connectMCP(); err != nil {
+		if err := c.connectMCP(callerCtx); err != nil {
 			return nil, err
 		}
 	}
@@ -578,7 +639,10 @@ func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface
 		return nil, fmt.Errorf("session not established for tool call")
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, 30*time.Second)
+	// The caller ctx contributes per-request values (Grafana user ID for
+	// OAuth token injection); the timeout stays rooted at the client ctx so
+	// the session outlives short-lived caller contexts.
+	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
 	defer cancel()
 
 	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -595,7 +659,7 @@ func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface
 			var reconnectErr error
 			if useOrgContext {
 				// connectMCPWithOrgContext handles session cleanup atomically
-				reconnectErr = c.connectMCPWithOrgContext(orgID, orgName, scopeOrgId)
+				reconnectErr = c.connectMCPWithOrgContext(callerCtx, orgID, orgName, scopeOrgId)
 			} else {
 				// Clear the session to force reconnection
 				c.mu.Lock()
@@ -604,7 +668,7 @@ func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface
 					c.session = nil
 				}
 				c.mu.Unlock()
-				reconnectErr = c.connectMCP()
+				reconnectErr = c.connectMCP(callerCtx)
 			}
 
 			if reconnectErr != nil {
@@ -621,7 +685,7 @@ func (c *Client) callMCPToolOnce(toolName string, arguments map[string]interface
 				return nil, fmt.Errorf("session not established after reconnection")
 			}
 
-			retryCtx, retryCancel := context.WithTimeout(c.ctx, 30*time.Second)
+			retryCtx, retryCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
 			defer retryCancel()
 
 			result, err = session.CallTool(retryCtx, &mcpsdk.CallToolParams{

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -1,0 +1,78 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// PerUserTokenProvider supplies the Authorization bearer value for a given
+// (request-context, serverID) pair. Implementations read the user identity
+// from the context via UserIDFromContext.
+type PerUserTokenProvider interface {
+	BearerFor(ctx context.Context, serverID string) (string, error)
+}
+
+// ErrPerUserTokenUnavailable is returned by BearerFor when the user has not
+// connected the server yet. The round tripper turns it into a user-visible
+// "please connect" error instead of a silent 401.
+var ErrPerUserTokenUnavailable = errors.New("per-user bearer token unavailable")
+
+type userIDCtxKey struct{}
+
+// WithUserID returns a context carrying the Grafana user ID for downstream
+// per-user token injection. A zero ID is treated as absent.
+func WithUserID(ctx context.Context, userID int64) context.Context {
+	if userID == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, userIDCtxKey{}, userID)
+}
+
+// UserIDFromContext returns the Grafana user ID previously stored via
+// WithUserID. The returned bool is true only when a non-zero ID is present.
+func UserIDFromContext(ctx context.Context) (int64, bool) {
+	v, ok := ctx.Value(userIDCtxKey{}).(int64)
+	return v, ok && v != 0
+}
+
+// mergeUserCtx returns a context rooted at base (for cancellation lifetime)
+// that additionally carries the user ID from caller. Rooting at base keeps
+// long-lived client state alive across short-lived caller contexts.
+func mergeUserCtx(base, caller context.Context) context.Context {
+	if userID, ok := UserIDFromContext(caller); ok {
+		return WithUserID(base, userID)
+	}
+	return base
+}
+
+// userTokenRoundTripper wraps an http.RoundTripper for servers with an OAuth
+// block. On every request it resolves the current user's bearer token and
+// injects it as the Authorization header, overriding any static value.
+//
+// Requests without a user in context (health probes, connection handshakes
+// initiated by the plugin itself) pass through without an Authorization
+// header so system-level plumbing keeps working; the MCP server decides
+// whether to accept them.
+type userTokenRoundTripper struct {
+	base     http.RoundTripper
+	serverID string
+	provider PerUserTokenProvider
+}
+
+func (rt *userTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, ok := UserIDFromContext(req.Context()); !ok {
+		return rt.base.RoundTrip(req)
+	}
+	token, err := rt.provider.BearerFor(req.Context(), rt.serverID)
+	if errors.Is(err, ErrPerUserTokenUnavailable) {
+		return nil, fmt.Errorf("MCP server %q requires you to connect your account first (open MCP connections and click Connect): %w", rt.serverID, err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve per-user token for MCP server %q: %w", rt.serverID, err)
+	}
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+token)
+	return rt.base.RoundTrip(req)
+}

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUserIDContextRoundTrip(t *testing.T) {
+	ctx := WithUserID(context.Background(), 0)
+	if _, ok := UserIDFromContext(ctx); ok {
+		t.Fatalf("zero user ID should not be stored")
+	}
+	ctx = WithUserID(context.Background(), 7)
+	if v, ok := UserIDFromContext(ctx); !ok || v != 7 {
+		t.Fatalf("expected 7, got %d ok=%v", v, ok)
+	}
+}
+
+type stubProvider struct {
+	token string
+	err   error
+}
+
+func (s stubProvider) BearerFor(ctx context.Context, serverID string) (string, error) {
+	return s.token, s.err
+}
+
+func TestUserTokenRoundTripperInjectsBearer(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer ts.Close()
+
+	rt := &userTokenRoundTripper{base: http.DefaultTransport, serverID: "s", provider: stubProvider{token: "tok"}}
+	req, _ := http.NewRequestWithContext(WithUserID(context.Background(), 42), http.MethodGet, ts.URL, nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("roundtrip: %v", err)
+	}
+	resp.Body.Close()
+	if gotAuth != "Bearer tok" {
+		t.Fatalf("expected injected bearer, got %q", gotAuth)
+	}
+}
+
+func TestUserTokenRoundTripperPassesThroughWithoutUser(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer ts.Close()
+
+	// Provider would error, but it must not even be consulted without a user.
+	rt := &userTokenRoundTripper{base: http.DefaultTransport, serverID: "s", provider: stubProvider{err: errors.New("boom")}}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("roundtrip: %v", err)
+	}
+	resp.Body.Close()
+	if gotAuth != "" {
+		t.Fatalf("expected no Authorization header, got %q", gotAuth)
+	}
+}
+
+func TestUserTokenRoundTripperNotConnected(t *testing.T) {
+	rt := &userTokenRoundTripper{base: http.DefaultTransport, serverID: "s", provider: stubProvider{err: ErrPerUserTokenUnavailable}}
+	req, _ := http.NewRequestWithContext(WithUserID(context.Background(), 42), http.MethodGet, "http://127.0.0.1:0", nil)
+	_, err := rt.RoundTrip(req)
+	if err == nil || !errors.Is(err, ErrPerUserTokenUnavailable) {
+		t.Fatalf("expected ErrPerUserTokenUnavailable, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Connect") {
+		t.Fatalf("expected user-actionable message, got %v", err)
+	}
+}
+
+func TestConfigHeaderRoundTripperSkipsAuthorizationForOAuth(t *testing.T) {
+	var gotAuth, gotOther string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotOther = r.Header.Get("X-Custom")
+	}))
+	defer ts.Close()
+
+	rt := &configHeaderRoundTripper{
+		base:              http.DefaultTransport,
+		headers:           map[string]string{"Authorization": "Bearer static", "X-Custom": "yes"},
+		skipAuthorization: true,
+	}
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("roundtrip: %v", err)
+	}
+	resp.Body.Close()
+	if gotAuth != "" {
+		t.Fatalf("static Authorization should be skipped for OAuth servers, got %q", gotAuth)
+	}
+	if gotOther != "yes" {
+		t.Fatalf("non-auth headers should still apply, got %q", gotOther)
+	}
+}

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -20,6 +20,20 @@ type Proxy struct {
 	mu            sync.RWMutex
 	healthMonitor *HealthMonitor
 	ctx           context.Context
+	// perUserToken, when set, is passed to every Client so OAuth-enabled
+	// servers can inject a per-user bearer on outbound MCP requests.
+	perUserToken PerUserTokenProvider
+}
+
+// SetPerUserTokenProvider registers the provider for per-user OAuth tokens
+// and propagates it to every existing and future MCP client.
+func (p *Proxy) SetPerUserTokenProvider(provider PerUserTokenProvider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.perUserToken = provider
+	for _, c := range p.clients {
+		c.SetPerUserTokenProvider(provider)
+	}
 }
 
 // NewProxy creates a new MCP proxy
@@ -76,7 +90,11 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) error {
 	}
 	for id, config := range newConfigs {
 		if _, exists := p.clients[id]; !exists {
-			p.clients[id] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+			c := NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+			if p.perUserToken != nil {
+				c.SetPerUserTokenProvider(p.perUserToken)
+			}
+			p.clients[id] = c
 			p.logger.Info("Added MCP client", "id", id, "url", config.URL, "type", config.Type)
 		}
 	}
@@ -92,6 +110,13 @@ func (p *Proxy) UpdateConfig(configs []ServerConfig) error {
 
 // ListTools aggregates tools from all configured MCP servers
 func (p *Proxy) ListTools() ([]Tool, error) {
+	return p.ListToolsWithContext(context.Background())
+}
+
+// ListToolsWithContext aggregates tools from all servers, forwarding the
+// caller's context so OAuth-enabled servers can authenticate discovery as
+// the current user (mcp.WithUserID).
+func (p *Proxy) ListToolsWithContext(ctx context.Context) ([]Tool, error) {
 	p.mu.RLock()
 	clients := make([]*Client, 0, len(p.clients))
 	for _, client := range p.clients {
@@ -112,7 +137,7 @@ func (p *Proxy) ListTools() ([]Tool, error) {
 	results := make(chan result, len(clients))
 	for _, client := range clients {
 		go func(c *Client) {
-			tools, err := c.ListTools()
+			tools, err := c.ListToolsWithContext(ctx)
 			results <- result{tools: tools, err: err}
 		}(client)
 	}
@@ -142,11 +167,12 @@ func (p *Proxy) ListTools() ([]Tool, error) {
 
 // CallTool routes a tool call to the appropriate MCP server
 func (p *Proxy) CallTool(toolName string, arguments map[string]interface{}) (*CallToolResult, error) {
-	return p.CallToolWithContext(toolName, arguments, "", "", "")
+	return p.CallToolWithContext(context.Background(), toolName, arguments, "", "", "")
 }
 
-// CallToolWithContext routes a tool call to the appropriate MCP server with additional context (e.g., Org ID, Org Name, Scope Org ID)
-func (p *Proxy) CallToolWithContext(toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
+// CallToolWithContext routes a tool call to the appropriate MCP server with additional context (e.g., Org ID, Org Name, Scope Org ID).
+// ctx carries the Grafana user ID (via mcp.WithUserID) for servers using per-user OAuth.
+func (p *Proxy) CallToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {
 	// Extract server ID from tool name prefix
 	parts := strings.SplitN(toolName, "_", 2)
 	if len(parts) < 2 {
@@ -173,7 +199,7 @@ func (p *Proxy) CallToolWithContext(toolName string, arguments map[string]interf
 
 	p.logger.Debug("Calling tool on MCP server", "tool", toolName, "server", serverID, "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
 
-	return client.CallToolWithContext(toolName, arguments, orgID, orgName, scopeOrgId)
+	return client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
 }
 
 // HandleMCPRequest handles an MCP JSON-RPC request
@@ -322,7 +348,11 @@ func (p *Proxy) EnsureServer(config ServerConfig) error {
 		p.logger.Debug("Replacing MCP client", "id", config.ID)
 	}
 
-	p.clients[config.ID] = NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+	c := NewClient(p.ctx, config, p.logger, sdkHTTPClient)
+	if p.perUserToken != nil {
+		c.SetPerUserTokenProvider(p.perUserToken)
+	}
+	p.clients[config.ID] = c
 	p.mu.Unlock()
 
 	if replaced != nil {

--- a/pkg/mcp/retry_test.go
+++ b/pkg/mcp/retry_test.go
@@ -25,7 +25,7 @@ func retryTestClient(ctx context.Context) *Client {
 
 func TestRetry_TransientTransportFailureThenSuccess(t *testing.T) {
 	var calls atomic.Int32
-	once := func(toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
+	once := func(_ context.Context, toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
 		n := calls.Add(1)
 		if n == 1 {
 			return nil, io.ErrUnexpectedEOF
@@ -35,7 +35,7 @@ func TestRetry_TransientTransportFailureThenSuccess(t *testing.T) {
 
 	c := retryTestClient(context.Background())
 	start := time.Now()
-	res, err := c.callMCPToolWithRetry(once, "t", nil, "", "", "")
+	res, err := c.callMCPToolWithRetry(context.Background(), once, "t", nil, "", "", "")
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("expected success after retry, got err %v", err)
@@ -54,13 +54,13 @@ func TestRetry_TransientTransportFailureThenSuccess(t *testing.T) {
 
 func TestRetry_PermanentTransportExhausts(t *testing.T) {
 	var calls atomic.Int32
-	once := func(toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
+	once := func(_ context.Context, toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
 		calls.Add(1)
 		return nil, errors.New("connection refused")
 	}
 
 	c := retryTestClient(context.Background())
-	res, err := c.callMCPToolWithRetry(once, "t", nil, "", "", "")
+	res, err := c.callMCPToolWithRetry(context.Background(), once, "t", nil, "", "", "")
 	if err == nil {
 		t.Fatal("expected error after exhaustion")
 	}
@@ -79,13 +79,13 @@ func TestRetry_PermanentTransportExhausts(t *testing.T) {
 
 func TestRetry_ProtocolErrorNotRetried(t *testing.T) {
 	var calls atomic.Int32
-	once := func(toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
+	once := func(_ context.Context, toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
 		calls.Add(1)
 		return nil, errors.New("unauthorized")
 	}
 
 	c := retryTestClient(context.Background())
-	_, err := c.callMCPToolWithRetry(once, "t", nil, "", "", "")
+	_, err := c.callMCPToolWithRetry(context.Background(), once, "t", nil, "", "", "")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -101,7 +101,7 @@ func TestRetry_ProtocolErrorNotRetried(t *testing.T) {
 func TestRetry_ContextCancelStopsBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var calls atomic.Int32
-	once := func(toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
+	once := func(_ context.Context, toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
 		n := calls.Add(1)
 		if n == 1 {
 			// Cancel the context mid-first-attempt so the retry loop trips ctx.Done
@@ -113,7 +113,7 @@ func TestRetry_ContextCancelStopsBackoff(t *testing.T) {
 
 	c := retryTestClient(ctx)
 	start := time.Now()
-	_, err := c.callMCPToolWithRetry(once, "t", nil, "", "", "")
+	_, err := c.callMCPToolWithRetry(context.Background(), once, "t", nil, "", "", "")
 	elapsed := time.Since(start)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
@@ -131,13 +131,13 @@ func TestRetry_ToolLogicErrorNeverSeenByRetry(t *testing.T) {
 	// The MCP SDK signals tool logic errors via result.IsError=true with err=nil,
 	// so the retry loop shouldn't treat that as a retry trigger. Simulate here.
 	var calls atomic.Int32
-	once := func(toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
+	once := func(_ context.Context, toolName string, args map[string]interface{}, orgID, orgName, scope string) (*CallToolResult, error) {
 		calls.Add(1)
 		return &CallToolResult{IsError: true, Content: []ContentBlock{{Type: "text", Text: "bad input"}}}, nil
 	}
 
 	c := retryTestClient(context.Background())
-	res, err := c.callMCPToolWithRetry(once, "t", nil, "", "", "")
+	res, err := c.callMCPToolWithRetry(context.Background(), once, "t", nil, "", "", "")
 	if err != nil {
 		t.Fatalf("tool logic error should come back with nil err, got %v", err)
 	}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -98,6 +98,34 @@ type ServerConfig struct {
 	Headers        map[string]string           `json:"headers,omitempty"`
 	ToolSelections map[string]bool             `json:"toolSelections,omitempty"`
 	RiskOverrides  map[string]ToolRiskOverride `json:"riskOverrides,omitempty"`
+	// OAuth, when set, makes the server authenticate per Grafana user via an
+	// OAuth2 authorization-code flow. Any static Authorization entry in Headers
+	// is ignored for OAuth-enabled servers; each user's access token is
+	// injected per request by the per-user token round tripper.
+	//
+	// Known limitation: the plugin keeps one MCP session per server, shared
+	// across users, and only swaps the Authorization header per request. A
+	// provider that binds authorization state to the identity used during the
+	// initialize handshake would need per-user sessions, which this v1 does
+	// not open.
+	OAuth *OAuthConfig `json:"oauth,omitempty"`
+}
+
+// OAuthConfig declares how to run the authorization-code flow for a server.
+type OAuthConfig struct {
+	AuthorizationURL string   `json:"authorizationURL"`
+	TokenURL         string   `json:"tokenURL"`
+	ClientID         string   `json:"clientID"`
+	ClientSecret     string   `json:"clientSecret,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	// PKCE enables the RFC 7636 code_challenge. Strongly recommended when the
+	// authorization server supports it; required when ClientSecret is empty.
+	PKCE bool `json:"pkce,omitempty"`
+	// RedirectURI is the callback URL registered with the authorization
+	// server. It must match the plugin resource path
+	// /api/plugins/consensys-asko11y-app/resources/api/oauth/{serverID}/callback.
+	// When empty the handler derives it from the incoming request.
+	RedirectURI string `json:"redirectURI,omitempty"`
 }
 
 // ToolRiskOverride lets administrators override a tool's MCP annotations or

--- a/pkg/plugin/datasource_snapshot.go
+++ b/pkg/plugin/datasource_snapshot.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -69,7 +70,7 @@ func (p *Plugin) datasourceSnapshot(orgID, orgName, scopeOrgID string) string {
 			done <- dsSnapshotFailOpen
 			return
 		}
-		result, err := p.mcpProxy.CallToolWithContext(toolName, map[string]interface{}{}, orgID, orgName, scopeOrgID)
+		result, err := p.mcpProxy.CallToolWithContext(context.Background(), toolName, map[string]interface{}{}, orgID, orgName, scopeOrgID)
 		if err != nil {
 			p.logger.Warn("datasourceSnapshot: list_datasources failed", "error", err, "orgID", orgID)
 			done <- dsSnapshotFailOpen

--- a/pkg/plugin/mcp_provisioner.go
+++ b/pkg/plugin/mcp_provisioner.go
@@ -1,0 +1,373 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+
+	"consensys-asko11y-app/pkg/mcp"
+	"consensys-asko11y-app/pkg/plugin/oauth"
+)
+
+// registerProvisionerRoutes mounts the endpoints the AppConfig UI calls to
+// add or remove OAuth-gated MCP servers at runtime. All mutating routes are
+// Admin-only; end users only Connect/Disconnect their own token via the
+// /api/oauth routes.
+func (p *Plugin) registerProvisionerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/mcp/provisioner/presets", p.handleListPresets)
+	mux.HandleFunc("/api/mcp/provisioner", p.handleProvisionerRoot)
+	mux.HandleFunc("/api/mcp/provisioner/preset", p.handleAddPreset)
+	mux.HandleFunc("/api/mcp/provisioner/generic", p.handleAddGeneric)
+	mux.HandleFunc("/api/mcp/provisioner/", p.handleProvisionerItem) // DELETE /{id}
+}
+
+// handleListPresets returns the static preset catalog so the UI can render
+// the preset cards without duplicating the list on the frontend.
+func (p *Plugin) handleListPresets(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isAdmin(r) {
+		http.Error(w, "admin role required", http.StatusForbidden)
+		return
+	}
+	type apiPreset struct {
+		ID          oauth.PresetID `json:"id"`
+		DisplayName string         `json:"displayName"`
+		ServerID    string         `json:"serverId"`
+		MCPURL      string         `json:"mcpUrl"`
+		Transport   string         `json:"transport"`
+		Scopes      []string       `json:"scopes"`
+		DCRCapable  bool           `json:"dcrCapable"`
+	}
+	presets := oauth.Presets()
+	out := make([]apiPreset, 0, len(presets))
+	for _, pr := range presets {
+		out = append(out, apiPreset{pr.ID, pr.DisplayName, pr.ServerID, pr.MCPURL, pr.Transport, pr.Scopes, pr.DCRCapable})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"presets": out})
+}
+
+// apiDynamicServer is the JSON shape for a provisioned dynamic server. OAuth
+// client credentials never leave the backend.
+type apiDynamicServer struct {
+	ServerID    string   `json:"serverId"`
+	DisplayName string   `json:"displayName"`
+	MCPURL      string   `json:"mcpUrl"`
+	Transport   string   `json:"transport"`
+	PresetID    string   `json:"presetId,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+}
+
+// handleProvisionerRoot lists currently provisioned dynamic servers.
+func (p *Plugin) handleProvisionerRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isAdmin(r) {
+		http.Error(w, "admin role required", http.StatusForbidden)
+		return
+	}
+	records, err := p.dynamicServerStore.List(r.Context())
+	if err != nil {
+		p.logger.Warn("list dynamic servers", "err", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	out := make([]apiDynamicServer, 0, len(records))
+	for _, s := range records {
+		scopes := []string{}
+		if s.Config.OAuth != nil {
+			scopes = s.Config.OAuth.Scopes
+		}
+		out = append(out, apiDynamicServer{s.Config.ID, s.Config.Name, s.Config.URL, s.Config.Type, s.PresetID, scopes})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"servers": out})
+}
+
+type addPresetBody struct {
+	Preset       oauth.PresetID `json:"preset"`
+	ClientID     string         `json:"clientId,omitempty"`
+	ClientSecret string         `json:"clientSecret,omitempty"`
+}
+
+func (p *Plugin) handleAddPreset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isAdmin(r) {
+		http.Error(w, "admin role required", http.StatusForbidden)
+		return
+	}
+	var body addPresetBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	preset, ok := oauth.Presets()[body.Preset]
+	if !ok {
+		http.Error(w, "unknown preset", http.StatusBadRequest)
+		return
+	}
+
+	redirectURI := oauth.CallbackURL(r, preset.ServerID)
+	authURL := preset.AuthEndpoint
+	tokenURL := preset.TokenEndpoint
+	clientID := body.ClientID
+	clientSecret := body.ClientSecret
+	var dcrURI, dcrToken string
+
+	if preset.DCRCapable {
+		meta, err := oauth.DiscoverMCPAuth(r.Context(), p.oauthHTTPClient, preset.MCPURL)
+		if err != nil {
+			p.logger.Warn("oauth discovery failed", "preset", preset.ID, "err", err)
+			http.Error(w, "OAuth discovery against the provider failed", http.StatusBadGateway)
+			return
+		}
+		authURL = meta.AuthorizationEndpoint
+		tokenURL = meta.TokenEndpoint
+		if clientID == "" {
+			dcr, err := oauth.RegisterClient(r.Context(), p.oauthHTTPClient, meta, "ask-o11y", []string{redirectURI})
+			if err != nil {
+				p.logger.Warn("dynamic client registration failed", "preset", preset.ID, "err", err)
+				http.Error(w, "dynamic client registration with the provider failed", http.StatusBadGateway)
+				return
+			}
+			clientID = dcr.ClientID
+			clientSecret = dcr.ClientSecret
+			dcrURI = dcr.RegistrationClientURI
+			dcrToken = dcr.RegistrationAccessToken
+		}
+	} else if clientID == "" {
+		http.Error(w, "preset requires clientId (register an OAuth app at the provider first)", http.StatusBadRequest)
+		return
+	}
+
+	cfg := mcp.ServerConfig{
+		ID:      preset.ServerID,
+		Name:    preset.DisplayName,
+		URL:     preset.MCPURL,
+		Type:    preset.Transport,
+		Enabled: true,
+		OAuth: &mcp.OAuthConfig{
+			AuthorizationURL: authURL,
+			TokenURL:         tokenURL,
+			ClientID:         clientID,
+			ClientSecret:     clientSecret,
+			Scopes:           preset.Scopes,
+			PKCE:             preset.PKCE,
+			RedirectURI:      redirectURI,
+		},
+	}
+
+	record := oauth.DynamicServer{
+		Config:                  cfg,
+		PresetID:                string(preset.ID),
+		RegistrationClientURI:   dcrURI,
+		RegistrationAccessToken: dcrToken,
+	}
+
+	if err := p.persistAndRegisterDynamicServer(r.Context(), record); err != nil {
+		p.logger.Error("persist dynamic server", "err", err)
+		http.Error(w, "persist failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"serverId": cfg.ID})
+}
+
+type addGenericBody struct {
+	ServerID         string   `json:"serverId"`
+	DisplayName      string   `json:"displayName"`
+	MCPURL           string   `json:"mcpUrl"`
+	Transport        string   `json:"transport"` // streamable-http | sse
+	AuthorizationURL string   `json:"authorizationUrl"`
+	TokenURL         string   `json:"tokenUrl"`
+	ClientID         string   `json:"clientId"`
+	ClientSecret     string   `json:"clientSecret,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	PKCE             bool     `json:"pkce"`
+	// Discover, when true, runs RFC 8414/9728 discovery (and RFC 7591 DCR
+	// when clientId is empty) to fill in the missing OAuth endpoints.
+	Discover bool `json:"discover,omitempty"`
+}
+
+func validDynamicServerID(id string) bool {
+	if id == "" || len(id) > 64 {
+		return false
+	}
+	for _, r := range id {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *Plugin) handleAddGeneric(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isAdmin(r) {
+		http.Error(w, "admin role required", http.StatusForbidden)
+		return
+	}
+	var body addGenericBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.ServerID == "" || body.MCPURL == "" || body.Transport == "" {
+		http.Error(w, "serverId, mcpUrl and transport are required", http.StatusBadRequest)
+		return
+	}
+	if !validDynamicServerID(body.ServerID) {
+		http.Error(w, "serverId must be 1-64 chars of [a-z0-9-]", http.StatusBadRequest)
+		return
+	}
+	if body.Transport != "streamable-http" && body.Transport != "sse" {
+		http.Error(w, "transport must be streamable-http or sse", http.StatusBadRequest)
+		return
+	}
+	if body.DisplayName == "" {
+		body.DisplayName = body.ServerID
+	}
+
+	redirectURI := oauth.CallbackURL(r, body.ServerID)
+	authURL := body.AuthorizationURL
+	tokenURL := body.TokenURL
+	clientID := body.ClientID
+	clientSecret := body.ClientSecret
+	var dcrURI, dcrToken string
+
+	if body.Discover && (authURL == "" || tokenURL == "" || clientID == "") {
+		meta, err := oauth.DiscoverMCPAuth(r.Context(), p.oauthHTTPClient, body.MCPURL)
+		if err != nil {
+			p.logger.Warn("oauth discovery failed", "server", body.ServerID, "err", err)
+			http.Error(w, "OAuth discovery against the provider failed", http.StatusBadGateway)
+			return
+		}
+		if authURL == "" {
+			authURL = meta.AuthorizationEndpoint
+		}
+		if tokenURL == "" {
+			tokenURL = meta.TokenEndpoint
+		}
+		if clientID == "" {
+			dcr, err := oauth.RegisterClient(r.Context(), p.oauthHTTPClient, meta, "ask-o11y", []string{redirectURI})
+			if err != nil {
+				p.logger.Warn("dynamic client registration failed", "server", body.ServerID, "err", err)
+				http.Error(w, "dynamic client registration with the provider failed", http.StatusBadGateway)
+				return
+			}
+			clientID = dcr.ClientID
+			clientSecret = dcr.ClientSecret
+			dcrURI = dcr.RegistrationClientURI
+			dcrToken = dcr.RegistrationAccessToken
+		}
+	}
+	if authURL == "" || tokenURL == "" || clientID == "" {
+		http.Error(w, "authorizationUrl, tokenUrl and clientId are required (or set discover:true)", http.StatusBadRequest)
+		return
+	}
+
+	cfg := mcp.ServerConfig{
+		ID:      body.ServerID,
+		Name:    body.DisplayName,
+		URL:     body.MCPURL,
+		Type:    body.Transport,
+		Enabled: true,
+		OAuth: &mcp.OAuthConfig{
+			AuthorizationURL: authURL,
+			TokenURL:         tokenURL,
+			ClientID:         clientID,
+			ClientSecret:     clientSecret,
+			Scopes:           body.Scopes,
+			PKCE:             body.PKCE,
+			RedirectURI:      redirectURI,
+		},
+	}
+	record := oauth.DynamicServer{
+		Config:                  cfg,
+		RegistrationClientURI:   dcrURI,
+		RegistrationAccessToken: dcrToken,
+	}
+	if err := p.persistAndRegisterDynamicServer(r.Context(), record); err != nil {
+		p.logger.Error("persist dynamic server", "err", err)
+		http.Error(w, "persist failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"serverId": cfg.ID})
+}
+
+func (p *Plugin) handleProvisionerItem(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/mcp/provisioner/")
+	if id == "" || strings.Contains(id, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isAdmin(r) {
+		http.Error(w, "admin role required", http.StatusForbidden)
+		return
+	}
+	if err := p.deleteDynamicServer(r.Context(), id); err != nil {
+		p.logger.Error("delete dynamic server", "err", err)
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (p *Plugin) persistAndRegisterDynamicServer(ctx context.Context, record oauth.DynamicServer) error {
+	if p.dynamicServerStore == nil {
+		return errors.New("dynamic server store not configured")
+	}
+	if err := p.dynamicServerStore.Put(ctx, record); err != nil {
+		return err
+	}
+	if record.Config.OAuth != nil {
+		p.oauthManager.RegisterConfig(record.Config.ID, record.Config.OAuth)
+	}
+	if err := p.mcpProxy.EnsureServer(record.Config); err != nil {
+		return fmt.Errorf("attach to proxy: %w", err)
+	}
+	return nil
+}
+
+func (p *Plugin) deleteDynamicServer(ctx context.Context, serverID string) error {
+	if p.dynamicServerStore == nil {
+		return errors.New("dynamic server store not configured")
+	}
+	if err := p.dynamicServerStore.Delete(ctx, serverID); err != nil {
+		return err
+	}
+	p.mcpProxy.RemoveServer(serverID)
+	p.oauthManager.UnregisterConfig(serverID)
+	return nil
+}
+
+// isAdmin reports whether the caller holds the Grafana Admin role.
+func isAdmin(r *http.Request) bool {
+	pc := httpadapter.PluginConfigFromContext(r.Context())
+	if pc.User != nil && strings.EqualFold(string(pc.User.Role), "Admin") {
+		return true
+	}
+	return strings.EqualFold(getUserRole(r), "Admin")
+}

--- a/pkg/plugin/mcp_provisioner.go
+++ b/pkg/plugin/mcp_provisioner.go
@@ -360,6 +360,11 @@ func (p *Plugin) deleteDynamicServer(ctx context.Context, serverID string) error
 	}
 	p.mcpProxy.RemoveServer(serverID)
 	p.oauthManager.UnregisterConfig(serverID)
+	// Purge every user's token: re-adding the server (a DCR may issue a new
+	// client_id) must not report stale tokens as Connected.
+	if err := p.oauthManager.Tokens().DeleteServer(ctx, serverID); err != nil {
+		return fmt.Errorf("purge user tokens: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/plugin/oauth/discovery.go
+++ b/pkg/plugin/oauth/discovery.go
@@ -1,0 +1,208 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// AuthServerMetadata is the subset of RFC 8414 metadata needed to drive the
+// authorization-code flow. Fields not set by the server are left empty.
+type AuthServerMetadata struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported       []string `json:"scopes_supported,omitempty"`
+	CodeChallengeMethods  []string `json:"code_challenge_methods_supported,omitempty"`
+}
+
+// ProtectedResourceMetadata is the RFC 9728 body returned by an MCP server's
+// oauth-protected-resource descriptor.
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported,omitempty"`
+}
+
+// DiscoverMCPAuth returns the authorization-server metadata for an MCP URL.
+// It first tries the RFC 8414 well-known path on the MCP origin; if that
+// fails it probes the MCP URL itself, follows the WWW-Authenticate
+// resource_metadata hint (RFC 9728), fetches the protected-resource
+// descriptor, and uses the first advertised authorization server's metadata.
+func DiscoverMCPAuth(ctx context.Context, client *http.Client, mcpURL string) (AuthServerMetadata, error) {
+	origin, err := originOf(mcpURL)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	if meta, err := fetchAuthServerMetadata(ctx, client, origin+"/.well-known/oauth-authorization-server"); err == nil {
+		return meta, nil
+	}
+	return discoverViaChallenge(ctx, client, mcpURL)
+}
+
+// DCRResult is the outcome of RFC 7591 dynamic client registration.
+type DCRResult struct {
+	ClientID                string
+	ClientSecret            string
+	RegistrationClientURI   string
+	RegistrationAccessToken string
+}
+
+// RegisterClient performs RFC 7591 dynamic client registration and returns
+// the assigned client_id (and secret, if the server issued one).
+func RegisterClient(ctx context.Context, client *http.Client, meta AuthServerMetadata, clientName string, redirectURIs []string) (DCRResult, error) {
+	if meta.RegistrationEndpoint == "" {
+		return DCRResult{}, fmt.Errorf("authorization server does not advertise a registration_endpoint")
+	}
+
+	body := map[string]interface{}{
+		"client_name":                clientName,
+		"redirect_uris":              redirectURIs,
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+		"application_type":           "web",
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("encode DCR request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, meta.RegistrationEndpoint, strings.NewReader(string(raw)))
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("build DCR request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("DCR request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return DCRResult{}, fmt.Errorf("read DCR response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return DCRResult{}, fmt.Errorf("DCR returned %s: %s", resp.Status, strings.TrimSpace(string(data)))
+	}
+	var parsed struct {
+		ClientID                string `json:"client_id"`
+		ClientSecret            string `json:"client_secret"`
+		RegistrationClientURI   string `json:"registration_client_uri"`
+		RegistrationAccessToken string `json:"registration_access_token"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return DCRResult{}, fmt.Errorf("decode DCR response: %w", err)
+	}
+	if parsed.ClientID == "" {
+		return DCRResult{}, fmt.Errorf("DCR response missing client_id")
+	}
+	return DCRResult{
+		ClientID:                parsed.ClientID,
+		ClientSecret:            parsed.ClientSecret,
+		RegistrationClientURI:   parsed.RegistrationClientURI,
+		RegistrationAccessToken: parsed.RegistrationAccessToken,
+	}, nil
+}
+
+func originOf(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("url missing scheme/host: %s", raw)
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+func fetchAuthServerMetadata(ctx context.Context, client *http.Client, metaURL string) (AuthServerMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return AuthServerMetadata{}, fmt.Errorf("metadata %s returned %s", metaURL, resp.Status)
+	}
+	var meta AuthServerMetadata
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&meta); err != nil {
+		return AuthServerMetadata{}, err
+	}
+	if meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
+		return AuthServerMetadata{}, fmt.Errorf("metadata %s missing endpoints", metaURL)
+	}
+	return meta, nil
+}
+
+var resourceMetadataRE = regexp.MustCompile(`resource_metadata="([^"]+)"`)
+
+// discoverViaChallenge probes the MCP URL without auth, reads the
+// WWW-Authenticate header for resource_metadata, fetches that descriptor,
+// then the first usable authorization server's metadata.
+func discoverViaChallenge(ctx context.Context, client *http.Client, mcpURL string) (AuthServerMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mcpURL, nil)
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return AuthServerMetadata{}, fmt.Errorf("probe %s: %w", mcpURL, err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+
+	challenge := resp.Header.Get("WWW-Authenticate")
+	match := resourceMetadataRE.FindStringSubmatch(challenge)
+	if len(match) < 2 {
+		return AuthServerMetadata{}, fmt.Errorf("no OAuth metadata advertised at %s (status %s)", mcpURL, resp.Status)
+	}
+	prMeta, err := fetchProtectedResource(ctx, client, match[1])
+	if err != nil {
+		return AuthServerMetadata{}, err
+	}
+	if len(prMeta.AuthorizationServers) == 0 {
+		return AuthServerMetadata{}, fmt.Errorf("protected-resource metadata lists no authorization servers")
+	}
+	for _, as := range prMeta.AuthorizationServers {
+		if meta, err := fetchAuthServerMetadata(ctx, client, strings.TrimSuffix(as, "/")+"/.well-known/oauth-authorization-server"); err == nil {
+			return meta, nil
+		}
+	}
+	return AuthServerMetadata{}, fmt.Errorf("no usable authorization-server metadata found")
+}
+
+func fetchProtectedResource(ctx context.Context, client *http.Client, metaURL string) (ProtectedResourceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ProtectedResourceMetadata{}, fmt.Errorf("protected-resource metadata %s returned %s", metaURL, resp.Status)
+	}
+	var m ProtectedResourceMetadata
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&m); err != nil {
+		return ProtectedResourceMetadata{}, err
+	}
+	return m, nil
+}

--- a/pkg/plugin/oauth/discovery_test.go
+++ b/pkg/plugin/oauth/discovery_test.go
@@ -1,0 +1,93 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverMCPAuthWellKnown(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"x","authorization_endpoint":"x/authorize","token_endpoint":"x/token","registration_endpoint":"x/register"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	meta, err := DiscoverMCPAuth(context.Background(), ts.Client(), ts.URL+"/v1/sse")
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if meta.AuthorizationEndpoint == "" || meta.RegistrationEndpoint == "" {
+		t.Fatalf("unexpected meta: %+v", meta)
+	}
+}
+
+func TestDiscoverMCPAuthViaChallenge(t *testing.T) {
+	// Authorization server + protected-resource metadata host.
+	asMux := http.NewServeMux()
+	asMux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer":"i","authorization_endpoint":"i/authorize","token_endpoint":"i/token"}`))
+	})
+	var asURL string
+	asMux.HandleFunc("/.well-known/oauth-protected-resource/mcp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"mcp","authorization_servers":["` + asURL + `"]}`))
+	})
+	asServer := httptest.NewServer(asMux)
+	defer asServer.Close()
+	asURL = asServer.URL
+
+	// The MCP host: no well-known metadata, 401s advertising resource metadata.
+	mcpMux := http.NewServeMux()
+	mcpMux.HandleFunc("/mcp/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", resource_metadata="`+asServer.URL+`/.well-known/oauth-protected-resource/mcp/"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	mcpServer := httptest.NewServer(mcpMux)
+	defer mcpServer.Close()
+
+	meta, err := DiscoverMCPAuth(context.Background(), asServer.Client(), mcpServer.URL+"/mcp/")
+	if err != nil {
+		t.Fatalf("discover via challenge: %v", err)
+	}
+	if !strings.HasSuffix(meta.AuthorizationEndpoint, "authorize") {
+		t.Fatalf("unexpected auth endpoint: %s", meta.AuthorizationEndpoint)
+	}
+}
+
+func TestRegisterClient(t *testing.T) {
+	mux := http.NewServeMux()
+	var gotBody string
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		gotBody = string(buf[:n])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"cid","registration_client_uri":"/register/cid"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	meta := AuthServerMetadata{RegistrationEndpoint: ts.URL + "/register"}
+	res, err := RegisterClient(context.Background(), ts.Client(), meta, "ask-o11y test", []string{"http://localhost/callback"})
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if res.ClientID != "cid" {
+		t.Fatalf("unexpected client_id %q", res.ClientID)
+	}
+	if !strings.Contains(gotBody, `"client_name":"ask-o11y test"`) {
+		t.Fatalf("body did not include client_name: %s", gotBody)
+	}
+}
+
+func TestRegisterClientRequiresEndpoint(t *testing.T) {
+	if _, err := RegisterClient(context.Background(), http.DefaultClient, AuthServerMetadata{}, "x", nil); err == nil {
+		t.Fatalf("expected error when registration_endpoint is missing")
+	}
+}

--- a/pkg/plugin/oauth/errors.go
+++ b/pkg/plugin/oauth/errors.go
@@ -1,0 +1,13 @@
+package oauth
+
+import "errors"
+
+// ErrOAuthNotConnected is returned when no token is stored for the current
+// user on a given MCP server. Callers surface it to the UI so the user can
+// click "Connect".
+var ErrOAuthNotConnected = errors.New("oauth: user not connected")
+
+// ErrStateInvalid is returned by the callback handler when the OAuth state
+// parameter is missing, expired, or does not match the one we issued. Never
+// leak details beyond "invalid state" to the browser.
+var ErrStateInvalid = errors.New("oauth: invalid state")

--- a/pkg/plugin/oauth/exchange.go
+++ b/pkg/plugin/oauth/exchange.go
@@ -1,0 +1,93 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// tokenResponse matches the OAuth2 token-endpoint response body.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type,omitempty"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// exchangeCode trades an authorization code for a token pair.
+func exchangeCode(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, code, codeVerifier, redirectURI string) (Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", cfg.ClientID)
+	form.Set("redirect_uri", redirectURI)
+	if cfg.PKCE && codeVerifier != "" {
+		form.Set("code_verifier", codeVerifier)
+	}
+	return postToken(ctx, httpClient, cfg, form)
+}
+
+// refreshToken trades a refresh token for a fresh access token. The server
+// may or may not rotate the refresh token; whatever comes back is persisted.
+func refreshToken(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, refresh string) (Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refresh)
+	form.Set("client_id", cfg.ClientID)
+	return postToken(ctx, httpClient, cfg, form)
+}
+
+func postToken(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfig, form url.Values) (Token, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return Token{}, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if cfg.ClientSecret != "" {
+		// RFC 6749 §2.3.1: credentials in the Basic header are form-urlencoded.
+		req.SetBasicAuth(url.QueryEscape(cfg.ClientID), url.QueryEscape(cfg.ClientSecret))
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Token{}, fmt.Errorf("token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return Token{}, fmt.Errorf("read token response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return Token{}, fmt.Errorf("token endpoint returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var parsed tokenResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Token{}, fmt.Errorf("decode token response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return Token{}, fmt.Errorf("token endpoint returned empty access_token")
+	}
+
+	expiresAt := time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	if parsed.ExpiresIn == 0 {
+		// Unknown expiry: assume a short window so we refresh conservatively.
+		expiresAt = time.Now().Add(15 * time.Minute)
+	}
+	return Token{
+		AccessToken:  parsed.AccessToken,
+		RefreshToken: parsed.RefreshToken,
+		TokenType:    parsed.TokenType,
+		ExpiresAt:    expiresAt,
+	}, nil
+}

--- a/pkg/plugin/oauth/exchange.go
+++ b/pkg/plugin/oauth/exchange.go
@@ -79,10 +79,13 @@ func postToken(ctx context.Context, httpClient *http.Client, cfg *mcp.OAuthConfi
 		return Token{}, fmt.Errorf("token endpoint returned empty access_token")
 	}
 
-	expiresAt := time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
-	if parsed.ExpiresIn == 0 {
-		// Unknown expiry: assume a short window so we refresh conservatively.
-		expiresAt = time.Now().Add(15 * time.Minute)
+	// A missing expires_in means the token does not expire (e.g. GitHub OAuth
+	// app tokens). Leave ExpiresAt zero — Expired/NeedsRefresh treat zero as
+	// never — rather than inventing a lifetime that would force refreshes the
+	// provider cannot serve.
+	var expiresAt time.Time
+	if parsed.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(parsed.ExpiresIn) * time.Second)
 	}
 	return Token{
 		AccessToken:  parsed.AccessToken,

--- a/pkg/plugin/oauth/handlers.go
+++ b/pkg/plugin/oauth/handlers.go
@@ -63,7 +63,7 @@ func splitOAuthPath(p string) (serverID, action string, ok bool) {
 func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request, serverID string, cfg *mcp.OAuthConfig, userIDFn UserIDFn) {
 	userID := userIDFn(r)
 	if userID == 0 {
-		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		http.Error(w, "Per-user OAuth requires a signed-in Grafana user; anonymous sessions have no identity to store a token for. Sign in and try Connect again.", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/plugin/oauth/handlers.go
+++ b/pkg/plugin/oauth/handlers.go
@@ -1,0 +1,282 @@
+package oauth
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// UserIDFn extracts the Grafana user ID from an incoming plugin resource
+// request. The plugin supplies this so we don't circular-import pkg/plugin.
+type UserIDFn func(*http.Request) int64
+
+// RegisterRoutes mounts the OAuth HTTP handlers on the given mux. All paths
+// live under /api/oauth/{serverID}/{start|callback|status|disconnect}.
+func (m *Manager) RegisterRoutes(mux *http.ServeMux, userIDFn UserIDFn) {
+	mux.HandleFunc("/api/oauth/", func(w http.ResponseWriter, r *http.Request) {
+		serverID, action, ok := splitOAuthPath(r.URL.Path)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		cfg := m.ConfigFor(serverID)
+		if cfg == nil {
+			http.Error(w, "server has no oauth configured", http.StatusNotFound)
+			return
+		}
+		switch action {
+		case "start":
+			m.handleStart(w, r, serverID, cfg, userIDFn)
+		case "callback":
+			m.handleCallback(w, r, serverID, cfg)
+		case "status":
+			m.handleStatus(w, r, serverID, userIDFn)
+		case "disconnect":
+			m.handleDisconnect(w, r, serverID, userIDFn)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// splitOAuthPath parses /api/oauth/{serverID}/{action}.
+func splitOAuthPath(p string) (serverID, action string, ok bool) {
+	trimmed := strings.TrimPrefix(p, "/api/oauth/")
+	if trimmed == p {
+		return "", "", false
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func (m *Manager) handleStart(w http.ResponseWriter, r *http.Request, serverID string, cfg *mcp.OAuthConfig, userIDFn UserIDFn) {
+	userID := userIDFn(r)
+	if userID == 0 {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+
+	state, err := NewState()
+	if err != nil {
+		m.logger.Error("generate oauth state", "err", err)
+		http.Error(w, "oauth init failed", http.StatusInternalServerError)
+		return
+	}
+
+	redirectURI := ResolveRedirectURI(r, serverID, cfg)
+
+	entry := StateEntry{ServerID: serverID, UserID: userID}
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", cfg.ClientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", state)
+	if len(cfg.Scopes) > 0 {
+		q.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	if cfg.PKCE {
+		verifier, challenge, err := NewPKCEPair()
+		if err != nil {
+			m.logger.Error("generate pkce pair", "err", err)
+			http.Error(w, "oauth init failed", http.StatusInternalServerError)
+			return
+		}
+		entry.CodeVerifier = verifier
+		q.Set("code_challenge", challenge)
+		q.Set("code_challenge_method", "S256")
+	}
+
+	if err := m.state.Put(r.Context(), state, entry); err != nil {
+		m.logger.Error("persist oauth state", "err", err)
+		http.Error(w, "oauth init failed", http.StatusInternalServerError)
+		return
+	}
+
+	authURL := cfg.AuthorizationURL
+	sep := "?"
+	if strings.Contains(authURL, "?") {
+		sep = "&"
+	}
+	http.Redirect(w, r, authURL+sep+q.Encode(), http.StatusFound)
+}
+
+func (m *Manager) handleCallback(w http.ResponseWriter, r *http.Request, serverID string, cfg *mcp.OAuthConfig) {
+	q := r.URL.Query()
+	if providerErr := q.Get("error"); providerErr != "" {
+		// error / error_description are attacker-controllable query params;
+		// writeCallbackHTML escapes them for both HTML and script contexts.
+		writeCallbackHTML(w, serverID, false, fmt.Sprintf("%s: %s", providerErr, q.Get("error_description")))
+		return
+	}
+	state := q.Get("state")
+	code := q.Get("code")
+	if state == "" || code == "" {
+		writeCallbackHTML(w, serverID, false, "missing state or code")
+		return
+	}
+
+	entry, err := m.state.PopAndGet(r.Context(), state)
+	if err != nil {
+		writeCallbackHTML(w, serverID, false, "invalid state")
+		return
+	}
+	if entry.ServerID != serverID {
+		writeCallbackHTML(w, serverID, false, "state/server mismatch")
+		return
+	}
+
+	redirectURI := ResolveRedirectURI(r, serverID, cfg)
+	tok, err := exchangeCode(r.Context(), m.httpClient, cfg, code, entry.CodeVerifier, redirectURI)
+	if err != nil {
+		m.logger.Warn("token exchange", "server", serverID, "err", err)
+		writeCallbackHTML(w, serverID, false, "token exchange failed")
+		return
+	}
+
+	if err := m.tokens.Put(r.Context(), serverID, entry.UserID, tok); err != nil {
+		m.logger.Error("persist token", "server", serverID, "userID", entry.UserID, "err", err)
+		writeCallbackHTML(w, serverID, false, "could not persist token")
+		return
+	}
+	writeCallbackHTML(w, serverID, true, "")
+}
+
+// StatusResponse is the JSON payload for /status and the per-server oauth
+// map returned by /api/mcp/servers.
+type StatusResponse struct {
+	Configured bool      `json:"configured"`
+	Connected  bool      `json:"connected"`
+	ExpiresAt  time.Time `json:"expiresAt,omitempty"`
+}
+
+func (m *Manager) handleStatus(w http.ResponseWriter, r *http.Request, serverID string, userIDFn UserIDFn) {
+	userID := userIDFn(r)
+	w.Header().Set("Content-Type", "application/json")
+	if userID == 0 {
+		_ = json.NewEncoder(w).Encode(StatusResponse{Configured: true})
+		return
+	}
+	tok, ok, err := m.tokens.Get(r.Context(), serverID, userID)
+	if err != nil {
+		m.logger.Warn("status token lookup", "server", serverID, "err", err)
+		http.Error(w, "lookup failed", http.StatusInternalServerError)
+		return
+	}
+	resp := StatusResponse{Configured: true, Connected: ok && (!tok.Expired() || tok.RefreshToken != "")}
+	if ok {
+		resp.ExpiresAt = tok.ExpiresAt
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (m *Manager) handleDisconnect(w http.ResponseWriter, r *http.Request, serverID string, userIDFn UserIDFn) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	userID := userIDFn(r)
+	if userID == 0 {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	if err := m.tokens.Delete(r.Context(), serverID, userID); err != nil {
+		m.logger.Warn("disconnect", "server", serverID, "err", err)
+		http.Error(w, "disconnect failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ResolveRedirectURI returns the callback URL registered with the
+// authorization server. Preference order: the explicit config value, the
+// Grafana AppURL from the plugin context (correct behind subpaths), then a
+// reconstruction from forwarded headers.
+func ResolveRedirectURI(r *http.Request, serverID string, cfg *mcp.OAuthConfig) string {
+	if cfg != nil && cfg.RedirectURI != "" {
+		return cfg.RedirectURI
+	}
+	return CallbackURL(r, serverID)
+}
+
+// CallbackURL derives the plugin's OAuth callback URL for a server from the
+// incoming request environment.
+func CallbackURL(r *http.Request, serverID string) string {
+	base := grafanaBaseURL(r)
+	return fmt.Sprintf("%s/api/plugins/consensys-asko11y-app/resources/api/oauth/%s/callback", base, url.PathEscape(serverID))
+}
+
+func grafanaBaseURL(r *http.Request) string {
+	if grafanaCfg := backend.GrafanaConfigFromContext(r.Context()); grafanaCfg != nil {
+		if appURL, err := grafanaCfg.AppURL(); err == nil && appURL != "" {
+			return strings.TrimSuffix(appURL, "/")
+		}
+	}
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	return scheme + "://" + host
+}
+
+// writeCallbackHTML writes a tiny HTML page that notifies the opening window
+// of the flow's outcome and closes itself. The payload is embedded as JSON —
+// encoding/json escapes <, >, and & as <-style sequences, so untrusted
+// provider-supplied strings (error_description) cannot break out of the
+// script block; visible text is HTML-escaped separately.
+func writeCallbackHTML(w http.ResponseWriter, serverID string, success bool, reason string) {
+	payload, err := json.Marshal(map[string]interface{}{
+		"source":   "asko11y-oauth",
+		"serverID": serverID,
+		"success":  success,
+		"reason":   reason,
+	})
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	visible := statusWord(success)
+	if reason != "" {
+		visible += ": " + reason
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>OAuth %s</title></head><body>
+<p>%s</p>
+<script>
+try {
+  if (window.opener) {
+    window.opener.postMessage(%s, '*');
+  }
+} catch (e) {}
+setTimeout(function() { window.close(); }, 500);
+</script>
+</body></html>`, statusWord(success), html.EscapeString(visible), payload)
+}
+
+func statusWord(success bool) string {
+	if success {
+		return "connected"
+	}
+	return "failed"
+}

--- a/pkg/plugin/oauth/handlers_test.go
+++ b/pkg/plugin/oauth/handlers_test.go
@@ -1,0 +1,192 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// fakeAuthServer implements the authorize + token endpoints of an OAuth
+// provider in-process so the full handshake can be driven under test.
+func fakeAuthServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		redirect := r.URL.Query().Get("redirect_uri")
+		state := r.URL.Query().Get("state")
+		http.Redirect(w, r, redirect+"?code=fake-code&state="+state, http.StatusFound)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("code") != "fake-code" {
+			http.Error(w, "bad code", http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("code_verifier") == "" {
+			http.Error(w, "missing PKCE verifier", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"AT","refresh_token":"RT","expires_in":3600,"token_type":"Bearer"}`))
+	})
+	s := httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s, &calls
+}
+
+func newTestManager(t *testing.T, servers []mcp.ServerConfig) *Manager {
+	t.Helper()
+	return NewManager(NewInMemoryUserTokenStore(), NewInMemoryStateStore(), http.DefaultClient, log.New(), servers)
+}
+
+func TestHandlersFullFlow(t *testing.T) {
+	fake, tokenCalls := fakeAuthServer(t)
+
+	cfg := &mcp.OAuthConfig{
+		AuthorizationURL: fake.URL + "/authorize",
+		TokenURL:         fake.URL + "/token",
+		ClientID:         "ask-o11y",
+		PKCE:             true,
+	}
+	server := mcp.ServerConfig{ID: "atlassian", OAuth: cfg}
+	mgr := newTestManager(t, []mcp.ServerConfig{server})
+
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, func(*http.Request) int64 { return 42 })
+
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+	// Point the registered redirect URI back at the test server so both the
+	// authorize redirect and the token exchange use it.
+	cfg.RedirectURI = plugin.URL + "/api/oauth/atlassian/callback"
+
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/start")
+	if err != nil {
+		t.Fatalf("start GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after full redirect chain, got %s", resp.Status)
+	}
+	if *tokenCalls != 1 {
+		t.Fatalf("expected token endpoint called once, got %d", *tokenCalls)
+	}
+
+	statusResp, err := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/status")
+	if err != nil {
+		t.Fatalf("status GET: %v", err)
+	}
+	defer statusResp.Body.Close()
+	var sr StatusResponse
+	if err := json.NewDecoder(statusResp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if !sr.Connected {
+		t.Fatalf("expected connected, got %+v", sr)
+	}
+
+	// The manager should now be able to serve the token as a bearer.
+	bearer, err := mgr.BearerFor(mcp.WithUserID(t.Context(), 42), "atlassian")
+	if err != nil || bearer != "AT" {
+		t.Fatalf("BearerFor: bearer=%q err=%v", bearer, err)
+	}
+
+	// Disconnect flips status back.
+	req, _ := http.NewRequest(http.MethodPost, plugin.URL+"/api/oauth/atlassian/disconnect", nil)
+	discResp, err := plugin.Client().Do(req)
+	if err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	_ = discResp.Body.Close()
+	if discResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %s", discResp.Status)
+	}
+	statusResp2, _ := plugin.Client().Get(plugin.URL + "/api/oauth/atlassian/status")
+	var sr2 StatusResponse
+	_ = json.NewDecoder(statusResp2.Body).Decode(&sr2)
+	statusResp2.Body.Close()
+	if sr2.Connected {
+		t.Fatalf("expected disconnected after disconnect, got %+v", sr2)
+	}
+}
+
+func TestCallbackRejectsUnknownState(t *testing.T) {
+	cfg := &mcp.OAuthConfig{AuthorizationURL: "http://x", TokenURL: "http://x/token", ClientID: "c"}
+	mgr := newTestManager(t, []mcp.ServerConfig{{ID: "s", OAuth: cfg}})
+
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, func(*http.Request) int64 { return 1 })
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+
+	q := url.Values{"code": {"c"}, "state": {"bogus"}}
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/s/callback?" + q.Encode())
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer resp.Body.Close()
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	if !strings.Contains(string(buf[:n]), "invalid state") {
+		t.Fatalf("expected 'invalid state' in body, got %s", string(buf[:n]))
+	}
+}
+
+// TestCallbackEscapesProviderError guards against reflected XSS: the
+// provider-controlled error/error_description query params must never reach
+// the HTML or script context unescaped.
+func TestCallbackEscapesProviderError(t *testing.T) {
+	cfg := &mcp.OAuthConfig{AuthorizationURL: "http://x", TokenURL: "http://x/token", ClientID: "c"}
+	mgr := newTestManager(t, []mcp.ServerConfig{{ID: "s", OAuth: cfg}})
+
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, func(*http.Request) int64 { return 1 })
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+
+	payload := `</script><script>alert(document.cookie)</script>`
+	q := url.Values{"error": {"access_denied"}, "error_description": {payload}}
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/s/callback?" + q.Encode())
+	if err != nil {
+		t.Fatalf("callback: %v", err)
+	}
+	defer resp.Body.Close()
+	buf := make([]byte, 8192)
+	n, _ := resp.Body.Read(buf)
+	body := string(buf[:n])
+	if strings.Contains(body, "</script><script>") {
+		t.Fatalf("provider error reflected unescaped:\n%s", body)
+	}
+	if !strings.Contains(body, "access_denied") {
+		t.Fatalf("expected error code to still be reported:\n%s", body)
+	}
+}
+
+func TestUnknownServer404s(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	mux := http.NewServeMux()
+	mgr.RegisterRoutes(mux, func(*http.Request) int64 { return 1 })
+	plugin := httptest.NewServer(mux)
+	t.Cleanup(plugin.Close)
+
+	resp, err := plugin.Client().Get(plugin.URL + "/api/oauth/nope/status")
+	if err != nil {
+		t.Fatalf("status GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown server, got %s", resp.Status)
+	}
+}

--- a/pkg/plugin/oauth/keys.go
+++ b/pkg/plugin/oauth/keys.go
@@ -1,0 +1,27 @@
+package oauth
+
+import (
+	"strconv"
+	"strings"
+)
+
+// serverIDEscape replaces Redis key separators in server IDs so keys remain
+// parseable. Server IDs come from provisioning YAML or the admin UI and are
+// already validated by the plugin, but we stay defensive.
+func serverIDEscape(s string) string {
+	return strings.ReplaceAll(s, ":", "_")
+}
+
+func userIDString(id int64) string {
+	return strconv.FormatInt(id, 10)
+}
+
+// tokenRedisKey is the Redis key used to store a user's token for a server.
+func tokenRedisKey(serverID string, userID int64) string {
+	return "mcp_oauth:" + serverIDEscape(serverID) + ":" + userIDString(userID)
+}
+
+// stateRedisKey is the Redis key for a pending OAuth state.
+func stateRedisKey(state string) string {
+	return "mcp_oauth_state:" + state
+}

--- a/pkg/plugin/oauth/manager.go
+++ b/pkg/plugin/oauth/manager.go
@@ -159,5 +159,14 @@ func (m *Manager) refresh(ctx context.Context, serverID string, tok Token) (Toke
 	if tok.RefreshToken == "" {
 		return Token{}, fmt.Errorf("no refresh token available")
 	}
-	return refreshToken(ctx, m.httpClient, cfg, tok.RefreshToken)
+	refreshed, err := refreshToken(ctx, m.httpClient, cfg, tok.RefreshToken)
+	if err != nil {
+		return Token{}, err
+	}
+	// Providers that don't rotate refresh tokens omit them from the refresh
+	// response; keep the current one so the next refresh still works.
+	if refreshed.RefreshToken == "" {
+		refreshed.RefreshToken = tok.RefreshToken
+	}
+	return refreshed, nil
 }

--- a/pkg/plugin/oauth/manager.go
+++ b/pkg/plugin/oauth/manager.go
@@ -1,0 +1,163 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// Manager wires together the OAuth HTTP handlers, stores, and per-server
+// configuration. A single Manager is created in NewPlugin and shared across
+// the plugin's lifetime. It implements mcp.PerUserTokenProvider.
+type Manager struct {
+	tokens     UserTokenStore
+	state      StateStore
+	httpClient *http.Client
+	logger     log.Logger
+	configs    map[string]*mcp.OAuthConfig // keyed by server ID
+	mu         sync.RWMutex
+	// refreshMu serializes token refresh per (serverID, userID). Providers
+	// commonly rotate the refresh token on use; two concurrent refreshes
+	// would let the loser persist a token derived from a consumed refresh
+	// token and lock the user out until they reconnect.
+	refreshMu sync.Map // string -> *sync.Mutex
+}
+
+// NewManager returns a Manager seeded with the OAuth configs declared on the
+// given server list. Servers without an OAuth block are ignored. httpClient
+// is used for token exchange/refresh and must come from the Grafana SDK's
+// httpclient.New.
+func NewManager(tokens UserTokenStore, state StateStore, httpClient *http.Client, logger log.Logger, servers []mcp.ServerConfig) *Manager {
+	m := &Manager{
+		tokens:     tokens,
+		state:      state,
+		httpClient: httpClient,
+		logger:     logger,
+		configs:    map[string]*mcp.OAuthConfig{},
+	}
+	for _, s := range servers {
+		if s.OAuth != nil {
+			m.configs[s.ID] = s.OAuth
+		}
+	}
+	return m
+}
+
+// ConfigFor returns the OAuth config for the given server, or nil if the
+// server does not use OAuth.
+func (m *Manager) ConfigFor(serverID string) *mcp.OAuthConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.configs[serverID]
+}
+
+// RegisterConfig inserts an OAuth config for a server added at runtime
+// through the AppConfig UI. Safe to call on an already-registered server.
+func (m *Manager) RegisterConfig(serverID string, cfg *mcp.OAuthConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.configs[serverID] = cfg
+}
+
+// UnregisterConfig removes the OAuth config for a server. Called when a
+// server is removed from the runtime registry.
+func (m *Manager) UnregisterConfig(serverID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.configs, serverID)
+}
+
+// ServerIDs returns the set of server IDs known to this manager.
+func (m *Manager) ServerIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, 0, len(m.configs))
+	for id := range m.configs {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Tokens exposes the underlying token store for status reporting and tests.
+func (m *Manager) Tokens() UserTokenStore { return m.tokens }
+
+// BearerFor implements mcp.PerUserTokenProvider. It reads the user ID from
+// the context, resolves the current token (refreshing if needed), and
+// returns the bearer value to inject in the Authorization header.
+func (m *Manager) BearerFor(ctx context.Context, serverID string) (string, error) {
+	userID, ok := mcp.UserIDFromContext(ctx)
+	if !ok {
+		return "", mcp.ErrPerUserTokenUnavailable
+	}
+	tok, err := m.TokenFor(ctx, serverID, userID)
+	if errors.Is(err, ErrOAuthNotConnected) {
+		return "", mcp.ErrPerUserTokenUnavailable
+	}
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+// TokenFor returns the stored token for a user on a server, refreshing it
+// when close to expiry. Returns ErrOAuthNotConnected when no token is stored.
+func (m *Manager) TokenFor(ctx context.Context, serverID string, userID int64) (Token, error) {
+	tok, ok, err := m.tokens.Get(ctx, serverID, userID)
+	if err != nil {
+		return Token{}, fmt.Errorf("token lookup: %w", err)
+	}
+	if !ok {
+		return Token{}, ErrOAuthNotConnected
+	}
+	if !tok.NeedsRefresh() {
+		return tok, nil
+	}
+
+	muAny, _ := m.refreshMu.LoadOrStore(memTokenKey(serverID, userID), &sync.Mutex{})
+	mu := muAny.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Re-read under the lock: a concurrent call may have refreshed already.
+	tok, ok, err = m.tokens.Get(ctx, serverID, userID)
+	if err != nil {
+		return Token{}, fmt.Errorf("token lookup: %w", err)
+	}
+	if !ok {
+		return Token{}, ErrOAuthNotConnected
+	}
+	if !tok.NeedsRefresh() {
+		return tok, nil
+	}
+	refreshed, err := m.refresh(ctx, serverID, tok)
+	if err != nil {
+		if tok.Expired() {
+			return Token{}, err
+		}
+		// Refresh failed but the token is still valid for a little while;
+		// return it so the in-flight request succeeds and retry next call.
+		m.logger.Warn("OAuth refresh failed, returning current token", "server", serverID, "err", err)
+		return tok, nil
+	}
+	if err := m.tokens.Put(ctx, serverID, userID, refreshed); err != nil {
+		m.logger.Warn("persist refreshed token", "server", serverID, "err", err)
+	}
+	return refreshed, nil
+}
+
+func (m *Manager) refresh(ctx context.Context, serverID string, tok Token) (Token, error) {
+	cfg := m.ConfigFor(serverID)
+	if cfg == nil {
+		return Token{}, fmt.Errorf("no oauth config for server %q", serverID)
+	}
+	if tok.RefreshToken == "" {
+		return Token{}, fmt.Errorf("no refresh token available")
+	}
+	return refreshToken(ctx, m.httpClient, cfg, tok.RefreshToken)
+}

--- a/pkg/plugin/oauth/manager_test.go
+++ b/pkg/plugin/oauth/manager_test.go
@@ -1,0 +1,70 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// TestRefreshPreservesRefreshToken guards against wiping the stored refresh
+// token when the provider's refresh response omits one (non-rotating
+// providers reuse the original refresh token).
+func TestRefreshPreservesRefreshToken(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// No refresh_token in the response.
+		_, _ = w.Write([]byte(`{"access_token":"AT2","expires_in":3600,"token_type":"Bearer"}`))
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	cfg := &mcp.OAuthConfig{AuthorizationURL: ts.URL + "/authorize", TokenURL: ts.URL + "/token", ClientID: "c"}
+	tokens := NewInMemoryUserTokenStore()
+	mgr := NewManager(tokens, NewInMemoryStateStore(), ts.Client(), log.New(), []mcp.ServerConfig{{ID: "s", OAuth: cfg}})
+
+	ctx := context.Background()
+	// Stored token is inside the refresh window.
+	_ = tokens.Put(ctx, "s", 7, Token{AccessToken: "AT1", RefreshToken: "RT1", ExpiresAt: time.Now().Add(10 * time.Second)})
+
+	got, err := mgr.TokenFor(ctx, "s", 7)
+	if err != nil {
+		t.Fatalf("TokenFor: %v", err)
+	}
+	if got.AccessToken != "AT2" {
+		t.Fatalf("expected refreshed access token, got %q", got.AccessToken)
+	}
+	if got.RefreshToken != "RT1" {
+		t.Fatalf("expected original refresh token preserved, got %q", got.RefreshToken)
+	}
+	stored, ok, _ := tokens.Get(ctx, "s", 7)
+	if !ok || stored.RefreshToken != "RT1" {
+		t.Fatalf("persisted token lost the refresh token: %+v", stored)
+	}
+}
+
+// TestNonExpiringTokenNeverRefreshes covers providers (GitHub OAuth apps)
+// that omit expires_in: the token must stay usable indefinitely instead of
+// being treated as expiring after an invented lifetime.
+func TestNonExpiringTokenNeverRefreshes(t *testing.T) {
+	cfg := &mcp.OAuthConfig{AuthorizationURL: "http://x", TokenURL: "http://x/token", ClientID: "c"}
+	tokens := NewInMemoryUserTokenStore()
+	mgr := NewManager(tokens, NewInMemoryStateStore(), http.DefaultClient, log.New(), []mcp.ServerConfig{{ID: "s", OAuth: cfg}})
+
+	ctx := context.Background()
+	_ = tokens.Put(ctx, "s", 7, Token{AccessToken: "AT"}) // zero ExpiresAt, no refresh token
+
+	got, err := mgr.TokenFor(ctx, "s", 7)
+	if err != nil {
+		t.Fatalf("TokenFor: %v", err)
+	}
+	if got.AccessToken != "AT" {
+		t.Fatalf("expected stored token returned as-is, got %+v", got)
+	}
+}

--- a/pkg/plugin/oauth/presets.go
+++ b/pkg/plugin/oauth/presets.go
@@ -61,11 +61,13 @@ func Presets() map[PresetID]Preset {
 			ID:          PresetAtlassian,
 			DisplayName: "Atlassian (Jira + Confluence)",
 			ServerID:    "atlassian",
-			MCPURL:      "https://mcp.atlassian.com/v1/sse",
-			Transport:   "sse",
-			Scopes:      []string{"offline_access"},
-			DCRCapable:  true,
-			PKCE:        true,
+			// Streamable HTTP endpoint; the legacy /v1/sse transport drops
+			// long-lived streams at Atlassian's Cloudflare edge.
+			MCPURL:     "https://mcp.atlassian.com/v1/mcp",
+			Transport:  "streamable-http",
+			Scopes:     []string{"offline_access"},
+			DCRCapable: true,
+			PKCE:       true,
 		},
 	}
 }

--- a/pkg/plugin/oauth/presets.go
+++ b/pkg/plugin/oauth/presets.go
@@ -1,0 +1,71 @@
+package oauth
+
+// PresetID identifies a one-click MCP provider.
+type PresetID string
+
+const (
+	PresetGitHubRead  PresetID = "github-read"
+	PresetGitHubWrite PresetID = "github-write"
+	PresetAtlassian   PresetID = "atlassian"
+)
+
+// Preset describes a known external MCP provider the admin can add with one
+// click from the UI. For providers that support RFC 7591 dynamic client
+// registration (Atlassian), DCRCapable is true and the client_id is issued
+// automatically. For providers that require a pre-registered OAuth app
+// (GitHub), DCRCapable is false and the admin must supply clientID (and
+// optionally clientSecret) at provisioning time.
+type Preset struct {
+	ID            PresetID
+	DisplayName   string   // shown in the UI card and as the MCP server name
+	ServerID      string   // the ID the ServerConfig will take (unique per preset)
+	MCPURL        string   // endpoint that speaks MCP over HTTP
+	Transport     string   // "streamable-http" | "sse"
+	Scopes        []string // scopes requested in the authorize URL
+	DCRCapable    bool
+	AuthEndpoint  string // used only when DCRCapable is false
+	TokenEndpoint string // used only when DCRCapable is false
+	PKCE          bool
+}
+
+// Presets returns the built-in preset catalog.
+func Presets() map[PresetID]Preset {
+	// #nosec G101 -- these are public OAuth endpoint URLs and scope names,
+	// not credentials; gosec pattern-matches the token-endpoint literals.
+	return map[PresetID]Preset{
+		PresetGitHubRead: {
+			ID:            PresetGitHubRead,
+			DisplayName:   "GitHub (read-only)",
+			ServerID:      "github-read",
+			MCPURL:        "https://api.githubcopilot.com/mcp/",
+			Transport:     "streamable-http",
+			Scopes:        []string{"read:user", "read:org", "read:project", "read:packages", "notifications"},
+			DCRCapable:    false,
+			AuthEndpoint:  "https://github.com/login/oauth/authorize",
+			TokenEndpoint: "https://github.com/login/oauth/access_token",
+			PKCE:          true,
+		},
+		PresetGitHubWrite: {
+			ID:            PresetGitHubWrite,
+			DisplayName:   "GitHub (read / write)",
+			ServerID:      "github-write",
+			MCPURL:        "https://api.githubcopilot.com/mcp/",
+			Transport:     "streamable-http",
+			Scopes:        []string{"repo", "user:email", "read:org", "project", "workflow", "write:packages", "notifications", "codespace"},
+			DCRCapable:    false,
+			AuthEndpoint:  "https://github.com/login/oauth/authorize",
+			TokenEndpoint: "https://github.com/login/oauth/access_token",
+			PKCE:          true,
+		},
+		PresetAtlassian: {
+			ID:          PresetAtlassian,
+			DisplayName: "Atlassian (Jira + Confluence)",
+			ServerID:    "atlassian",
+			MCPURL:      "https://mcp.atlassian.com/v1/sse",
+			Transport:   "sse",
+			Scopes:      []string{"offline_access"},
+			DCRCapable:  true,
+			PKCE:        true,
+		},
+	}
+}

--- a/pkg/plugin/oauth/servers.go
+++ b/pkg/plugin/oauth/servers.go
@@ -1,0 +1,114 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+
+	"consensys-asko11y-app/pkg/mcp"
+)
+
+// DynamicServer is the persisted record for an MCP server added through the
+// UI at runtime (rather than via provisioning YAML).
+type DynamicServer struct {
+	Config                  mcp.ServerConfig `json:"config"`
+	PresetID                string           `json:"presetID,omitempty"`
+	RegistrationClientURI   string           `json:"registrationClientURI,omitempty"`
+	RegistrationAccessToken string           `json:"registrationAccessToken,omitempty"`
+}
+
+// DynamicServerStore persists runtime-added MCP server records so they
+// survive plugin restarts.
+type DynamicServerStore interface {
+	Put(ctx context.Context, server DynamicServer) error
+	Delete(ctx context.Context, serverID string) error
+	List(ctx context.Context) ([]DynamicServer, error)
+}
+
+// InMemoryDynamicServerStore is sufficient for single-replica dev; records
+// are lost on plugin restart.
+type InMemoryDynamicServerStore struct {
+	mu      sync.RWMutex
+	records map[string]DynamicServer
+}
+
+func NewInMemoryDynamicServerStore() *InMemoryDynamicServerStore {
+	return &InMemoryDynamicServerStore{records: map[string]DynamicServer{}}
+}
+
+func (s *InMemoryDynamicServerStore) Put(_ context.Context, server DynamicServer) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[server.Config.ID] = server
+	return nil
+}
+
+func (s *InMemoryDynamicServerStore) Delete(_ context.Context, serverID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, serverID)
+	return nil
+}
+
+func (s *InMemoryDynamicServerStore) List(_ context.Context) ([]DynamicServer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]DynamicServer, 0, len(s.records))
+	for _, v := range s.records {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// RedisDynamicServerStore persists dynamic server records under a single
+// Redis hash so list operations are one round-trip.
+type RedisDynamicServerStore struct {
+	client *redis.Client
+	logger log.Logger
+}
+
+const redisDynamicServersKey = "mcp_dynamic_servers"
+
+func NewRedisDynamicServerStore(client *redis.Client, logger log.Logger) *RedisDynamicServerStore {
+	return &RedisDynamicServerStore{client: client, logger: logger}
+}
+
+func (s *RedisDynamicServerStore) Put(ctx context.Context, server DynamicServer) error {
+	raw, err := json.Marshal(server)
+	if err != nil {
+		return fmt.Errorf("encode dynamic server: %w", err)
+	}
+	if err := s.client.HSet(ctx, redisDynamicServersKey, server.Config.ID, raw).Err(); err != nil {
+		return fmt.Errorf("redis hset: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisDynamicServerStore) Delete(ctx context.Context, serverID string) error {
+	if err := s.client.HDel(ctx, redisDynamicServersKey, serverID).Err(); err != nil {
+		return fmt.Errorf("redis hdel: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisDynamicServerStore) List(ctx context.Context) ([]DynamicServer, error) {
+	m, err := s.client.HGetAll(ctx, redisDynamicServersKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return nil, fmt.Errorf("redis hgetall: %w", err)
+	}
+	out := make([]DynamicServer, 0, len(m))
+	for _, raw := range m {
+		var v DynamicServer
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			s.logger.Warn("skip corrupt dynamic server record", "err", err)
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/pkg/plugin/oauth/state.go
+++ b/pkg/plugin/oauth/state.go
@@ -1,0 +1,139 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+)
+
+// StateTTL is how long a pending authorization-code flow is kept alive. The
+// state parameter travels through a browser redirect and must be one-shot
+// and short-lived.
+const StateTTL = 5 * time.Minute
+
+// StateEntry stores everything needed to complete the authorization-code
+// exchange in the /callback handler.
+type StateEntry struct {
+	ServerID     string    `json:"serverID"`
+	UserID       int64     `json:"userID"`
+	CodeVerifier string    `json:"codeVerifier,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+// StateStore persists pending-flow state keyed by the opaque `state` param
+// passed to the authorization server.
+type StateStore interface {
+	Put(ctx context.Context, state string, entry StateEntry) error
+	// PopAndGet atomically consumes the state so it cannot be replayed.
+	PopAndGet(ctx context.Context, state string) (StateEntry, error)
+}
+
+// InMemoryStateStore is process-local and sufficient for single-replica or
+// dev environments.
+type InMemoryStateStore struct {
+	mu      sync.Mutex
+	entries map[string]StateEntry
+}
+
+func NewInMemoryStateStore() *InMemoryStateStore {
+	return &InMemoryStateStore{entries: map[string]StateEntry{}}
+}
+
+func (s *InMemoryStateStore) Put(_ context.Context, state string, entry StateEntry) error {
+	entry.CreatedAt = time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Opportunistically prune expired entries so abandoned flows don't
+	// accumulate for the plugin's lifetime.
+	for k, e := range s.entries {
+		if time.Since(e.CreatedAt) > StateTTL {
+			delete(s.entries, k)
+		}
+	}
+	s.entries[state] = entry
+	return nil
+}
+
+func (s *InMemoryStateStore) PopAndGet(_ context.Context, state string) (StateEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[state]
+	if !ok {
+		return StateEntry{}, ErrStateInvalid
+	}
+	delete(s.entries, state)
+	if time.Since(e.CreatedAt) > StateTTL {
+		return StateEntry{}, ErrStateInvalid
+	}
+	return e, nil
+}
+
+// RedisStateStore persists pending state in Redis with a short TTL so the
+// callback can land on any Grafana replica.
+type RedisStateStore struct {
+	client *redis.Client
+	logger log.Logger
+}
+
+func NewRedisStateStore(client *redis.Client, logger log.Logger) *RedisStateStore {
+	return &RedisStateStore{client: client, logger: logger}
+}
+
+func (s *RedisStateStore) Put(ctx context.Context, state string, entry StateEntry) error {
+	entry.CreatedAt = time.Now()
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode state: %w", err)
+	}
+	if err := s.client.Set(ctx, stateRedisKey(state), raw, StateTTL).Err(); err != nil {
+		return fmt.Errorf("redis set state: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisStateStore) PopAndGet(ctx context.Context, state string) (StateEntry, error) {
+	// GETDEL atomically reads and removes the key, preventing replay.
+	raw, err := s.client.GetDel(ctx, stateRedisKey(state)).Result()
+	if errors.Is(err, redis.Nil) {
+		return StateEntry{}, ErrStateInvalid
+	}
+	if err != nil {
+		return StateEntry{}, fmt.Errorf("redis getdel state: %w", err)
+	}
+	var e StateEntry
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		return StateEntry{}, fmt.Errorf("decode state: %w", err)
+	}
+	return e, nil
+}
+
+// NewState returns a cryptographically random opaque string suitable for use
+// as the OAuth `state` parameter.
+func NewState() (string, error) {
+	var buf [32]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf[:]), nil
+}
+
+// NewPKCEPair generates an RFC 7636 code_verifier and its S256 challenge.
+func NewPKCEPair() (verifier, challenge string, err error) {
+	var buf [64]byte
+	if _, err = rand.Read(buf[:]); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(buf[:])
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}

--- a/pkg/plugin/oauth/state_test.go
+++ b/pkg/plugin/oauth/state_test.go
@@ -1,0 +1,58 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInMemoryStateStoreRoundTrip(t *testing.T) {
+	s := NewInMemoryStateStore()
+	ctx := context.Background()
+
+	state, err := NewState()
+	if err != nil {
+		t.Fatalf("NewState: %v", err)
+	}
+	if err := s.Put(ctx, state, StateEntry{ServerID: "atlassian", UserID: 42, CodeVerifier: "v"}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, err := s.PopAndGet(ctx, state)
+	if err != nil {
+		t.Fatalf("popAndGet: %v", err)
+	}
+	if got.ServerID != "atlassian" || got.UserID != 42 || got.CodeVerifier != "v" {
+		t.Fatalf("unexpected entry: %+v", got)
+	}
+
+	// Replay must fail.
+	if _, err := s.PopAndGet(ctx, state); !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected ErrStateInvalid on replay, got %v", err)
+	}
+}
+
+func TestInMemoryStateStoreExpiry(t *testing.T) {
+	s := NewInMemoryStateStore()
+	ctx := context.Background()
+	// Insert an entry manually with a stale CreatedAt to force expiry.
+	s.entries["stale"] = StateEntry{CreatedAt: time.Now().Add(-2 * StateTTL)}
+	if _, err := s.PopAndGet(ctx, "stale"); !errors.Is(err, ErrStateInvalid) {
+		t.Fatalf("expected expired state to be rejected, got %v", err)
+	}
+}
+
+func TestPKCEPair(t *testing.T) {
+	v, c, err := NewPKCEPair()
+	if err != nil {
+		t.Fatalf("NewPKCEPair: %v", err)
+	}
+	if v == "" || c == "" {
+		t.Fatalf("empty verifier/challenge")
+	}
+	v2, c2, _ := NewPKCEPair()
+	if v == v2 || c == c2 {
+		t.Fatalf("PKCE pair not random across calls")
+	}
+}

--- a/pkg/plugin/oauth/store.go
+++ b/pkg/plugin/oauth/store.go
@@ -1,0 +1,72 @@
+package oauth
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Token is a stored OAuth2 access/refresh token pair for a single
+// (serverID, userID) tuple.
+type Token struct {
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"refreshToken,omitempty"`
+	TokenType    string    `json:"tokenType,omitempty"`
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+// Expired reports whether the token is past its expiry (with a small clock
+// skew allowance) at the current instant.
+func (t Token) Expired() bool {
+	return !t.ExpiresAt.IsZero() && time.Now().After(t.ExpiresAt.Add(-5*time.Second))
+}
+
+// NeedsRefresh reports whether the token is close enough to expiry that we
+// should refresh it proactively before the next outbound call.
+func (t Token) NeedsRefresh() bool {
+	return !t.ExpiresAt.IsZero() && time.Until(t.ExpiresAt) < 60*time.Second
+}
+
+// UserTokenStore persists per-user OAuth tokens scoped by MCP server.
+type UserTokenStore interface {
+	Get(ctx context.Context, serverID string, userID int64) (Token, bool, error)
+	Put(ctx context.Context, serverID string, userID int64, token Token) error
+	Delete(ctx context.Context, serverID string, userID int64) error
+}
+
+// InMemoryUserTokenStore is a process-local token store used when Redis is
+// unavailable. Tokens are lost on plugin restart — the same trade-off the
+// in-memory session store accepts.
+type InMemoryUserTokenStore struct {
+	mu     sync.RWMutex
+	tokens map[string]Token
+}
+
+func NewInMemoryUserTokenStore() *InMemoryUserTokenStore {
+	return &InMemoryUserTokenStore{tokens: map[string]Token{}}
+}
+
+func (s *InMemoryUserTokenStore) Get(_ context.Context, serverID string, userID int64) (Token, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.tokens[memTokenKey(serverID, userID)]
+	return t, ok, nil
+}
+
+func (s *InMemoryUserTokenStore) Put(_ context.Context, serverID string, userID int64, token Token) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[memTokenKey(serverID, userID)] = token
+	return nil
+}
+
+func (s *InMemoryUserTokenStore) Delete(_ context.Context, serverID string, userID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tokens, memTokenKey(serverID, userID))
+	return nil
+}
+
+func memTokenKey(serverID string, userID int64) string {
+	return serverIDEscape(serverID) + "|" + userIDString(userID)
+}

--- a/pkg/plugin/oauth/store.go
+++ b/pkg/plugin/oauth/store.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 )
@@ -32,6 +33,9 @@ type UserTokenStore interface {
 	Get(ctx context.Context, serverID string, userID int64) (Token, bool, error)
 	Put(ctx context.Context, serverID string, userID int64, token Token) error
 	Delete(ctx context.Context, serverID string, userID int64) error
+	// DeleteServer removes every user's token for a server. Called when the
+	// server is deprovisioned so stale credentials can't outlive it.
+	DeleteServer(ctx context.Context, serverID string) error
 }
 
 // InMemoryUserTokenStore is a process-local token store used when Redis is
@@ -64,6 +68,18 @@ func (s *InMemoryUserTokenStore) Delete(_ context.Context, serverID string, user
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.tokens, memTokenKey(serverID, userID))
+	return nil
+}
+
+func (s *InMemoryUserTokenStore) DeleteServer(_ context.Context, serverID string) error {
+	prefix := serverIDEscape(serverID) + "|"
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.tokens {
+		if strings.HasPrefix(k, prefix) {
+			delete(s.tokens, k)
+		}
+	}
 	return nil
 }
 

--- a/pkg/plugin/oauth/store_redis.go
+++ b/pkg/plugin/oauth/store_redis.go
@@ -43,10 +43,16 @@ func (s *RedisUserTokenStore) Put(ctx context.Context, serverID string, userID i
 		return fmt.Errorf("encode token: %w", err)
 	}
 	// Keep the record alive past access-token expiry so the refresh token
-	// stays usable; the manager refreshes lazily on the next call.
-	ttl := time.Until(token.ExpiresAt) + 30*24*time.Hour
-	if ttl <= 0 {
-		ttl = 30 * 24 * time.Hour
+	// stays usable; the manager refreshes lazily on the next call. A zero
+	// ExpiresAt means the provider's token never expires (e.g. GitHub OAuth
+	// apps) — persist it without a TTL so the connection doesn't silently
+	// lapse; disconnect and server deletion still remove it explicitly.
+	var ttl time.Duration // 0 = no expiration
+	if !token.ExpiresAt.IsZero() {
+		ttl = time.Until(token.ExpiresAt) + 30*24*time.Hour
+		if ttl <= 0 {
+			ttl = 30 * 24 * time.Hour
+		}
 	}
 	if err := s.client.Set(ctx, tokenRedisKey(serverID, userID), raw, ttl).Err(); err != nil {
 		return fmt.Errorf("redis set token: %w", err)

--- a/pkg/plugin/oauth/store_redis.go
+++ b/pkg/plugin/oauth/store_redis.go
@@ -60,3 +60,17 @@ func (s *RedisUserTokenStore) Delete(ctx context.Context, serverID string, userI
 	}
 	return nil
 }
+
+func (s *RedisUserTokenStore) DeleteServer(ctx context.Context, serverID string) error {
+	pattern := "mcp_oauth:" + serverIDEscape(serverID) + ":*"
+	iter := s.client.Scan(ctx, 0, pattern, 100).Iterator()
+	for iter.Next(ctx) {
+		if err := s.client.Del(ctx, iter.Val()).Err(); err != nil {
+			return fmt.Errorf("redis del token %s: %w", iter.Val(), err)
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("redis scan tokens: %w", err)
+	}
+	return nil
+}

--- a/pkg/plugin/oauth/store_redis.go
+++ b/pkg/plugin/oauth/store_redis.go
@@ -1,0 +1,62 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisUserTokenStore persists per-user OAuth tokens in Redis so they survive
+// plugin restarts and are shared across Grafana replicas.
+type RedisUserTokenStore struct {
+	client *redis.Client
+	logger log.Logger
+}
+
+func NewRedisUserTokenStore(client *redis.Client, logger log.Logger) *RedisUserTokenStore {
+	return &RedisUserTokenStore{client: client, logger: logger}
+}
+
+func (s *RedisUserTokenStore) Get(ctx context.Context, serverID string, userID int64) (Token, bool, error) {
+	raw, err := s.client.Get(ctx, tokenRedisKey(serverID, userID)).Result()
+	if errors.Is(err, redis.Nil) {
+		return Token{}, false, nil
+	}
+	if err != nil {
+		return Token{}, false, fmt.Errorf("redis get token: %w", err)
+	}
+	var t Token
+	if err := json.Unmarshal([]byte(raw), &t); err != nil {
+		return Token{}, false, fmt.Errorf("decode token: %w", err)
+	}
+	return t, true, nil
+}
+
+func (s *RedisUserTokenStore) Put(ctx context.Context, serverID string, userID int64, token Token) error {
+	raw, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("encode token: %w", err)
+	}
+	// Keep the record alive past access-token expiry so the refresh token
+	// stays usable; the manager refreshes lazily on the next call.
+	ttl := time.Until(token.ExpiresAt) + 30*24*time.Hour
+	if ttl <= 0 {
+		ttl = 30 * 24 * time.Hour
+	}
+	if err := s.client.Set(ctx, tokenRedisKey(serverID, userID), raw, ttl).Err(); err != nil {
+		return fmt.Errorf("redis set token: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisUserTokenStore) Delete(ctx context.Context, serverID string, userID int64) error {
+	if err := s.client.Del(ctx, tokenRedisKey(serverID, userID)).Err(); err != nil {
+		return fmt.Errorf("redis del token: %w", err)
+	}
+	return nil
+}

--- a/pkg/plugin/oauth/store_test.go
+++ b/pkg/plugin/oauth/store_test.go
@@ -1,0 +1,64 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryUserTokenStore(t *testing.T) {
+	s := NewInMemoryUserTokenStore()
+	ctx := context.Background()
+
+	tok := Token{AccessToken: "a", ExpiresAt: time.Now().Add(time.Hour)}
+	if err := s.Put(ctx, "atlassian", 42, tok); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	got, ok, err := s.Get(ctx, "atlassian", 42)
+	if err != nil || !ok || got.AccessToken != "a" {
+		t.Fatalf("get: ok=%v err=%v got=%+v", ok, err, got)
+	}
+
+	if _, ok, _ := s.Get(ctx, "atlassian", 99); ok {
+		t.Fatalf("unexpected token for other user")
+	}
+	if _, ok, _ := s.Get(ctx, "other", 42); ok {
+		t.Fatalf("unexpected token for other server")
+	}
+
+	if err := s.Delete(ctx, "atlassian", 42); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok, _ := s.Get(ctx, "atlassian", 42); ok {
+		t.Fatalf("token still present after delete")
+	}
+}
+
+func TestTokenExpiryHelpers(t *testing.T) {
+	past := Token{ExpiresAt: time.Now().Add(-time.Minute)}
+	if !past.Expired() {
+		t.Fatalf("expected past token to be expired")
+	}
+	if !past.NeedsRefresh() {
+		t.Fatalf("expected past token to need refresh")
+	}
+
+	soon := Token{ExpiresAt: time.Now().Add(30 * time.Second)}
+	if soon.Expired() {
+		t.Fatalf("token expiring in 30s should not be reported as expired")
+	}
+	if !soon.NeedsRefresh() {
+		t.Fatalf("token expiring in 30s should need refresh (60s threshold)")
+	}
+
+	future := Token{ExpiresAt: time.Now().Add(2 * time.Hour)}
+	if future.Expired() || future.NeedsRefresh() {
+		t.Fatalf("future token should neither be expired nor need refresh")
+	}
+
+	zero := Token{}
+	if zero.Expired() || zero.NeedsRefresh() {
+		t.Fatalf("token without expiry should never expire or need refresh")
+	}
+}

--- a/pkg/plugin/oauth/store_test.go
+++ b/pkg/plugin/oauth/store_test.go
@@ -35,6 +35,27 @@ func TestInMemoryUserTokenStore(t *testing.T) {
 	}
 }
 
+func TestInMemoryUserTokenStoreDeleteServer(t *testing.T) {
+	s := NewInMemoryUserTokenStore()
+	ctx := context.Background()
+	_ = s.Put(ctx, "atlassian", 1, Token{AccessToken: "a"})
+	_ = s.Put(ctx, "atlassian", 2, Token{AccessToken: "b"})
+	_ = s.Put(ctx, "github-read", 1, Token{AccessToken: "c"})
+
+	if err := s.DeleteServer(ctx, "atlassian"); err != nil {
+		t.Fatalf("deleteServer: %v", err)
+	}
+	if _, ok, _ := s.Get(ctx, "atlassian", 1); ok {
+		t.Fatalf("token for user 1 survived DeleteServer")
+	}
+	if _, ok, _ := s.Get(ctx, "atlassian", 2); ok {
+		t.Fatalf("token for user 2 survived DeleteServer")
+	}
+	if _, ok, _ := s.Get(ctx, "github-read", 1); !ok {
+		t.Fatalf("token for other server was deleted")
+	}
+}
+
 func TestTokenExpiryHelpers(t *testing.T) {
 	past := Token{ExpiresAt: time.Now().Add(-time.Minute)}
 	if !past.Expired() {

--- a/pkg/plugin/openapi/openapi.json
+++ b/pkg/plugin/openapi/openapi.json
@@ -474,6 +474,13 @@
                           "type": "integer"
                         }
                       }
+                    },
+                    "oauth": {
+                      "type": "object",
+                      "description": "Per-user OAuth connection state keyed by server ID; present only for servers configured with an oauth block.",
+                      "additionalProperties": {
+                        "$ref": "#/components/schemas/OAuthStatus"
+                      }
                     }
                   }
                 }
@@ -1530,7 +1537,7 @@
     "/api/sessions/{sessionId}/stats": {
       "get": {
         "summary": "Get session usage stats",
-        "description": "Returns cumulative usage stats (tokens, turns, tool calls) for a session, accumulated across all its agent runs. Only the session owner (same user + org) can access it. Omits the full message history — use GET /api/sessions/{sessionId} for the full transcript.",
+        "description": "Returns cumulative usage stats (tokens, turns, tool calls) for a session, accumulated across all its agent runs. Only the session owner (same user + org) can access it. Omits the full message history \u2014 use GET /api/sessions/{sessionId} for the full transcript.",
         "operationId": "getSessionStats",
         "tags": [
           "Sessions"
@@ -1975,6 +1982,417 @@
           },
           "500": {
             "description": "Failed to ingest session"
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/start": {
+      "get": {
+        "summary": "Start per-user OAuth flow",
+        "description": "Begins the OAuth 2.0 authorization-code flow (with PKCE when configured) for the current Grafana user against an OAuth-enabled MCP server. Responds with a 302 redirect to the provider's authorization endpoint. Intended to be opened in a popup window.",
+        "operationId": "startMCPOAuth",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "MCP server ID"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to the provider's authorization endpoint"
+          },
+          "401": {
+            "description": "No authenticated Grafana user"
+          },
+          "404": {
+            "description": "Server unknown or has no OAuth configuration"
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/callback": {
+      "get": {
+        "summary": "OAuth authorization-code callback",
+        "description": "Redirect target registered with the authorization server. Validates the one-shot state, exchanges the code for tokens, persists them for the initiating user, and returns a small HTML page that notifies the opener window via postMessage and closes itself.",
+        "operationId": "mcpOAuthCallback",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "MCP server ID"
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Authorization code issued by the provider"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Opaque one-shot state issued at /start"
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Provider error code when the grant was denied"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML page reporting the outcome to the opener window",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/status": {
+      "get": {
+        "summary": "Per-user OAuth connection status",
+        "description": "Reports whether the current Grafana user has connected their account for an OAuth-enabled MCP server.",
+        "operationId": "getMCPOAuthStatus",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "MCP server ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthStatus"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Server unknown or has no OAuth configuration"
+          }
+        }
+      }
+    },
+    "/api/oauth/{serverId}/disconnect": {
+      "post": {
+        "summary": "Disconnect per-user OAuth",
+        "description": "Deletes the current Grafana user's stored token for an OAuth-enabled MCP server.",
+        "operationId": "disconnectMCPOAuth",
+        "tags": [
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "MCP server ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Token deleted"
+          },
+          "401": {
+            "description": "No authenticated Grafana user"
+          },
+          "404": {
+            "description": "Server unknown or has no OAuth configuration"
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner/presets": {
+      "get": {
+        "summary": "List MCP provider presets",
+        "description": "Returns the built-in catalog of one-click external MCP providers (GitHub read-only, GitHub read/write, Atlassian) so the admin UI can render preset cards.",
+        "operationId": "listMCPPresets",
+        "tags": [
+          "MCP Provisioner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Preset catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "presets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MCPPreset"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner": {
+      "get": {
+        "summary": "List dynamically provisioned MCP servers",
+        "description": "Returns MCP servers added at runtime through the admin UI. OAuth client credentials are never included in responses.",
+        "operationId": "listDynamicMCPServers",
+        "tags": [
+          "MCP Provisioner"
+        ],
+        "responses": {
+          "200": {
+            "description": "Provisioned servers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "servers": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DynamicMCPServer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner/preset": {
+      "post": {
+        "summary": "Provision an MCP server from a preset",
+        "description": "Admin-only. Attaches a preset external MCP server. For DCR-capable providers (Atlassian) OAuth endpoints are discovered via RFC 8414/9728 and a client is registered via RFC 7591 automatically; for others (GitHub) the admin supplies clientId and optionally clientSecret.",
+        "operationId": "addMCPPreset",
+        "tags": [
+          "MCP Provisioner"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "preset"
+                ],
+                "properties": {
+                  "preset": {
+                    "type": "string",
+                    "enum": [
+                      "github-read",
+                      "github-write",
+                      "atlassian"
+                    ]
+                  },
+                  "clientId": {
+                    "type": "string",
+                    "description": "OAuth client ID; required for presets without dynamic client registration"
+                  },
+                  "clientSecret": {
+                    "type": "string",
+                    "description": "Optional OAuth client secret (PKCE preferred)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server provisioned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "serverId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unknown preset or missing clientId"
+          },
+          "403": {
+            "description": "Caller is not a Grafana Admin"
+          },
+          "502": {
+            "description": "OAuth discovery or dynamic client registration against the provider failed"
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner/generic": {
+      "post": {
+        "summary": "Provision a generic OAuth-gated MCP server",
+        "description": "Admin-only. Attaches any MCP server that authenticates users via OAuth 2.0 authorization-code. With discover=true the OAuth endpoints (and client registration when clientId is empty) are resolved automatically from the server's advertised metadata.",
+        "operationId": "addGenericMCP",
+        "tags": [
+          "MCP Provisioner"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId",
+                  "mcpUrl",
+                  "transport"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9-]{1,64}$"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "mcpUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "transport": {
+                    "type": "string",
+                    "enum": [
+                      "streamable-http",
+                      "sse"
+                    ]
+                  },
+                  "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "tokenUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "clientId": {
+                    "type": "string"
+                  },
+                  "clientSecret": {
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "pkce": {
+                    "type": "boolean"
+                  },
+                  "discover": {
+                    "type": "boolean",
+                    "description": "Resolve OAuth endpoints (and register a client when clientId is empty) from the server's advertised metadata"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server provisioned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "serverId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid fields"
+          },
+          "403": {
+            "description": "Caller is not a Grafana Admin"
+          },
+          "502": {
+            "description": "OAuth discovery or dynamic client registration against the provider failed"
+          }
+        }
+      }
+    },
+    "/api/mcp/provisioner/{serverId}": {
+      "delete": {
+        "summary": "Remove a dynamically provisioned MCP server",
+        "description": "Admin-only. Detaches the server from the MCP proxy and deletes its persisted record and OAuth configuration.",
+        "operationId": "removeDynamicMCPServer",
+        "tags": [
+          "MCP Provisioner"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "MCP server ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Server removed"
+          },
+          "403": {
+            "description": "Caller is not a Grafana Admin"
           }
         }
       }
@@ -3287,6 +3705,91 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "OAuthStatus": {
+        "type": "object",
+        "description": "Per-user OAuth connection state for an MCP server",
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "The server has an OAuth block"
+          },
+          "connected": {
+            "type": "boolean",
+            "description": "The current user holds a usable token"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MCPPreset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "github-read",
+              "github-write",
+              "atlassian"
+            ]
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "serverId": {
+            "type": "string"
+          },
+          "mcpUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "transport": {
+            "type": "string",
+            "enum": [
+              "streamable-http",
+              "sse"
+            ]
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dcrCapable": {
+            "type": "boolean",
+            "description": "Provider supports RFC 7591 dynamic client registration"
+          }
+        }
+      },
+      "DynamicMCPServer": {
+        "type": "object",
+        "properties": {
+          "serverId": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "mcpUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "transport": {
+            "type": "string"
+          },
+          "presetId": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       }
     }
   }

--- a/pkg/plugin/openapi/openapi_test.go
+++ b/pkg/plugin/openapi/openapi_test.go
@@ -113,6 +113,15 @@ func TestSpecHasAllEndpoints(t *testing.T) {
 		"/api/sessions/share",
 		"/api/sessions/shared/{shareId}",
 		"/api/sessions/share/{shareId}",
+		"/api/oauth/{serverId}/start",
+		"/api/oauth/{serverId}/callback",
+		"/api/oauth/{serverId}/status",
+		"/api/oauth/{serverId}/disconnect",
+		"/api/mcp/provisioner",
+		"/api/mcp/provisioner/presets",
+		"/api/mcp/provisioner/preset",
+		"/api/mcp/provisioner/generic",
+		"/api/mcp/provisioner/{serverId}",
 	}
 
 	for _, path := range expectedPaths {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"consensys-asko11y-app/pkg/agent"
 	"consensys-asko11y-app/pkg/mcp"
+	"consensys-asko11y-app/pkg/plugin/oauth"
 	"consensys-asko11y-app/pkg/plugin/openapi"
 	"consensys-asko11y-app/pkg/rbac"
 	"context"
@@ -183,6 +184,15 @@ type Plugin struct {
 	cancel         context.CancelFunc
 	runCancelsMu   sync.Mutex
 	runCancels     map[string]context.CancelFunc
+	// oauthManager drives per-user OAuth for external MCP servers; it also
+	// implements mcp.PerUserTokenProvider for the proxy.
+	oauthManager *oauth.Manager
+	// dynamicServerStore persists MCP servers provisioned at runtime from the
+	// AppConfig UI so they survive restarts.
+	dynamicServerStore oauth.DynamicServerStore
+	// oauthHTTPClient is the SDK-built HTTP client used for OAuth discovery,
+	// dynamic client registration, and token exchange.
+	oauthHTTPClient *http.Client
 	// dsCache memoises the per-org datasource UID snapshot injected into the
 	// system prompt. See datasource_snapshot.go.
 	dsCache   map[string]dsCacheEntry
@@ -282,6 +292,47 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		sessionStore = NewRedisSessionStore(pluginCtx, redisClient, logger)
 	}
 
+	oauthHTTPClient, err := httpclient.New(httpclient.Options{
+		Timeouts: &httpclient.TimeoutOptions{
+			Timeout:     30 * time.Second,
+			DialTimeout: 10 * time.Second,
+		},
+	})
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create SDK HTTP client for OAuth: %w", err)
+	}
+
+	var tokenStore oauth.UserTokenStore
+	var stateStore oauth.StateStore
+	var dynamicServerStore oauth.DynamicServerStore
+	if usingRedis && redisClient != nil {
+		tokenStore = oauth.NewRedisUserTokenStore(redisClient, logger)
+		stateStore = oauth.NewRedisStateStore(redisClient, logger)
+		dynamicServerStore = oauth.NewRedisDynamicServerStore(redisClient, logger)
+	} else {
+		tokenStore = oauth.NewInMemoryUserTokenStore()
+		stateStore = oauth.NewInMemoryStateStore()
+		dynamicServerStore = oauth.NewInMemoryDynamicServerStore()
+	}
+	oauthManager := oauth.NewManager(tokenStore, stateStore, oauthHTTPClient, logger, pluginSettings.MCPServers)
+	mcpProxy.SetPerUserTokenProvider(oauthManager)
+
+	// Restore dynamic (UI-added) MCP servers so they're attached before the
+	// first requests come in.
+	if dynamicRecords, err := dynamicServerStore.List(pluginCtx); err != nil {
+		logger.Warn("list dynamic MCP servers", "err", err)
+	} else {
+		for _, rec := range dynamicRecords {
+			if rec.Config.OAuth != nil {
+				oauthManager.RegisterConfig(rec.Config.ID, rec.Config.OAuth)
+			}
+			if err := mcpProxy.EnsureServer(rec.Config); err != nil {
+				logger.Warn("restore dynamic MCP server", "id", rec.Config.ID, "err", err)
+			}
+		}
+	}
+
 	var approvalBroker ApprovalBroker
 	var approvalGrants ApprovalGrantStore
 	if usingRedis && redisClient != nil {
@@ -334,6 +385,10 @@ func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (insta
 		ctx:            pluginCtx,
 		cancel:         cancel,
 		runCancels:     make(map[string]context.CancelFunc),
+
+		oauthManager:       oauthManager,
+		dynamicServerStore: dynamicServerStore,
+		oauthHTTPClient:    oauthHTTPClient,
 	}
 
 	if !usingRedis {
@@ -460,6 +515,10 @@ func (p *Plugin) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/sessions/share/", p.handleDeleteShare)
 	mux.HandleFunc("/api/sessions/", p.handleSessionRouter)
 	mux.HandleFunc("/api/sessions", p.handleSessionsRoot)
+
+	// Per-user OAuth for external MCP servers + admin provisioning.
+	p.oauthManager.RegisterRoutes(mux, getUserID)
+	p.registerProvisionerRoutes(mux)
 
 	mux.HandleFunc("/", p.handleDefault)
 }
@@ -619,7 +678,7 @@ func (p *Plugin) handleMCPTools(w http.ResponseWriter, r *http.Request) {
 
 	p.ensureBuiltInForListing(r)
 
-	tools, err := p.mcpProxy.ListTools()
+	tools, err := p.mcpProxy.ListToolsWithContext(mcp.WithUserID(r.Context(), getUserID(r)))
 	if err != nil {
 		p.logger.Error("Failed to list tools", "error", err)
 		http.Error(w, "Failed to list tools", http.StatusInternalServerError)
@@ -694,7 +753,8 @@ func (p *Plugin) handleMCPCallTool(w http.ResponseWriter, r *http.Request) {
 
 	p.logger.Debug("Tool call context", "orgID", orgID, "orgName", req.OrgName, "scopeOrgId", req.ScopeOrgId, "tool", req.Name)
 
-	result, err := p.mcpProxy.CallToolWithContext(req.Name, req.Arguments, orgID, req.OrgName, req.ScopeOrgId)
+	callCtx := mcp.WithUserID(r.Context(), getUserID(r))
+	result, err := p.mcpProxy.CallToolWithContext(callCtx, req.Name, req.Arguments, orgID, req.OrgName, req.ScopeOrgId)
 	if err != nil {
 		p.logger.Error("Failed to call tool", "error", err)
 		http.Error(w, "Failed to call tool", http.StatusInternalServerError)
@@ -719,9 +779,32 @@ func (p *Plugin) handleMCPServers(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
 		"servers":      serversHealth,
 		"systemHealth": systemHealth,
+		"oauth":        p.oauthStatusForUser(r),
 	}
 
 	json.NewEncoder(w).Encode(response)
+}
+
+// oauthStatusForUser returns serverID → {configured, connected, expiresAt}
+// for every MCP server with an OAuth block, telling the frontend whether the
+// current user still needs to click Connect.
+func (p *Plugin) oauthStatusForUser(r *http.Request) map[string]oauth.StatusResponse {
+	out := map[string]oauth.StatusResponse{}
+	if p.oauthManager == nil {
+		return out
+	}
+	userID := getUserID(r)
+	for _, id := range p.oauthManager.ServerIDs() {
+		status := oauth.StatusResponse{Configured: true}
+		if userID != 0 {
+			if tok, ok, err := p.oauthManager.Tokens().Get(r.Context(), id, userID); err == nil && ok {
+				status.Connected = !tok.Expired() || tok.RefreshToken != ""
+				status.ExpiresAt = tok.ExpiresAt
+			}
+		}
+		out[id] = status
+	}
+	return out
 }
 
 func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
@@ -941,6 +1024,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 		GrafanaURL:           grafanaURL,
 		AuthToken:            saToken,
 		UserRole:             userRole,
+		UserID:               userID,
 		OrgID:                orgID,
 		OrgName:              req.OrgName,
 		ScopeOrgID:           req.ScopeOrgID,
@@ -1553,6 +1637,7 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 		query = graphitiTopologyFactQuery()
 	}
 	result, err := p.mcpProxy.CallToolWithContext(
+		r.Context(),
 		toolName,
 		graphitiSearchFactsArgs(tools, toolName, orgID, query, maxEdges),
 		strconv.FormatInt(orgID, 10),
@@ -1575,6 +1660,7 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 	} else {
 		for _, nodeQuery := range graphitiTopologyNodeQueries() {
 			nodeResult, nodeErr := p.mcpProxy.CallToolWithContext(
+				r.Context(),
 				nodeToolName,
 				graphitiSearchNodesArgs(tools, nodeToolName, orgID, nodeQuery.query, hardTopologyMaxNodes, nodeQuery.entityTypes),
 				strconv.FormatInt(orgID, 10),
@@ -1604,6 +1690,7 @@ func (p *Plugin) handleAgentTopology(w http.ResponseWriter, r *http.Request) {
 		centerFactLimit := topologyCenteredFactLimit(maxEdges, len(centerNodes))
 		for _, node := range centerNodes {
 			nodeResult, nodeErr := p.mcpProxy.CallToolWithContext(
+				r.Context(),
 				toolName,
 				graphitiSearchFactsForNodeArgs(tools, toolName, orgID, graphitiTopologyFactQuery(), centerFactLimit, node.UUID),
 				strconv.FormatInt(orgID, 10),

--- a/src/components/AppConfig/AppConfig.tsx
+++ b/src/components/AppConfig/AppConfig.tsx
@@ -23,6 +23,7 @@ import { testIds } from '../testIds';
 import { ValidationService } from '../../services/validation';
 import { PromptEditor } from './PromptEditor';
 import { ManageToolsModal } from './ManageToolsModal';
+import { ExternalMCPs } from './ExternalMCPs';
 import { mcpServerStatusService, type MCPServerStatus, type MCPTool } from '../../services/mcpServerStatus';
 import type { AppPluginSettings, MCPServerConfig } from '../../types/plugin';
 import { AgentTopologyResponse, getAgentTopology } from '../../services/agentTopologyClient';
@@ -1418,6 +1419,8 @@ const AppConfig = ({ plugin }: AppConfigProps) => {
                 Save MCP Servers
               </Button>
             </div>
+
+            <ExternalMCPs />
           </FieldSet>
         )}
 

--- a/src/components/AppConfig/ExternalMCPs.test.tsx
+++ b/src/components/AppConfig/ExternalMCPs.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const listPresetsMock = jest.fn();
+const listDynamicServersMock = jest.fn();
+const addPresetMock = jest.fn();
+const removeDynamicServerMock = jest.fn();
+const addGenericMock = jest.fn();
+
+jest.mock('../../services/mcpProvisionerClient', () => ({
+  listPresets: (...args: unknown[]) => listPresetsMock(...args),
+  listDynamicServers: (...args: unknown[]) => listDynamicServersMock(...args),
+  addPreset: (...args: unknown[]) => addPresetMock(...args),
+  removeDynamicServer: (...args: unknown[]) => removeDynamicServerMock(...args),
+  addGeneric: (...args: unknown[]) => addGenericMock(...args),
+}));
+
+import { ExternalMCPs } from './ExternalMCPs';
+import { testIds } from '../testIds';
+
+const githubPreset = {
+  id: 'github-read',
+  displayName: 'GitHub (read-only)',
+  serverId: 'github-read',
+  mcpUrl: 'https://api.githubcopilot.com/mcp/',
+  transport: 'streamable-http',
+  scopes: ['read:user'],
+  dcrCapable: false,
+};
+
+const atlassianPreset = {
+  id: 'atlassian',
+  displayName: 'Atlassian (Jira + Confluence)',
+  serverId: 'atlassian',
+  mcpUrl: 'https://mcp.atlassian.com/v1/sse',
+  transport: 'sse',
+  scopes: ['offline_access'],
+  dcrCapable: true,
+};
+
+describe('ExternalMCPs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Grafana's Combobox measures option text on a canvas jsdom doesn't provide.
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: () => ({
+        measureText: () => ({ width: 100 }),
+      }),
+    });
+    listPresetsMock.mockResolvedValue([githubPreset, atlassianPreset]);
+    listDynamicServersMock.mockResolvedValue([]);
+    addPresetMock.mockResolvedValue({ serverId: 'atlassian' });
+    removeDynamicServerMock.mockResolvedValue(undefined);
+  });
+
+  it('provisions a DCR-capable preset with one click', async () => {
+    render(<ExternalMCPs />);
+    const addButton = await screen.findByTestId(testIds.appConfig.externalMcpPresetAddButton('atlassian'));
+    fireEvent.click(addButton);
+    await waitFor(() =>
+      expect(addPresetMock).toHaveBeenCalledWith({ preset: 'atlassian', clientId: undefined, clientSecret: undefined })
+    );
+  });
+
+  it('disables Add for non-DCR presets until a client ID is typed, then sends it', async () => {
+    render(<ExternalMCPs />);
+    const addButton = await screen.findByTestId(testIds.appConfig.externalMcpPresetAddButton('github-read'));
+    expect(addButton).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId(testIds.appConfig.externalMcpPresetClientIdInput('github-read')), {
+      target: { value: 'Iv1.client' },
+    });
+    expect(addButton).toBeEnabled();
+
+    fireEvent.click(addButton);
+    await waitFor(() =>
+      expect(addPresetMock).toHaveBeenCalledWith({
+        preset: 'github-read',
+        clientId: 'Iv1.client',
+        clientSecret: undefined,
+      })
+    );
+  });
+
+  it('shows Remove for already-provisioned presets', async () => {
+    listDynamicServersMock.mockResolvedValue([
+      {
+        serverId: 'atlassian',
+        displayName: 'Atlassian (Jira + Confluence)',
+        mcpUrl: 'https://mcp.atlassian.com/v1/sse',
+        transport: 'sse',
+        presetId: 'atlassian',
+      },
+    ]);
+    render(<ExternalMCPs />);
+    const removeButton = await screen.findByTestId(testIds.appConfig.externalMcpPresetRemoveButton('atlassian'));
+    fireEvent.click(removeButton);
+    await waitFor(() => expect(removeDynamicServerMock).toHaveBeenCalledWith('atlassian'));
+  });
+
+  it('surfaces provisioning errors', async () => {
+    addPresetMock.mockRejectedValue(new Error('discovery failed'));
+    render(<ExternalMCPs />);
+    fireEvent.click(await screen.findByTestId(testIds.appConfig.externalMcpPresetAddButton('atlassian')));
+    expect(await screen.findByText('discovery failed')).toBeInTheDocument();
+  });
+});

--- a/src/components/AppConfig/ExternalMCPs.tsx
+++ b/src/components/AppConfig/ExternalMCPs.tsx
@@ -1,0 +1,308 @@
+/**
+ * ExternalMCPs
+ *
+ * AppConfig section that lets Admin users attach external OAuth-gated MCP
+ * servers at runtime — presets (GitHub read-only, GitHub read/write,
+ * Atlassian) plus a generic form. After provisioning, each end user runs
+ * their own Connect flow from the chat toolbar.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Button, Combobox, Field, Input, Switch } from '@grafana/ui';
+import { testIds } from '../testIds';
+import {
+  addGeneric,
+  addPreset,
+  AddGenericInput,
+  DynamicMCPServer,
+  listDynamicServers,
+  listPresets,
+  MCPPreset,
+  removeDynamicServer,
+} from '../../services/mcpProvisionerClient';
+
+interface PresetCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+function PresetCard({
+  preset,
+  isProvisioned,
+  onProvision,
+  onRemove,
+  busyWith,
+}: {
+  preset: MCPPreset;
+  isProvisioned: boolean;
+  onProvision: (preset: MCPPreset, credentials: PresetCredentials) => Promise<void>;
+  onRemove: (serverId: string) => Promise<void>;
+  busyWith: string | null;
+}) {
+  const needsClientId = !preset.dcrCapable;
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+  const busy = busyWith === preset.id;
+
+  const handleAdd = async () => {
+    await onProvision(preset, { clientId, clientSecret });
+    setClientId('');
+    setClientSecret('');
+  };
+
+  return (
+    <div
+      className="p-3 rounded border border-weak flex flex-col gap-2 mb-3"
+      data-testid={testIds.appConfig.externalMcpPresetCard(preset.id)}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium">{preset.displayName}</div>
+          <div className="text-xs text-secondary">
+            {preset.mcpUrl} · {preset.transport} ·{' '}
+            {preset.dcrCapable ? 'auto-registers with provider' : 'bring your own OAuth app'}
+          </div>
+          {preset.scopes.length > 0 && <div className="text-xs text-secondary">scopes: {preset.scopes.join(', ')}</div>}
+        </div>
+        {isProvisioned ? (
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={busy}
+            onClick={() => onRemove(preset.serverId)}
+            data-testid={testIds.appConfig.externalMcpPresetRemoveButton(preset.id)}
+          >
+            Remove
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            variant="primary"
+            disabled={busy || (needsClientId && !clientId)}
+            onClick={handleAdd}
+            data-testid={testIds.appConfig.externalMcpPresetAddButton(preset.id)}
+          >
+            {busy ? 'Adding…' : 'Add'}
+          </Button>
+        )}
+      </div>
+      {needsClientId && !isProvisioned && (
+        <div className="grid grid-cols-2 gap-2">
+          <Field
+            label="Client ID"
+            description="Create an OAuth App at the provider (e.g. github.com/settings/developers) using the plugin callback URL, then paste its client ID here."
+          >
+            <Input
+              value={clientId}
+              onChange={(e) => setClientId(e.currentTarget.value)}
+              placeholder="Iv1.abcd…"
+              data-testid={testIds.appConfig.externalMcpPresetClientIdInput(preset.id)}
+            />
+          </Field>
+          <Field label="Client Secret" description="Optional — leave blank for PKCE-only.">
+            <Input
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.currentTarget.value)}
+              placeholder="leave blank for PKCE-only"
+            />
+          </Field>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const EMPTY_GENERIC_FORM: AddGenericInput = {
+  serverId: '',
+  displayName: '',
+  mcpUrl: '',
+  transport: 'streamable-http',
+  pkce: true,
+  discover: true,
+};
+
+function GenericForm({ onSubmit, busy }: { onSubmit: (input: AddGenericInput) => Promise<void>; busy: boolean }) {
+  const [form, setForm] = useState<AddGenericInput>(EMPTY_GENERIC_FORM);
+  const [scopesText, setScopesText] = useState('');
+
+  const set = <K extends keyof AddGenericInput>(k: K, v: AddGenericInput[K]) => setForm((prev) => ({ ...prev, [k]: v }));
+
+  const submit = async () => {
+    const scopes = scopesText
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    await onSubmit({ ...form, scopes });
+  };
+
+  return (
+    <div className="p-3 rounded border border-weak" data-testid={testIds.appConfig.externalMcpGenericForm}>
+      <div className="font-medium mb-2">Generic OAuth MCP</div>
+      <div className="text-xs text-secondary mb-3">
+        Keep <strong>Discover</strong> on when the server publishes OAuth metadata
+        (/.well-known/oauth-authorization-server); turn it off to supply the URLs manually.
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <Field label="Server ID" description="Lowercase letters, digits and dashes.">
+          <Input value={form.serverId} onChange={(e) => set('serverId', e.currentTarget.value)} placeholder="my-mcp" />
+        </Field>
+        <Field label="Display name">
+          <Input value={form.displayName ?? ''} onChange={(e) => set('displayName', e.currentTarget.value)} />
+        </Field>
+        <Field label="MCP URL" className="col-span-2">
+          <Input
+            value={form.mcpUrl}
+            onChange={(e) => set('mcpUrl', e.currentTarget.value)}
+            placeholder="https://mcp.example.com/v1/mcp"
+          />
+        </Field>
+        <Field label="Transport">
+          <Combobox
+            value={form.transport}
+            onChange={(v) => set('transport', (v?.value as 'streamable-http' | 'sse') || 'streamable-http')}
+            options={[
+              { value: 'streamable-http', label: 'streamable-http' },
+              { value: 'sse', label: 'sse' },
+            ]}
+          />
+        </Field>
+        <Field label="Discover + auto-register" description="RFC 8414 discovery, RFC 7591 registration.">
+          <Switch value={form.discover ?? true} onChange={(e) => set('discover', e.currentTarget.checked)} />
+        </Field>
+        <Field label="Authorization URL" description="Leave blank when Discover is on.">
+          <Input value={form.authorizationUrl ?? ''} onChange={(e) => set('authorizationUrl', e.currentTarget.value)} />
+        </Field>
+        <Field label="Token URL" description="Leave blank when Discover is on.">
+          <Input value={form.tokenUrl ?? ''} onChange={(e) => set('tokenUrl', e.currentTarget.value)} />
+        </Field>
+        <Field label="Client ID" description="Required unless Discover registers one automatically.">
+          <Input value={form.clientId ?? ''} onChange={(e) => set('clientId', e.currentTarget.value)} />
+        </Field>
+        <Field label="Client Secret" description="Optional — PKCE preferred.">
+          <Input
+            type="password"
+            value={form.clientSecret ?? ''}
+            onChange={(e) => set('clientSecret', e.currentTarget.value)}
+          />
+        </Field>
+        <Field label="Scopes" description="Space or comma separated." className="col-span-2">
+          <Input
+            value={scopesText}
+            onChange={(e) => setScopesText(e.currentTarget.value)}
+            placeholder="offline_access read:content"
+          />
+        </Field>
+      </div>
+      <div className="mt-2">
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={submit}
+          disabled={busy || !form.serverId || !form.mcpUrl}
+          data-testid={testIds.appConfig.externalMcpGenericAddButton}
+        >
+          {busy ? 'Adding…' : 'Add generic MCP'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ExternalMCPs() {
+  const [presets, setPresets] = useState<MCPPreset[]>([]);
+  const [servers, setServers] = useState<DynamicMCPServer[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busyWith, setBusyWith] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [p, s] = await Promise.all([listPresets(), listDynamicServers()]);
+      setPresets(p);
+      setServers(s);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load external MCP servers');
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const provisionedByPreset = new Set(servers.map((s) => s.presetId).filter(Boolean));
+
+  const runAction = async (busyKey: string, action: () => Promise<unknown>) => {
+    setBusyWith(busyKey);
+    setError(null);
+    try {
+      await action();
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Action failed');
+    } finally {
+      setBusyWith(null);
+    }
+  };
+
+  const handleProvision = (preset: MCPPreset, credentials: PresetCredentials) =>
+    runAction(preset.id, () =>
+      addPreset({
+        preset: preset.id,
+        clientId: credentials.clientId || undefined,
+        clientSecret: credentials.clientSecret || undefined,
+      })
+    );
+
+  const handleRemove = (serverId: string) => runAction(serverId, () => removeDynamicServer(serverId));
+
+  const handleGeneric = (input: AddGenericInput) => runAction('generic', () => addGeneric(input));
+
+  return (
+    <div className="mt-6" data-testid={testIds.appConfig.externalMcpSection}>
+      <h3 className="text-xl font-semibold mb-2">External MCP servers (OAuth)</h3>
+      <p className="text-sm text-secondary mb-4">
+        Attach one-click presets or any MCP server that speaks OAuth 2.0 authorization-code. Each Grafana user then
+        connects with their own account from the MCP connections button in the chat toolbar.
+      </p>
+      {error && (
+        <Alert severity="error" title="Action failed" onRemove={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {presets.map((p) => (
+        <PresetCard
+          key={p.id}
+          preset={p}
+          isProvisioned={provisionedByPreset.has(p.id)}
+          onProvision={handleProvision}
+          onRemove={handleRemove}
+          busyWith={busyWith}
+        />
+      ))}
+
+      {servers
+        .filter((s) => !s.presetId)
+        .map((s) => (
+          <div key={s.serverId} className="p-3 rounded border border-weak flex items-center justify-between mb-3">
+            <div>
+              <div className="font-medium">{s.displayName}</div>
+              <div className="text-xs text-secondary">
+                {s.mcpUrl} · {s.transport}
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={busyWith === s.serverId}
+              onClick={() => handleRemove(s.serverId)}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+
+      <GenericForm onSubmit={handleGeneric} busy={busyWith === 'generic'} />
+    </div>
+  );
+}

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -8,7 +8,14 @@ import { useChatScene } from './hooks/useChatScene';
 import { useSidePanelState } from './hooks/useSidePanelState';
 import { ChatInterfaceState } from './scenes/ChatInterfaceScene';
 import { GrafanaPageState } from './scenes/GrafanaPageScene';
-import { SessionSidebar, NewChatButton, HistoryButton, SaveToMemoryButton, ModelSelector } from './components';
+import {
+  SessionSidebar,
+  NewChatButton,
+  HistoryButton,
+  SaveToMemoryButton,
+  ModelSelector,
+  McpConnectionsButton,
+} from './components';
 import { ChatInputRef } from './components/ChatInput/ChatInput';
 import { ChatErrorBoundary } from '../ErrorBoundary';
 import type { SessionMetadata } from './hooks/useSessionManager';
@@ -175,6 +182,7 @@ function ChatComponent({
       rightSlot: (
         <div className="flex items-center gap-1">
           {graphitiEnabled && hasMessages && <SaveToMemoryButton messages={chatHistory} />}
+          <McpConnectionsButton />
           <HistoryButton onClick={openHistory} sessionCount={sessionManager.sessions.length} />
         </div>
       ),

--- a/src/components/Chat/components/McpConnections/McpConnectionsButton.test.tsx
+++ b/src/components/Chat/components/McpConnections/McpConnectionsButton.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+const fetchServerStatusesMock = jest.fn();
+const disconnectOAuthMock = jest.fn().mockResolvedValue(undefined);
+const openOAuthPopupMock = jest.fn();
+let callbackSubscriber: ((msg: unknown) => void) | undefined;
+
+jest.mock('../../../../services/mcpServerStatus', () => ({
+  mcpServerStatusService: {
+    fetchServerStatuses: (...args: unknown[]) => fetchServerStatusesMock(...args),
+  },
+}));
+
+jest.mock('../../../../services/oauthClient', () => ({
+  disconnectOAuth: (...args: unknown[]) => disconnectOAuthMock(...args),
+  openOAuthPopup: (...args: unknown[]) => openOAuthPopupMock(...args),
+  startOAuthUrl: (id: string) => `/start/${id}`,
+  onOAuthCallback: (cb: (msg: unknown) => void) => {
+    callbackSubscriber = cb;
+    return () => {
+      callbackSubscriber = undefined;
+    };
+  },
+}));
+
+import { McpConnectionsButton } from './McpConnectionsButton';
+import { testIds } from '../../../testIds';
+
+const serverEntry = (overrides: Record<string, unknown> = {}) => ({
+  serverId: 'atlassian',
+  name: 'Atlassian',
+  url: 'https://mcp.atlassian.com/v1/sse',
+  type: 'sse',
+  status: 'healthy',
+  lastCheck: '',
+  responseTime: 0,
+  successRate: 100,
+  errorCount: 0,
+  consecutiveFailures: 0,
+  tools: [],
+  toolCount: 0,
+  ...overrides,
+});
+
+describe('McpConnectionsButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    callbackSubscriber = undefined;
+  });
+
+  it('renders nothing when no server has OAuth configured', async () => {
+    fetchServerStatusesMock.mockResolvedValue({ servers: [serverEntry()], systemHealth: {}, oauth: {} });
+    const { container } = render(<McpConnectionsButton />);
+    await waitFor(() => expect(fetchServerStatusesMock).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the button with disconnected count and opens the connect popup', async () => {
+    fetchServerStatusesMock.mockResolvedValue({
+      servers: [serverEntry()],
+      systemHealth: {},
+      oauth: { atlassian: { configured: true, connected: false } },
+    });
+    openOAuthPopupMock.mockReturnValue({});
+
+    render(<McpConnectionsButton />);
+    const button = await screen.findByTestId(testIds.chat.mcpConnectionsButton);
+    expect(button).toHaveTextContent('Connections (1)');
+
+    fireEvent.click(button);
+    const connect = await screen.findByTestId(testIds.chat.mcpConnectionConnect('atlassian'));
+    fireEvent.click(connect);
+    expect(openOAuthPopupMock).toHaveBeenCalledWith('atlassian');
+  });
+
+  it('disconnects a connected server and refreshes', async () => {
+    fetchServerStatusesMock.mockResolvedValue({
+      servers: [serverEntry()],
+      systemHealth: {},
+      oauth: { atlassian: { configured: true, connected: true } },
+    });
+
+    render(<McpConnectionsButton />);
+    fireEvent.click(await screen.findByTestId(testIds.chat.mcpConnectionsButton));
+    fireEvent.click(await screen.findByTestId(testIds.chat.mcpConnectionDisconnect('atlassian')));
+
+    await waitFor(() => expect(disconnectOAuthMock).toHaveBeenCalledWith('atlassian'));
+    await waitFor(() => expect(fetchServerStatusesMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('refreshes when the OAuth popup reports back', async () => {
+    fetchServerStatusesMock.mockResolvedValue({
+      servers: [serverEntry()],
+      systemHealth: {},
+      oauth: { atlassian: { configured: true, connected: false } },
+    });
+
+    render(<McpConnectionsButton />);
+    await screen.findByTestId(testIds.chat.mcpConnectionsButton);
+    expect(callbackSubscriber).toBeDefined();
+
+    callbackSubscriber?.({ source: 'asko11y-oauth', serverID: 'atlassian', success: true });
+    await waitFor(() => expect(fetchServerStatusesMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/components/Chat/components/McpConnections/McpConnectionsButton.tsx
+++ b/src/components/Chat/components/McpConnections/McpConnectionsButton.tsx
@@ -1,0 +1,162 @@
+/**
+ * McpConnectionsButton
+ *
+ * Chat toolbar button that lets the current user connect or disconnect
+ * their own account on OAuth-gated MCP servers. Renders nothing when no
+ * configured server requires per-user OAuth.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Badge, Button, Modal, useStyles2, useTheme2 } from '@grafana/ui';
+import { cx } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { getHoverButtonStyle } from '../../../../theme';
+import { testIds } from '../../../testIds';
+import { mcpServerStatusService, MCPOAuthStatus, MCPServerStatus } from '../../../../services/mcpServerStatus';
+import { disconnectOAuth, onOAuthCallback, openOAuthPopup, startOAuthUrl } from '../../../../services/oauthClient';
+
+interface OAuthServerRow {
+  serverId: string;
+  name: string;
+  status: MCPOAuthStatus;
+}
+
+export function McpConnectionsButton(): React.ReactElement | null {
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles);
+  const [rows, setRows] = useState<OAuthServerRow[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [busyWith, setBusyWith] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const response = await mcpServerStatusService.fetchServerStatuses();
+    const oauth = response.oauth ?? {};
+    const byId = new Map(response.servers.map((s: MCPServerStatus) => [s.serverId, s]));
+    setRows(
+      Object.entries(oauth)
+        .filter(([, status]) => status.configured)
+        .map(([serverId, status]) => ({
+          serverId,
+          name: byId.get(serverId)?.name || serverId,
+          status,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const unsubscribe = onOAuthCallback(() => {
+      refresh();
+    });
+    return unsubscribe;
+  }, [refresh]);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const disconnectedCount = rows.filter((r) => !r.status.connected).length;
+
+  const handleConnect = (serverId: string) => {
+    const popup = openOAuthPopup(serverId);
+    if (!popup) {
+      // Popup blocked: fall back to same-tab navigation.
+      window.location.href = startOAuthUrl(serverId);
+    }
+  };
+
+  const handleDisconnect = async (serverId: string) => {
+    setBusyWith(serverId);
+    try {
+      await disconnectOAuth(serverId);
+      await refresh();
+    } finally {
+      setBusyWith(null);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className={cx(
+          'flex items-center gap-2 px-2 py-1 text-xs font-medium rounded-md transition-colors',
+          styles.hoverButton
+        )}
+        aria-label="MCP connections"
+        title="Connect your accounts for external MCP servers"
+        style={{ color: theme.colors.text.secondary }}
+        data-testid={testIds.chat.mcpConnectionsButton}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+        <span>Connections{disconnectedCount > 0 ? ` (${disconnectedCount})` : ''}</span>
+      </button>
+
+      <Modal
+        title="MCP connections"
+        isOpen={isOpen}
+        onDismiss={() => setIsOpen(false)}
+        data-testid={testIds.chat.mcpConnectionsModal}
+      >
+        <p className="text-sm text-secondary mb-3">
+          These MCP servers authenticate each user individually. Connect with your own account to let the assistant
+          use their tools on your behalf.
+        </p>
+        {rows.map((row) => (
+          <div
+            key={row.serverId}
+            className="flex items-center justify-between py-2 border-b border-weak"
+            data-testid={testIds.chat.mcpConnectionRow(row.serverId)}
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-medium">{row.name}</span>
+              <Badge
+                text={row.status.connected ? 'Connected' : 'Not connected'}
+                color={row.status.connected ? 'green' : 'orange'}
+              />
+            </div>
+            {row.status.connected ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="unlock"
+                disabled={busyWith === row.serverId}
+                onClick={() => handleDisconnect(row.serverId)}
+                data-testid={testIds.chat.mcpConnectionDisconnect(row.serverId)}
+              >
+                Disconnect
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="primary"
+                icon="external-link-alt"
+                onClick={() => handleConnect(row.serverId)}
+                data-testid={testIds.chat.mcpConnectionConnect(row.serverId)}
+              >
+                Connect
+              </Button>
+            )}
+          </div>
+        ))}
+      </Modal>
+    </>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  hoverButton: getHoverButtonStyle(theme),
+});

--- a/src/components/Chat/components/index.ts
+++ b/src/components/Chat/components/index.ts
@@ -4,6 +4,7 @@ export { ChatInput } from './ChatInput/ChatInput';
 export { ChatMessage } from './ChatMessage/ChatMessage';
 export { GraphRenderer } from './GraphRenderer/GraphRenderer';
 export { HistoryButton } from './HistoryButton/HistoryButton';
+export { McpConnectionsButton } from './McpConnections/McpConnectionsButton';
 export { SaveToMemoryButton } from './SaveToMemoryButton/SaveToMemoryButton';
 export { LogsRenderer } from './LogsRenderer/LogsRenderer';
 export { ModelSelector } from './ModelSelector/ModelSelector';

--- a/src/components/testIds.ts
+++ b/src/components/testIds.ts
@@ -43,6 +43,13 @@ export const testIds = {
     refreshServiceGraphButton: 'data-testid ac-refresh-service-graph',
     serviceGraphSummary: 'data-testid ac-service-graph-summary',
     saveServiceGraphSettingsButton: 'data-testid ac-save-service-graph-settings',
+    externalMcpSection: 'data-testid ac-external-mcp-section',
+    externalMcpPresetCard: (id: string) => `data-testid ac-external-mcp-preset-${id}`,
+    externalMcpPresetAddButton: (id: string) => `data-testid ac-external-mcp-preset-add-${id}`,
+    externalMcpPresetRemoveButton: (id: string) => `data-testid ac-external-mcp-preset-remove-${id}`,
+    externalMcpPresetClientIdInput: (id: string) => `data-testid ac-external-mcp-preset-client-id-${id}`,
+    externalMcpGenericForm: 'data-testid ac-external-mcp-generic-form',
+    externalMcpGenericAddButton: 'data-testid ac-external-mcp-generic-add',
   },
   home: {
     container: 'data-testid home-container',
@@ -50,6 +57,11 @@ export const testIds = {
   chat: {
     newChatButton: 'data-testid chat-new-chat-button',
     retryButton: 'data-testid chat-retry-button',
+    mcpConnectionsButton: 'data-testid chat-mcp-connections-button',
+    mcpConnectionsModal: 'data-testid chat-mcp-connections-modal',
+    mcpConnectionRow: (id: string) => `data-testid chat-mcp-connection-${id}`,
+    mcpConnectionConnect: (id: string) => `data-testid chat-mcp-connection-connect-${id}`,
+    mcpConnectionDisconnect: (id: string) => `data-testid chat-mcp-connection-disconnect-${id}`,
   },
   investigation: {
     error: 'data-testid investigation-error',

--- a/src/services/__tests__/oauthClient.test.ts
+++ b/src/services/__tests__/oauthClient.test.ts
@@ -1,0 +1,73 @@
+import { of, throwError } from 'rxjs';
+
+const fetchMock = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  config: { appSubUrl: '/grafana' },
+  getBackendSrv: () => ({ fetch: fetchMock }),
+}));
+
+import { disconnectOAuth, getOAuthStatus, onOAuthCallback, startOAuthUrl } from '../oauthClient';
+
+describe('oauthClient', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('builds subpath-aware start URLs and escapes the server ID', () => {
+    expect(startOAuthUrl('my server')).toBe(
+      '/grafana/api/plugins/consensys-asko11y-app/resources/api/oauth/my%20server/start'
+    );
+  });
+
+  it('fetches OAuth status', async () => {
+    fetchMock.mockReturnValue(of({ data: { configured: true, connected: true, expiresAt: '2026-01-01T00:00:00Z' } }));
+    const status = await getOAuthStatus('atlassian');
+    expect(status.connected).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/grafana/api/plugins/consensys-asko11y-app/resources/api/oauth/atlassian/status',
+        method: 'GET',
+      })
+    );
+  });
+
+  it('reports not configured when the status call fails', async () => {
+    fetchMock.mockReturnValue(throwError(() => new Error('404')));
+    const status = await getOAuthStatus('unknown');
+    expect(status).toEqual({ configured: false, connected: false });
+  });
+
+  it('POSTs disconnect', async () => {
+    fetchMock.mockReturnValue(of({}));
+    await disconnectOAuth('atlassian');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/grafana/api/plugins/consensys-asko11y-app/resources/api/oauth/atlassian/disconnect',
+        method: 'POST',
+      })
+    );
+  });
+
+  describe('onOAuthCallback', () => {
+    it('invokes the callback for same-origin oauth messages only', () => {
+      const cb = jest.fn();
+      const unsubscribe = onOAuthCallback(cb);
+
+      const valid = { source: 'asko11y-oauth', serverID: 'atlassian', success: true };
+      window.dispatchEvent(new MessageEvent('message', { data: valid, origin: window.location.origin }));
+      expect(cb).toHaveBeenCalledWith(valid);
+
+      cb.mockClear();
+      // Wrong origin is ignored.
+      window.dispatchEvent(new MessageEvent('message', { data: valid, origin: 'https://evil.example' }));
+      // Wrong shape is ignored.
+      window.dispatchEvent(new MessageEvent('message', { data: { source: 'other' }, origin: window.location.origin }));
+      expect(cb).not.toHaveBeenCalled();
+
+      unsubscribe();
+      window.dispatchEvent(new MessageEvent('message', { data: valid, origin: window.location.origin }));
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/mcpProvisionerClient.ts
+++ b/src/services/mcpProvisionerClient.ts
@@ -1,0 +1,90 @@
+import { firstValueFrom } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+import { pluginUrl } from '../utils/subpath';
+
+const base = () => pluginUrl('/api/mcp/provisioner');
+
+export type PresetId = 'github-read' | 'github-write' | 'atlassian';
+
+export interface MCPPreset {
+  id: PresetId;
+  displayName: string;
+  serverId: string;
+  mcpUrl: string;
+  transport: 'streamable-http' | 'sse';
+  scopes: string[];
+  dcrCapable: boolean;
+}
+
+export interface DynamicMCPServer {
+  serverId: string;
+  displayName: string;
+  mcpUrl: string;
+  transport: string;
+  presetId?: string;
+  scopes?: string[];
+}
+
+export async function listPresets(): Promise<MCPPreset[]> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ presets: MCPPreset[] }>({ url: `${base()}/presets`, method: 'GET' })
+  );
+  return resp?.data?.presets ?? [];
+}
+
+export async function listDynamicServers(): Promise<DynamicMCPServer[]> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ servers: DynamicMCPServer[] }>({ url: base(), method: 'GET' })
+  );
+  return resp?.data?.servers ?? [];
+}
+
+export interface AddPresetInput {
+  preset: PresetId;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export async function addPreset(input: AddPresetInput): Promise<{ serverId: string }> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ serverId: string }>({
+      url: `${base()}/preset`,
+      method: 'POST',
+      data: input,
+      showErrorAlert: false,
+    })
+  );
+  return resp?.data ?? { serverId: '' };
+}
+
+export interface AddGenericInput {
+  serverId: string;
+  displayName?: string;
+  mcpUrl: string;
+  transport: 'streamable-http' | 'sse';
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  scopes?: string[];
+  pkce?: boolean;
+  discover?: boolean;
+}
+
+export async function addGeneric(input: AddGenericInput): Promise<{ serverId: string }> {
+  const resp = await firstValueFrom(
+    getBackendSrv().fetch<{ serverId: string }>({
+      url: `${base()}/generic`,
+      method: 'POST',
+      data: input,
+      showErrorAlert: false,
+    })
+  );
+  return resp?.data ?? { serverId: '' };
+}
+
+export async function removeDynamicServer(serverId: string): Promise<void> {
+  await firstValueFrom(
+    getBackendSrv().fetch({ url: `${base()}/${encodeURIComponent(serverId)}`, method: 'DELETE' })
+  );
+}

--- a/src/services/mcpServerStatus.ts
+++ b/src/services/mcpServerStatus.ts
@@ -45,9 +45,18 @@ export interface SystemHealth {
   total: number;
 }
 
+export interface MCPOAuthStatus {
+  configured: boolean;
+  connected: boolean;
+  expiresAt?: string;
+}
+
 export interface MCPServersResponse {
   servers: MCPServerStatus[];
   systemHealth: SystemHealth;
+  // Keyed by server ID; present only for servers with an oauth block.
+  // Reflects the current Grafana user's connection state.
+  oauth?: Record<string, MCPOAuthStatus>;
 }
 
 export class MCPServerStatusService {

--- a/src/services/oauthClient.ts
+++ b/src/services/oauthClient.ts
@@ -1,0 +1,89 @@
+import { firstValueFrom } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+import { pluginUrl } from '../utils/subpath';
+
+export interface OAuthStatus {
+  configured: boolean;
+  connected: boolean;
+  expiresAt?: string;
+}
+
+/**
+ * Returns the OAuth connection status for a given MCP server and the current
+ * Grafana user. Safe to call for servers without an OAuth block — the backend
+ * responds 404 and this resolves to configured:false.
+ */
+export async function getOAuthStatus(serverId: string): Promise<OAuthStatus> {
+  try {
+    const resp = await firstValueFrom(
+      getBackendSrv().fetch<OAuthStatus>({
+        url: pluginUrl(`/api/oauth/${encodeURIComponent(serverId)}/status`),
+        method: 'GET',
+        showErrorAlert: false,
+      })
+    );
+    return resp?.data ?? { configured: false, connected: false };
+  } catch {
+    return { configured: false, connected: false };
+  }
+}
+
+/**
+ * Returns the URL the UI should open in a popup to kick off the
+ * authorization-code flow. The backend 302s to the authorization server.
+ */
+export function startOAuthUrl(serverId: string): string {
+  return pluginUrl(`/api/oauth/${encodeURIComponent(serverId)}/start`);
+}
+
+/**
+ * Opens the OAuth flow in a popup. Returns the handle so the caller can
+ * detect popup-blocker scenarios and fall back to a same-tab redirect.
+ */
+export function openOAuthPopup(serverId: string): Window | null {
+  return window.open(startOAuthUrl(serverId), '_blank', 'width=600,height=750,menubar=no,toolbar=no');
+}
+
+/** Tells the backend to forget the current user's stored token for a server. */
+export async function disconnectOAuth(serverId: string): Promise<void> {
+  await firstValueFrom(
+    getBackendSrv().fetch({
+      url: pluginUrl(`/api/oauth/${encodeURIComponent(serverId)}/disconnect`),
+      method: 'POST',
+    })
+  );
+}
+
+/** Shape of the postMessage the /callback page dispatches to the opener. */
+export interface OAuthCallbackMessage {
+  source: 'asko11y-oauth';
+  serverID: string;
+  success: boolean;
+  reason?: string;
+}
+
+function isOAuthCallbackMessage(data: unknown): data is OAuthCallbackMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as Record<string, unknown>).source === 'asko11y-oauth' &&
+    typeof (data as Record<string, unknown>).serverID === 'string' &&
+    typeof (data as Record<string, unknown>).success === 'boolean'
+  );
+}
+
+/**
+ * Subscribes to OAuth popup completion events. Only messages from this
+ * window's own origin are accepted (the callback page is served by the
+ * plugin backend on the Grafana origin). Returns an unsubscribe function.
+ */
+export function onOAuthCallback(cb: (msg: OAuthCallbackMessage) => void): () => void {
+  const handler = (e: MessageEvent) => {
+    if (e.origin !== window.location.origin || !isOAuthCallbackMessage(e.data)) {
+      return;
+    }
+    cb(e.data);
+  };
+  window.addEventListener('message', handler);
+  return () => window.removeEventListener('message', handler);
+}


### PR DESCRIPTION
## Summary

- Each Grafana user can authorise external MCP servers with their own identity via OAuth 2.0 authorization-code + PKCE; the agent injects that user's token on every tool call **and on tool discovery**, so auth-gated providers list tools correctly.
- Admins attach OAuth-gated MCP servers at runtime from the plugin config page — presets (GitHub read-only, GitHub read/write, Atlassian) plus a Generic form with optional RFC 8414/9728 discovery and RFC 7591 dynamic client registration.
- End users connect/disconnect their accounts from a new **Connections** button in the chat toolbar (popup + origin-checked postMessage).
- Servers without an `oauth` block keep the existing static-header path unchanged.

Supersedes #124, re-implemented from scratch against the current runtime (the old branch predates the agent-runtime rewrite, per-server tool selection, and subpath support).

## Review feedback from #124 addressed

- **Reflected XSS in the OAuth callback (Bugbot, high)** — the postMessage payload is embedded via `json.Marshal` (escapes `<`/`>`), visible text is HTML-escaped, and a regression test injects `</script><script>…` through `error_description`.
- **Non-DCR preset "Add" dropped the typed clientId (Bugbot, low)** — single Add flow that always carries the credentials; covered by a component test.

## Design & hardening beyond #124

- `Proxy/Client.CallToolWithContext` and `ListToolsWithContext` carry the caller context; the user ID travels via `mcp.WithUserID` and is read per-request by a round tripper, so one MCP client serves all users with per-request bearers. Requests without a user (health checks) pass through unauthenticated; a user without a token gets an actionable "connect first" error.
- Token refresh is serialised per (server, user) — providers rotate refresh tokens, so concurrent refreshes must not race.
- Redirect URIs derive from Grafana's `AppURL` (subpath-safe), falling back to forwarded headers; all frontend URLs use `pluginUrl()`.
- Provisioner endpoints (including reads) are Admin-only; OAuth client secrets and DCR registration tokens never leave the backend.
- SDK `httpclient.New()` everywhere (no `http.DefaultClient` as in the old branch).
- Stores follow the existing Redis-with-in-memory-fallback pattern (tokens, PKCE state, dynamic server records).
- Transport fixes found during live testing against `mcp.atlassian.com`:
  - the SSE transport binds its event stream to the ctx passed to `Connect`; cancelling the dial-timeout ctx on return killed sessions instantly. The session ctx now lives until the session is replaced/closed, with the dial timeout on a timer. The client-level HTTP timeout is also dropped for SSE (it severs streams at 30 s).
  - the Atlassian preset uses the streamable-http endpoint `/v1/mcp`; the legacy `/v1/sse` drops long-lived streams at Atlassian's Cloudflare edge.

## Known limitations (documented in code)

- One MCP session per server shared across users, with per-request bearer swap. Providers that bind authorization to the `initialize` identity would need per-user sessions (v2).
- Per-user OAuth requires a signed-in Grafana user; anonymous sessions get an explanatory 401.
- Without Redis, tokens/state/dynamic servers are in-memory and lost on plugin restart (same trade-off as the session store).

## Test plan

- [x] `go test ./pkg/...` (all packages), `npm run test:ci` (518/518), `npm run lint`, `npm run typecheck`
- [x] `npm run validate:openapi` (one new benign warning: `/api/oauth/{serverId}/start` legitimately has no 2XX — it is a pure 302)
- [x] `npm run validate` — clean apart from documented benign findings; two gosec G101 false positives on the GitHub preset URL literals suppressed with `#nosec` + justification
- [x] Atlassian end-to-end verified manually in the dev environment: preset Add → discovery + DCR → per-user Connect popup → token exchange → status Connected
- [ ] GitHub preset (needs an OAuth App in the GitHub developer console)
- [ ] Second Grafana user profile to confirm token isolation

## Dev-loop gotcha (for reviewers testing locally)

After backend changes, rebuild the container's platform binary (`mage build:linuxARM64` on Apple Silicon, or `buildAll`) before `docker compose restart grafana` — `npm run build:backend` alone builds only the host (darwin) binary and the container keeps running the stale one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces OAuth token storage, refresh, and per-request Authorization injection on MCP traffic, plus admin-only provisioning that stores client secrets. Shared MCP sessions with swapped bearers and Redis-backed credentials make this security-critical.
> 
> **Overview**
> GrafanaGrafana users can connect their own accounts to OAuth-gated MCP servers (authorization-code + PKCE). The agent injects that user's bearer on **tool discovery and tool calls**; servers without an `oauth` block keep static headers.
> 
> Admins provision servers at runtime from App Config: GitHub read/write presets (bring-your-own app) and Atlassian (RFC 8414/9728 discovery + RFC 7591 DCR), plus a generic form. End users Connect/Disconnect from a new chat **Connections** button (popup + origin-checked `postMessage`).
> 
> MCP client sessions now outlive the dial timeout (SSE streams were dying immediately) and skip `http.Client.Timeout` for SSE. Tokens, PKCE state, and dynamic servers persist in Redis (in-memory fallback). Client secrets never leave the backend; provisioner routes are Admin-only.
> 
> **Limitation:** one shared MCP session per server with per-request bearer swap — providers that bind identity at `initialize` would need per-user sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab36d326ecd924a6d21542f88775c5113dc10182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->