### PR TITLE
fix(backend): cut agent loop token cost via context eviction and lower ceiling

### DIFF
--- a/pkg/agent/context_window.go
+++ b/pkg/agent/context_window.go
@@ -244,7 +244,7 @@ func toolNamesByCallID(messages []Message) map[string]string {
 // larger savings of not resending the raw content every remaining iteration.
 type toolResultSummarizer func(toolName, content string) string
 
-func evictStaleToolResults(messages []Message, keepRecent int, summarize toolResultSummarizer) []Message {
+func evictStaleToolResults(messages []Message, keepRecent int, summarize toolResultSummarizer, isError func(toolCallID string) bool) []Message {
 	if keepRecent <= 0 {
 		keepRecent = keepRecentToolResults
 	}
@@ -274,8 +274,14 @@ func evictStaleToolResults(messages []Message, keepRecent int, summarize toolRes
 			name = "unknown tool"
 		}
 
-		summary := ""
-		if summarize != nil {
+		var summary string
+		if isError != nil && isError(m.ToolCallID) {
+			// Error results are short, deterministic diagnostics — one of them
+			// is the anti-hallucination "do not fabricate output" directive on
+			// transport failures. Never paraphrase these through an LLM; keep
+			// the exact wording (truncated only if unexpectedly long).
+			summary = truncateWhitespace(m.Content, evictionSummaryFallbackChars)
+		} else if summarize != nil {
 			summary = strings.TrimSpace(summarize(name, m.Content))
 		}
 		if summary == "" {

--- a/pkg/agent/context_window.go
+++ b/pkg/agent/context_window.go
@@ -2,14 +2,34 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
-const DefaultMaxTotalTokens = 128_000
+// DefaultMaxTotalTokens was 128,000 until a production cost audit (Aug 2026)
+// found the agent loop resending near-max-context on almost every iteration —
+// with no prompt caching on the OpenAI-compat LLM transport, each iteration
+// billed the full window from scratch. Halved to shrink that per-iteration
+// cost; admins can still raise it via PluginSettings.MaxTotalTokens.
+const DefaultMaxTotalTokens = 64_000
 const defaultRecentMessageCount = 15
 const systemMessageBuffer = 1000
 const maxToolResponseTokens = 8000
 const aggressiveToolResponseTokens = 2000
+
+// highVolumeToolResponseTokens and aggressiveHighVolumeToolResponseTokens cap
+// tool results from raw-data query tools (Loki/Prometheus/Tempo/Pyroscope/
+// dashboard JSON) tighter than other tools — these dominate context growth
+// and are usually redundant once the LLM has already summarized them once.
+const highVolumeToolResponseTokens = 3000
+const aggressiveHighVolumeToolResponseTokens = 800
+
+// keepRecentToolResults bounds how many of the most recent tool results stay
+// in full in the resent context; older ones are replaced by a short
+// placeholder via evictStaleToolResults. This is the manual equivalent of
+// Anthropic's context-editing (clear_tool_uses) strategy, needed because the
+// OpenAI-compat LLM transport has no server-side caching or context editing.
+const keepRecentToolResults = 8
 
 // TruncationMarker is the prefix used to detect an existing truncation notice
 // so repeated trims in the same run don't stack duplicates.
@@ -19,6 +39,27 @@ const TruncationMarker = "[NOTICE: Conversation history truncated."
 // system prompt when TrimMessagesToTokenLimit drops messages from the front
 // of the window, so the LLM knows prior context is gone and must re-query.
 const TruncationNotice = TruncationMarker + " Earlier messages are no longer visible — re-query tools if you need prior data.]"
+
+// EvictedToolResultMarker prefixes a stale tool result's replacement content
+// so repeated eviction passes over the same message are idempotent.
+const EvictedToolResultMarker = "[NOTICE: Tool result evicted to save context."
+
+// highVolumeToolNamePatterns match tool names whose results tend to be large,
+// raw query output (log lines, metric samples, trace spans, dashboard JSON)
+// rather than a short summary. Matched case-insensitively as a substring.
+var highVolumeToolNamePatterns = []string{
+	"query", "logs", "loki", "prometheus", "tempo", "trace", "pyroscope", "dashboard",
+}
+
+func isHighVolumeTool(toolName string) bool {
+	lower := strings.ToLower(toolName)
+	for _, p := range highVolumeToolNamePatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
 
 func EstimateTokens(text string) int {
 	return (len(text) + 3) / 4
@@ -88,12 +129,14 @@ func TrimMessagesToTokenLimit(messages []Message, tools []OpenAITool, maxTokens 
 		return messages
 	}
 
-	trimmed := trimToolResponses(messages, maxToolResponseTokens)
+	toolNames := toolNamesByCallID(messages)
+
+	trimmed := trimToolResponses(messages, maxToolResponseTokens, highVolumeToolResponseTokens, toolNames)
 	if estimateMessagesTokens(trimmed, tools) <= maxTokens {
 		return trimmed
 	}
 
-	trimmed = trimToolResponses(trimmed, aggressiveToolResponseTokens)
+	trimmed = trimToolResponses(trimmed, aggressiveToolResponseTokens, aggressiveHighVolumeToolResponseTokens, toolNames)
 	if estimateMessagesTokens(trimmed, tools) <= maxTokens {
 		return trimmed
 	}
@@ -153,17 +196,97 @@ func hasTruncationNotice(messages []Message) bool {
 	return false
 }
 
-func trimToolResponses(messages []Message, maxTokens int) []Message {
+func trimToolResponses(messages []Message, maxTokens, maxTokensHighVolume int, toolNames map[string]string) []Message {
 	out := make([]Message, len(messages))
 	for i, m := range messages {
-		if m.Role == "tool" && EstimateTokens(m.Content) > maxTokens {
-			maxChars := maxTokens * 4
+		limit := maxTokens
+		if isHighVolumeTool(toolNames[m.ToolCallID]) {
+			limit = maxTokensHighVolume
+		}
+		if m.Role == "tool" && EstimateTokens(m.Content) > limit {
+			maxChars := limit * 4
 			if maxChars > len(m.Content) {
 				maxChars = len(m.Content)
 			}
 			m.Content = m.Content[:maxChars] + "\n[...truncated]"
 		}
 		out[i] = m
+	}
+	return out
+}
+
+// toolNamesByCallID maps each tool_call id to the function name the assistant
+// invoked it with, so later passes (truncation, eviction) can key limits and
+// placeholders off the tool name even though the "tool" role message that
+// carries the result only stores the call id.
+func toolNamesByCallID(messages []Message) map[string]string {
+	names := make(map[string]string)
+	for _, m := range messages {
+		for _, tc := range m.ToolCalls {
+			names[tc.ID] = tc.Function.Name
+		}
+	}
+	return names
+}
+
+// evictStaleToolResults replaces the content of all but the most recent
+// keepRecent tool results with a short placeholder. Without prompt caching on
+// the LLM transport, every iteration re-bills the full accumulated tool-call
+// history from scratch — this is the manual equivalent of Anthropic's
+// context-editing (clear_tool_uses) strategy: it shrinks what's actually
+// transmitted instead of relying on a cache discount that isn't available.
+// The placeholder names the tool so the model can re-call it if it still
+// needs that data. Idempotent: already-evicted messages are left alone.
+// toolResultSummarizer condenses a stale tool result's content into a short
+// summary the model can keep in context instead of the raw payload. Called at
+// most once per tool result (evictStaleToolResults is idempotent), so an
+// LLM-backed implementation is a reasonable one-time cost against the much
+// larger savings of not resending the raw content every remaining iteration.
+type toolResultSummarizer func(toolName, content string) string
+
+func evictStaleToolResults(messages []Message, keepRecent int, summarize toolResultSummarizer) []Message {
+	if keepRecent <= 0 {
+		keepRecent = keepRecentToolResults
+	}
+
+	var toolIdx []int
+	for i, m := range messages {
+		if m.Role == "tool" {
+			toolIdx = append(toolIdx, i)
+		}
+	}
+	if len(toolIdx) <= keepRecent {
+		return messages
+	}
+
+	toolNames := toolNamesByCallID(messages)
+	staleIdx := toolIdx[:len(toolIdx)-keepRecent]
+
+	out := make([]Message, len(messages))
+	copy(out, messages)
+	for _, i := range staleIdx {
+		m := out[i]
+		if strings.HasPrefix(m.Content, EvictedToolResultMarker) {
+			continue
+		}
+		name := toolNames[m.ToolCallID]
+		if name == "" {
+			name = "unknown tool"
+		}
+
+		summary := ""
+		if summarize != nil {
+			summary = strings.TrimSpace(summarize(name, m.Content))
+		}
+		if summary == "" {
+			summary = "no summary available"
+		}
+
+		out[i] = Message{
+			Role:       m.Role,
+			ToolCallID: m.ToolCallID,
+			Content:    fmt.Sprintf("%s Tool: %s. Summary: %s Re-call the tool if you need the full data again.]", EvictedToolResultMarker, name, summary),
+		}
 	}
 	return out
 }

--- a/pkg/agent/context_window_test.go
+++ b/pkg/agent/context_window_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -69,7 +70,7 @@ func TestTrimMessagesToTokenLimit(t *testing.T) {
 func TestTrimMessagesToTokenLimit_DropsOldMessages(t *testing.T) {
 	messages := []Message{
 		{Role: "system", Content: "sys"},
-		{Role: "user", Content: strings.Repeat("a", 40000)},    // ~10000 tokens
+		{Role: "user", Content: strings.Repeat("a", 40000)},      // ~10000 tokens
 		{Role: "assistant", Content: strings.Repeat("b", 40000)}, // ~10000 tokens
 		{Role: "user", Content: "recent"},                        // small
 	}
@@ -126,7 +127,7 @@ func TestTrimToolResponses(t *testing.T) {
 		{Role: "tool", ToolCallID: "1", Content: strings.Repeat("x", 100000)},
 	}
 
-	result := trimToolResponses(messages, 100)
+	result := trimToolResponses(messages, 100, 100, nil)
 	if !strings.Contains(result[0].Content, "[...truncated]") {
 		t.Error("expected tool response to be truncated")
 	}
@@ -201,6 +202,175 @@ func TestBuildContextWindow_FiltersEmptyAssistant(t *testing.T) {
 	for _, m := range result {
 		if m.Role == "assistant" {
 			t.Error("empty assistant message should have been filtered")
+		}
+	}
+}
+
+func toolCallMessage(assistantContent string, ids ...string) Message {
+	tcs := make([]ToolCall, len(ids))
+	for i, id := range ids {
+		tcs[i] = ToolCall{ID: id, Type: "function", Function: FunctionCall{Name: "query_prometheus_" + id}}
+	}
+	return Message{Role: "assistant", Content: assistantContent, ToolCalls: tcs}
+}
+
+func toolResultMessage(id, content string) Message {
+	return Message{Role: "tool", ToolCallID: id, Content: content}
+}
+
+func TestEvictStaleToolResults_KeepsAllWhenUnderLimit(t *testing.T) {
+	messages := []Message{
+		{Role: "system", Content: "sys"},
+		toolCallMessage("", "1", "2"),
+		toolResultMessage("1", "result one"),
+		toolResultMessage("2", "result two"),
+	}
+
+	result := evictStaleToolResults(messages, 5, nil)
+	if result[2].Content != "result one" || result[3].Content != "result two" {
+		t.Fatalf("expected results untouched when under keepRecent, got %+v", result)
+	}
+}
+
+func TestEvictStaleToolResults_EvictsOldestKeepsNewest(t *testing.T) {
+	var messages []Message
+	for i := 1; i <= 5; i++ {
+		id := fmt.Sprintf("%d", i)
+		messages = append(messages, toolCallMessage("", id))
+		messages = append(messages, toolResultMessage(id, "result "+id))
+	}
+
+	result := evictStaleToolResults(messages, 2, nil)
+
+	var toolMsgs []Message
+	for _, m := range result {
+		if m.Role == "tool" {
+			toolMsgs = append(toolMsgs, m)
+		}
+	}
+	if len(toolMsgs) != 5 {
+		t.Fatalf("expected 5 tool messages, got %d", len(toolMsgs))
+	}
+	// Oldest 3 evicted, newest 2 kept in full.
+	for i := 0; i < 3; i++ {
+		if !strings.HasPrefix(toolMsgs[i].Content, EvictedToolResultMarker) {
+			t.Errorf("expected tool result %d to be evicted, got %q", i, toolMsgs[i].Content)
+		}
+		if !strings.Contains(toolMsgs[i].Content, "query_prometheus_") {
+			t.Errorf("expected placeholder to name the tool, got %q", toolMsgs[i].Content)
+		}
+	}
+	for i := 3; i < 5; i++ {
+		if strings.HasPrefix(toolMsgs[i].Content, EvictedToolResultMarker) {
+			t.Errorf("expected tool result %d to remain in full, got %q", i, toolMsgs[i].Content)
+		}
+	}
+}
+
+func TestEvictStaleToolResults_NoSummarizerFallsBackToPlaceholder(t *testing.T) {
+	var messages []Message
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("%d", i)
+		messages = append(messages, toolCallMessage("", id))
+		messages = append(messages, toolResultMessage(id, "result "+id))
+	}
+
+	result := evictStaleToolResults(messages, 0, nil)
+	for _, m := range result {
+		if m.Role != "tool" {
+			continue
+		}
+		if strings.HasPrefix(m.Content, EvictedToolResultMarker) && !strings.Contains(m.Content, "no summary available") {
+			t.Errorf("expected nil-summarizer fallback text, got %q", m.Content)
+		}
+	}
+}
+
+func TestEvictStaleToolResults_UsesSummarizerOncePerResult(t *testing.T) {
+	var messages []Message
+	for i := 1; i <= 5; i++ {
+		id := fmt.Sprintf("%d", i)
+		messages = append(messages, toolCallMessage("", id))
+		messages = append(messages, toolResultMessage(id, "raw content "+id))
+	}
+
+	var calls []string
+	summarize := func(toolName, content string) string {
+		calls = append(calls, content)
+		return "summary of: " + content
+	}
+
+	first := evictStaleToolResults(messages, 2, summarize)
+
+	var evicted int
+	for _, m := range first {
+		if m.Role == "tool" && strings.HasPrefix(m.Content, EvictedToolResultMarker) {
+			evicted++
+			if !strings.Contains(m.Content, "summary of: raw content") {
+				t.Errorf("expected summarizer output embedded in placeholder, got %q", m.Content)
+			}
+		}
+	}
+	if evicted != 3 {
+		t.Fatalf("expected 3 evicted results, got %d", evicted)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected summarizer called exactly once per stale result (3), got %d calls", len(calls))
+	}
+
+	// Re-running eviction on the already-evicted output must not call the
+	// summarizer again — evictStaleToolResults is idempotent.
+	second := evictStaleToolResults(first, 2, summarize)
+	if len(calls) != 3 {
+		t.Fatalf("expected no additional summarizer calls on re-eviction, got %d total calls", len(calls))
+	}
+	for i, m := range second {
+		if m.Role != "tool" {
+			continue
+		}
+		if strings.Count(m.Content, EvictedToolResultMarker) > 1 {
+			t.Fatalf("message[%d] has a duplicated eviction marker: %q", i, m.Content)
+		}
+		if m.Content != first[i].Content {
+			t.Errorf("message[%d] changed on re-eviction: %q -> %q", i, first[i].Content, m.Content)
+		}
+	}
+}
+
+func TestTrimToolResponses_HighVolumeToolGetsTighterLimit(t *testing.T) {
+	toolNames := map[string]string{
+		"1": "query_loki_logs",
+		"2": "create_annotation",
+	}
+	messages := []Message{
+		toolResultMessage("1", strings.Repeat("x", 100000)),
+		toolResultMessage("2", strings.Repeat("y", 100000)),
+	}
+
+	result := trimToolResponses(messages, 8000, 3000, toolNames)
+
+	if got := EstimateTokens(result[0].Content); got > 3000+10 {
+		t.Errorf("expected high-volume tool result capped near 3000 tokens, got %d", got)
+	}
+	if got := EstimateTokens(result[1].Content); got <= 3000 {
+		t.Errorf("expected non-high-volume tool result to use the higher 8000 cap, got %d tokens", got)
+	}
+}
+
+func TestIsHighVolumeTool(t *testing.T) {
+	cases := map[string]bool{
+		"query_prometheus":      true,
+		"query_loki_logs":       true,
+		"tempo_traceql-search":  true,
+		"list_pyroscope_labels": true,
+		"get_dashboard_by_uid":  true,
+		"create_annotation":     false,
+		"list_incidents":        false,
+		"get_current_oncall":    false,
+	}
+	for name, want := range cases {
+		if got := isHighVolumeTool(name); got != want {
+			t.Errorf("isHighVolumeTool(%q) = %v, want %v", name, got, want)
 		}
 	}
 }

--- a/pkg/agent/context_window_test.go
+++ b/pkg/agent/context_window_test.go
@@ -226,7 +226,7 @@ func TestEvictStaleToolResults_KeepsAllWhenUnderLimit(t *testing.T) {
 		toolResultMessage("2", "result two"),
 	}
 
-	result := evictStaleToolResults(messages, 5, nil)
+	result := evictStaleToolResults(messages, 5, nil, nil)
 	if result[2].Content != "result one" || result[3].Content != "result two" {
 		t.Fatalf("expected results untouched when under keepRecent, got %+v", result)
 	}
@@ -240,7 +240,7 @@ func TestEvictStaleToolResults_EvictsOldestKeepsNewest(t *testing.T) {
 		messages = append(messages, toolResultMessage(id, "result "+id))
 	}
 
-	result := evictStaleToolResults(messages, 2, nil)
+	result := evictStaleToolResults(messages, 2, nil, nil)
 
 	var toolMsgs []Message
 	for _, m := range result {
@@ -275,7 +275,7 @@ func TestEvictStaleToolResults_NoSummarizerFallsBackToPlaceholder(t *testing.T) 
 		messages = append(messages, toolResultMessage(id, "result "+id))
 	}
 
-	result := evictStaleToolResults(messages, 0, nil)
+	result := evictStaleToolResults(messages, 0, nil, nil)
 	for _, m := range result {
 		if m.Role != "tool" {
 			continue
@@ -300,7 +300,7 @@ func TestEvictStaleToolResults_UsesSummarizerOncePerResult(t *testing.T) {
 		return "summary of: " + content
 	}
 
-	first := evictStaleToolResults(messages, 2, summarize)
+	first := evictStaleToolResults(messages, 2, summarize, nil)
 
 	var evicted int
 	for _, m := range first {
@@ -320,7 +320,7 @@ func TestEvictStaleToolResults_UsesSummarizerOncePerResult(t *testing.T) {
 
 	// Re-running eviction on the already-evicted output must not call the
 	// summarizer again — evictStaleToolResults is idempotent.
-	second := evictStaleToolResults(first, 2, summarize)
+	second := evictStaleToolResults(first, 2, summarize, nil)
 	if len(calls) != 3 {
 		t.Fatalf("expected no additional summarizer calls on re-eviction, got %d total calls", len(calls))
 	}
@@ -333,6 +333,53 @@ func TestEvictStaleToolResults_UsesSummarizerOncePerResult(t *testing.T) {
 		}
 		if m.Content != first[i].Content {
 			t.Errorf("message[%d] changed on re-eviction: %q -> %q", i, first[i].Content, m.Content)
+		}
+	}
+}
+
+func TestEvictStaleToolResults_ErrorResultsSkipSummarizerVerbatim(t *testing.T) {
+	var messages []Message
+	for i := 1; i <= 5; i++ {
+		id := fmt.Sprintf("%d", i)
+		messages = append(messages, toolCallMessage("", id))
+		content := "raw content " + id
+		if id == "2" {
+			content = "[SYSTEM: MCP transport failure for tool 'query_loki_logs' after retries. Result is UNAVAILABLE — do not fabricate output.]"
+		}
+		messages = append(messages, toolResultMessage(id, content))
+	}
+
+	summarize := func(toolName, content string) string {
+		return "PARAPHRASED (should never appear for error results)"
+	}
+	isError := func(toolCallID string) bool {
+		return toolCallID == "2"
+	}
+
+	result := evictStaleToolResults(messages, 2, summarize, isError)
+
+	for _, m := range result {
+		if m.Role != "tool" || m.ToolCallID != "2" {
+			continue
+		}
+		if !strings.HasPrefix(m.Content, EvictedToolResultMarker) {
+			t.Fatalf("expected error tool result to be evicted, got %q", m.Content)
+		}
+		if strings.Contains(m.Content, "PARAPHRASED") {
+			t.Errorf("error tool result must never be paraphrased by the summarizer, got %q", m.Content)
+		}
+		if !strings.Contains(m.Content, "do not fabricate output") {
+			t.Errorf("expected the anti-hallucination directive preserved verbatim, got %q", m.Content)
+		}
+	}
+
+	// Non-error stale results should still go through the summarizer as before.
+	for _, m := range result {
+		if m.Role != "tool" || m.ToolCallID == "2" || !strings.HasPrefix(m.Content, EvictedToolResultMarker) {
+			continue
+		}
+		if !strings.Contains(m.Content, "PARAPHRASED") {
+			t.Errorf("expected non-error stale result to use the summarizer, got %q", m.Content)
 		}
 	}
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -31,6 +31,15 @@ const nearLimitWarning = "[SYSTEM: You are approaching the iteration limit. Prod
 // this the run ends with a clean, retryable error instead of spinning.
 const maxTruncationRetries = 1
 
+// Eviction-summary tunables: evictStaleToolResults calls out to the cheap
+// "base" model once per stale tool result to compress it before dropping the
+// raw content — see summarizeForEviction.
+const evictionSummaryMaxTokens = 200
+const evictionSummaryMaxInputChars = 20000
+const evictionSummaryFallbackChars = 300
+
+const evictionSummarySystemPrompt = "Summarize the following observability tool result in 2-3 concise sentences for later reference during an ongoing investigation. Preserve concrete facts: numbers, identifiers, timestamps, error messages, and anomalies. Do not add commentary or speculation."
+
 // truncatedToolCallNudge is injected after a truncated tool call is discarded so
 // the model reissues a smaller, complete call rather than repeating the cutoff.
 const truncatedToolCallNudge = "[SYSTEM: Your previous tool call was cut off before its arguments were complete, so it was discarded. Reissue it now as a single, complete, valid JSON tool call. If the arguments are large (for example a full dashboard), reduce their size or split the work into smaller steps.]"
@@ -142,6 +151,9 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 			return
 		}
 
+		messages = evictStaleToolResults(messages, keepRecentToolResults, func(toolName, content string) string {
+			return a.summarizeForEviction(ctx, req, usageByModel, toolName, content)
+		})
 		messages = TrimMessagesToTokenLimit(messages, openAITools, promptBudget)
 
 		a.logger.Debug("Agent loop iteration",
@@ -349,6 +361,56 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 		Type: "error",
 		Data: ErrorEvent{Message: fmt.Sprintf("Agent loop reached maximum iterations (%d)", maxIter)},
 	})
+}
+
+// summarizeForEviction condenses a stale tool result with a cheap ("base")
+// model call before evictStaleToolResults drops the raw content, so the model
+// keeps the gist of earlier evidence instead of nothing. Any failure (network
+// error, empty response, exhausted quota) falls back to a plain whitespace
+// truncation of the original content rather than surfacing an error — this is
+// a cost optimization on top of an already-working eviction path, not a
+// critical request, so degrading quietly is preferable to failing the run.
+func (a *AgentLoop) summarizeForEviction(ctx context.Context, req LoopRequest, usageByModel map[string]ModelUsage, toolName, content string) string {
+	fallback := truncateWhitespace(content, evictionSummaryFallbackChars)
+
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return fallback
+	}
+	if len(trimmed) > evictionSummaryMaxInputChars {
+		trimmed = trimmed[:evictionSummaryMaxInputChars]
+	}
+
+	resp, err := a.llmClient.ChatCompletion(ctx, ChatCompletionRequest{
+		Model: "base",
+		Messages: []Message{
+			{Role: "system", Content: evictionSummarySystemPrompt},
+			{Role: "user", Content: fmt.Sprintf("Tool: %s\n\nResult:\n%s", toolName, trimmed)},
+		},
+		MaxTokens: evictionSummaryMaxTokens,
+	}, req.GrafanaURL, req.AuthToken, req.OrgID)
+	if err != nil {
+		a.logger.Warn("Tool result eviction summary failed, falling back to truncation", "error", err, "tool", toolName)
+		return fallback
+	}
+
+	if resp.Usage != nil {
+		usage := usageByModel["base"]
+		usage.Model = "base"
+		usage.PromptTokens += resp.Usage.PromptTokens
+		usage.CompletionTokens += resp.Usage.CompletionTokens
+		usage.TotalTokens += resp.Usage.TotalTokens
+		usageByModel["base"] = usage
+	}
+
+	if len(resp.Choices) == 0 {
+		return fallback
+	}
+	summary := strings.TrimSpace(resp.Choices[0].Message.Content)
+	if summary == "" {
+		return fallback
+	}
+	return summary
 }
 
 func (a *AgentLoop) chatCompletionWithFallback(ctx context.Context, llmReq ChatCompletionRequest, req LoopRequest) (*ChatCompletionResponse, string, error) {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -146,6 +146,13 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	usageByModel := make(map[string]ModelUsage)
 	toolCallCount := 0
 
+	// toolResultIsError records which tool_call ids produced an error result,
+	// so evictStaleToolResults can skip LLM summarization for them — error
+	// content is short, deterministic diagnostic text (including the
+	// anti-hallucination directive on transport failures) that must never be
+	// paraphrased.
+	toolResultIsError := make(map[string]bool)
+
 	for iteration := 0; iteration < maxIter; iteration++ {
 		if ctx.Err() != nil {
 			return
@@ -153,6 +160,8 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 
 		messages = evictStaleToolResults(messages, keepRecentToolResults, func(toolName, content string) string {
 			return a.summarizeForEviction(ctx, req, usageByModel, toolName, content)
+		}, func(toolCallID string) bool {
+			return toolResultIsError[toolCallID]
 		})
 		messages = TrimMessagesToTokenLimit(messages, openAITools, promptBudget)
 
@@ -331,6 +340,7 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 				ToolCallID: tc.ID,
 				Content:    llmContent,
 			})
+			toolResultIsError[tc.ID] = isError
 
 			if !mcpUnavailableEmitted && len(transportFailedTools) >= 2 {
 				mcpUnavailableEmitted = true

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1157,3 +1157,119 @@ func TestAgentLoop_ContextCancellation(t *testing.T) {
 		}
 	}
 }
+
+// TestAgentLoop_EvictsStaleToolResultsAcrossIterations runs enough tool-calling
+// iterations to exceed keepRecentToolResults and verifies the LLM requests sent
+// in later iterations no longer carry the full content of the oldest tool
+// results — the manual context-editing pass in the loop (evictStaleToolResults)
+// must actually run each iteration, not just exist as a unit-tested function.
+func TestAgentLoop_EvictsStaleToolResultsAcrossIterations(t *testing.T) {
+	const iterations = keepRecentToolResults + 4
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	var mainCallCount int
+
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		requestBodies = append(requestBodies, body)
+		mu.Unlock()
+
+		var parsed ChatCompletionRequest
+		json.Unmarshal(body, &parsed) //nolint:errcheck
+
+		// Eviction summarization calls explicitly request the "base" model —
+		// serve them a plain text summary without consuming a slot in the
+		// main tool-calling iteration sequence below.
+		if parsed.Model == "base" {
+			respondAsStream(w, ChatCompletionResponse{
+				ID:      "summary",
+				Choices: []Choice{{Message: Message{Role: "assistant", Content: "summary"}, FinishReason: "stop"}},
+			})
+			return
+		}
+
+		mu.Lock()
+		mainCallCount++
+		call := mainCallCount
+		mu.Unlock()
+
+		if call > iterations {
+			respondAsStream(w, ChatCompletionResponse{
+				ID:      "final",
+				Choices: []Choice{{Message: Message{Role: "assistant", Content: "done"}, FinishReason: "stop"}},
+			})
+			return
+		}
+		respondAsStream(w, ChatCompletionResponse{
+			ID: fmt.Sprintf("iter-%d", call),
+			Choices: []Choice{{
+				Message: Message{
+					Role: "assistant",
+					ToolCalls: []ToolCall{{
+						ID:   fmt.Sprintf("tc_%d", call),
+						Type: "function",
+						Function: FunctionCall{
+							Name:      "query_loki_logs",
+							Arguments: "{}",
+						},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := NewLLMClient(log.DefaultLogger, &http.Client{Timeout: llmTimeout})
+	mcpProxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
+	loop := NewAgentLoop(llmClient, mcpProxy, log.DefaultLogger)
+
+	eventCh := make(chan SSEEvent, 256)
+	req := LoopRequest{
+		Messages:      []Message{{Role: "user", Content: "investigate"}},
+		SystemPrompt:  "sys",
+		MaxIterations: iterations + 2,
+		GrafanaURL:    llmServer.URL,
+		AuthToken:     "test-token",
+		UserRole:      "Admin",
+		OrgID:         "1",
+	}
+
+	go loop.Run(context.Background(), req, eventCh)
+	collectEvents(eventCh)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) < iterations+1 {
+		t.Fatalf("expected at least %d LLM requests, got %d", iterations+1, len(requestBodies))
+	}
+
+	// The final request (after the last tool call) should carry evicted
+	// placeholders for the oldest tool results, since more tool calls than
+	// keepRecentToolResults have accumulated in this run's history.
+	last := requestBodies[len(requestBodies)-1]
+	var lastReq ChatCompletionRequest
+	if err := json.Unmarshal(last, &lastReq); err != nil {
+		t.Fatalf("failed to unmarshal final LLM request: %v", err)
+	}
+
+	var evictedCount, fullCount int
+	for _, m := range lastReq.Messages {
+		if m.Role != "tool" {
+			continue
+		}
+		if strings.HasPrefix(m.Content, EvictedToolResultMarker) {
+			evictedCount++
+		} else {
+			fullCount++
+		}
+	}
+	if evictedCount == 0 {
+		t.Errorf("expected at least one evicted tool result in the final request, got none (fullCount=%d)", fullCount)
+	}
+	if fullCount > keepRecentToolResults {
+		t.Errorf("expected at most %d full tool results, got %d", keepRecentToolResults, fullCount)
+	}
+}


### PR DESCRIPTION
## Summary

A production Redis-dump + Tempo-trace audit of investigation-session cost found the agent loop resending near-max-context (~126K prompt tokens) on almost every LLM call, with iteration budgets up to 60 for alert-investigation runs and no prompt caching available on the OpenAI-compatible LLM transport (grafana-llm-app). Some single investigations were running up to 14M tokens. This PR implements the P0 mitigations from that audit — all cost reductions, no behavior/feature changes beyond the context-shrinking mechanics described below.

- **Evict stale tool results** (`pkg/agent/context_window.go`, wired into `pkg/agent/loop.go`): the most recent 8 tool results stay in full; older ones are replaced with a short LLM-generated summary (using the cheap "base" model) instead of being resent raw on every subsequent iteration. If the summarization call fails (including during an Anthropic quota-exhaustion incident found during the audit), it falls back to a plain truncated excerpt rather than erroring the run. Idempotent — re-running eviction on already-evicted messages doesn't re-summarize or duplicate markers. Summarization token usage is folded into `usageByModel["base"]` so cost reporting stays accurate.
- **Lower `DefaultMaxTotalTokens`** from 128,000 to 64,000 — this only changes the shipped default; it's already admin-overridable via `PluginSettings.MaxTotalTokens`, so nothing breaks for orgs that have tuned it.
- **Tighter truncation for high-volume tools**: raw query-result tools (Loki/Prometheus/Tempo/Pyroscope/dashboard, matched by name) get capped at 3,000/800 tokens (normal/aggressive) instead of the 8,000/2,000 used for other tools — these dominate context growth and are usually redundant once summarized once.

## Why

Without prompt caching, cost scales as iterations × context-size, and ~95%+ of each iteration's payload was a byte-for-byte repeat of the prior one (system prompt + full MCP tool schema + accumulated tool-call history). These changes shrink what's actually transmitted each iteration instead of relying on a cache discount that isn't available on this transport.

## Trade-off reviewers should know about

Evicting tool results (even summarized) removes information from the model's working context, unlike real prompt caching which is a pure cost optimization with no information loss. There's a real, non-zero risk that a long investigation needing to cross-reference far-back evidence in its final synthesis gets a vaguer answer or needs to re-call a tool it doesn't realize it needs. The summarization step (vs. a bare placeholder) is meant to reduce — not eliminate — that gap. Worth watching hallucination/quality metrics on long alert-investigation sessions after this ships.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/...`
- [x] `gofmt -l` clean on all changed files
- [x] `go test ./pkg/...` — full suite passes
- [x] New unit tests: eviction keeps-under-limit, evicts-oldest-keeps-newest, idempotency, summarizer-invoked-once-per-result, no-summarizer fallback, per-tool-type truncation limits, `isHighVolumeTool` matching
- [x] New loop-level integration test verifying real outgoing LLM request bodies across iterations show evicted placeholders for stale results (with a mock server that deterministically separates "base"-model summarization calls from main-loop calls)
- [ ] Not run: `npm run validate` / frontend build (no frontend or OpenAPI changes in this PR)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Long investigations may lose far-back raw tool evidence (only summaries/placeholders remain), which can weaken final synthesis or increase re-queries; default 64K window also caps context more aggressively unless overridden.
> 
> **Overview**
> **Cuts per-iteration LLM prompt size** for the agent loop when there is no prompt caching on the OpenAI-compatible transport—addressing runs that were re-billing near-max context every iteration.
> 
> **Default context ceiling** drops from **128K to 64K** tokens (`DefaultMaxTotalTokens`); admins can still override via `PluginSettings.MaxTotalTokens`.
> 
> **Before each iteration**, `evictStaleToolResults` keeps the **8 most recent** tool results in full and replaces older ones with short placeholders. Stale successes are summarized once via the cheap **`base`** model (`summarizeForEviction`); failures fall back to truncated text and **error/tool transport diagnostics are never LLM-paraphrased**. Eviction is idempotent and summary usage is counted in `usageByModel["base"]`.
> 
> **Token trimming** now applies **tighter caps** to high-volume observability tools (Loki/Prometheus/Tempo/Pyroscope/dashboard name patterns): **3K/800** tokens (normal/aggressive) vs **8K/2K** for other tools, using `toolNamesByCallID` to map results to tool names.
> 
> Unit and loop integration tests cover eviction, summarizer behavior, high-volume truncation, and outgoing request bodies across iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fca7fca4a9d67abb3c927daba31188ad3da0af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->