### PR TITLE
fix(backend): speed up alert-investigation runs (guardrails, async eviction, token accounting, metric-catalog caching)

### DIFF
--- a/pkg/agent/context_window.go
+++ b/pkg/agent/context_window.go
@@ -244,7 +244,16 @@ func trimToolResponses(messages []Message, maxTokens, maxTokensHighVolume int, t
 			limit = maxTokensHighVolume
 		}
 		if m.Role == "tool" && EstimateTokens(m.Content) > limit {
-			maxChars := limit * 4
+			// Use the same chars-per-token ratio EstimateTokens will apply when
+			// re-checking this content, so a single trim pass actually lands
+			// under limit instead of still estimating ~1.6x over it for
+			// structured content and falling through to more aggressive
+			// truncation than necessary.
+			charsPerToken := proseCharsPerToken
+			if looksStructured(m.Content) {
+				charsPerToken = structuredContentCharsPerToken
+			}
+			maxChars := int(float64(limit) * charsPerToken)
 			if maxChars > len(m.Content) {
 				maxChars = len(m.Content)
 			}

--- a/pkg/agent/context_window.go
+++ b/pkg/agent/context_window.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
+	"unicode"
 )
 
 // DefaultMaxTotalTokens was 128,000 until a production cost audit (Aug 2026)
@@ -61,8 +63,46 @@ func isHighVolumeTool(toolName string) bool {
 	return false
 }
 
+// structuredContentCharsPerToken and proseCharsPerToken bound EstimateTokens.
+// A flat chars/4 ratio is tuned for English prose; dense structured content
+// (JSON tool results, metric/label listings, dashboard payloads) packs more
+// tokens per character because delimiters, quotes, and short numeric or
+// identifier fields each cost close to a full token. A production trace
+// (2026-09-01) showed a single LLM call actually billed 291K prompt tokens
+// against an estimated-under-budget request, because the flat ratio let a
+// context dominated by tool-result JSON through without triggering the trim
+// pass early enough. Tool results are the dominant source of context growth
+// (see keepRecentToolResults), so undercounting them is what matters most.
+const proseCharsPerToken = 4.0
+const structuredContentCharsPerToken = 2.5
+
 func EstimateTokens(text string) int {
-	return (len(text) + 3) / 4
+	if text == "" {
+		return 0
+	}
+	charsPerToken := proseCharsPerToken
+	if looksStructured(text) {
+		charsPerToken = structuredContentCharsPerToken
+	}
+	return int(math.Ceil(float64(len(text)) / charsPerToken))
+}
+
+// looksStructured reports whether text reads as dense structured data (JSON,
+// metric/label output) rather than prose, using the fraction of letter
+// characters as a proxy: prose is mostly letters, while structured data is
+// dominated by punctuation, digits, and short quoted tokens.
+func looksStructured(text string) bool {
+	letters, total := 0, 0
+	for _, r := range text {
+		total++
+		if unicode.IsLetter(r) {
+			letters++
+		}
+	}
+	if total == 0 {
+		return false
+	}
+	return float64(letters)/float64(total) < 0.55
 }
 
 func estimateMessagesTokens(messages []Message, tools []OpenAITool) int {

--- a/pkg/agent/context_window.go
+++ b/pkg/agent/context_window.go
@@ -242,7 +242,10 @@ func toolNamesByCallID(messages []Message) map[string]string {
 // most once per tool result (evictStaleToolResults is idempotent), so an
 // LLM-backed implementation is a reasonable one-time cost against the much
 // larger savings of not resending the raw content every remaining iteration.
-type toolResultSummarizer func(toolName, content string) string
+// Receives the tool_call id so callers can resolve a summary that was already
+// kicked off in the background (see loop.go's pendingSummaries) instead of
+// blocking here.
+type toolResultSummarizer func(toolCallID, toolName, content string) string
 
 func evictStaleToolResults(messages []Message, keepRecent int, summarize toolResultSummarizer, isError func(toolCallID string) bool) []Message {
 	if keepRecent <= 0 {
@@ -282,7 +285,7 @@ func evictStaleToolResults(messages []Message, keepRecent int, summarize toolRes
 			// the exact wording (truncated only if unexpectedly long).
 			summary = truncateWhitespace(m.Content, evictionSummaryFallbackChars)
 		} else if summarize != nil {
-			summary = strings.TrimSpace(summarize(name, m.Content))
+			summary = strings.TrimSpace(summarize(m.ToolCallID, name, m.Content))
 		}
 		if summary == "" {
 			summary = "no summary available"

--- a/pkg/agent/context_window_test.go
+++ b/pkg/agent/context_window_test.go
@@ -295,7 +295,7 @@ func TestEvictStaleToolResults_UsesSummarizerOncePerResult(t *testing.T) {
 	}
 
 	var calls []string
-	summarize := func(toolName, content string) string {
+	summarize := func(toolCallID, toolName, content string) string {
 		calls = append(calls, content)
 		return "summary of: " + content
 	}
@@ -349,7 +349,7 @@ func TestEvictStaleToolResults_ErrorResultsSkipSummarizerVerbatim(t *testing.T) 
 		messages = append(messages, toolResultMessage(id, content))
 	}
 
-	summarize := func(toolName, content string) string {
+	summarize := func(toolCallID, toolName, content string) string {
 		return "PARAPHRASED (should never appear for error results)"
 	}
 	isError := func(toolCallID string) bool {

--- a/pkg/agent/context_window_test.go
+++ b/pkg/agent/context_window_test.go
@@ -404,6 +404,24 @@ func TestTrimToolResponses_HighVolumeToolGetsTighterLimit(t *testing.T) {
 	}
 }
 
+// TestTrimToolResponses_StructuredContentConvergesInOnePass guards against a
+// Bugbot-reported regression: trimToolResponses cut at limit*4 characters
+// regardless of content, but EstimateTokens re-checks structured content at
+// a tighter 2.5-chars-per-token ratio. A single trim pass on JSON content
+// used to still estimate ~1.6x over the target, forcing an unnecessary
+// escalation to more aggressive truncation.
+func TestTrimToolResponses_StructuredContentConvergesInOnePass(t *testing.T) {
+	toolNames := map[string]string{"1": "query_prometheus"}
+	jsonContent := strings.Repeat(`{"target_group":"tg-1","value":12345,"ts":"2026-09-01T00:00:00Z"},`, 5000)
+	messages := []Message{toolResultMessage("1", jsonContent)}
+
+	result := trimToolResponses(messages, 8000, 3000, toolNames)
+
+	if got := EstimateTokens(result[0].Content); got > 3000+10 {
+		t.Errorf("expected structured content trimmed in one pass to land near the 3000 token limit, got %d", got)
+	}
+}
+
 func TestIsHighVolumeTool(t *testing.T) {
 	cases := map[string]bool{
 		"query_prometheus":      true,

--- a/pkg/agent/context_window_test.go
+++ b/pkg/agent/context_window_test.go
@@ -431,3 +431,19 @@ func TestEstimateTokens(t *testing.T) {
 		t.Errorf("EstimateTokens('') = %d, expected 0", got)
 	}
 }
+
+// TestEstimateTokens_StructuredContentGetsTighterRatio guards against the
+// Sept 2026 production trace where a single LLM call actually billed 291K
+// prompt tokens while our own estimate thought it was under budget — the
+// flat chars/4 ratio undercounts JSON-heavy tool results. Structured content
+// must estimate to more tokens per byte than equivalent-length prose.
+func TestEstimateTokens_StructuredContentGetsTighterRatio(t *testing.T) {
+	prose := strings.Repeat("the quick brown fox jumps over lazy dogs ", 100)
+	jsonish := strings.Repeat(`{"target_group":"tg-1","value":12345,"ts":"2026-09-01T00:00:00Z"},`, 100)
+
+	proseTokensPerByte := float64(EstimateTokens(prose)) / float64(len(prose))
+	jsonTokensPerByte := float64(EstimateTokens(jsonish)) / float64(len(jsonish))
+	if jsonTokensPerByte <= proseTokensPerByte {
+		t.Fatalf("expected structured content to estimate more tokens per byte than prose: json=%.4f prose=%.4f", jsonTokensPerByte, proseTokensPerByte)
+	}
+}

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -299,9 +299,18 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 					Data: ContentEvent{Content: msg.Content},
 				})
 			}
+			// Snapshot into a fresh map under the lock: background eviction-summary
+			// goroutines for tool results still within keepRecentToolResults (never
+			// evicted before the run ended) may still be writing to usageByModel
+			// after this point. DoneEvent crosses into another goroutine over
+			// eventCh, so handing out the live map risks a concurrent read/write
+			// (and, for callers that marshal it to JSON, a fatal concurrent map
+			// access) — the copy is the only value anything ever reads again.
 			usageMu.Lock()
+			usageSnapshot := make(map[string]ModelUsage, len(usageByModel))
 			var promptTokens, completionTokens, totalTokens int64
-			for _, u := range usageByModel {
+			for model, u := range usageByModel {
+				usageSnapshot[model] = u
 				promptTokens += int64(u.PromptTokens)
 				completionTokens += int64(u.CompletionTokens)
 				totalTokens += int64(u.TotalTokens)
@@ -315,7 +324,7 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 					CompletionTokens: completionTokens,
 					TotalTokens:      totalTokens,
 					ToolCallCount:    toolCallCount,
-					UsageByModel:     usageByModel,
+					UsageByModel:     usageSnapshot,
 				},
 			})
 			return

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -143,7 +144,11 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 
 	// Run-level usage/tool-call totals, surfaced on the "done" event so the
 	// caller can persist per-session stats (tokens, turns, tool calls).
+	// usageMu guards it: eviction summaries now run in background goroutines
+	// (see pendingSummaries below) that write into it concurrently with the
+	// main loop's own writes after each LLM call.
 	usageByModel := make(map[string]ModelUsage)
+	var usageMu sync.Mutex
 	toolCallCount := 0
 
 	// toolResultIsError records which tool_call ids produced an error result,
@@ -153,13 +158,30 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	// paraphrased.
 	toolResultIsError := make(map[string]bool)
 
+	// pendingSummaries holds eviction summaries kicked off in the background
+	// as soon as each tool result is appended (see the tool-call loop below),
+	// keyed by tool_call id. A result typically doesn't go stale for several
+	// iterations (keepRecentToolResults=8 tool calls later), so by the time
+	// evictStaleToolResults actually needs the summary it has almost always
+	// already finished — turning what used to be a blocking "base" model call
+	// on the hot path into a wait that resolves instantly. Only ever read and
+	// deleted from the main loop goroutine, so it needs no lock of its own.
+	pendingSummaries := make(map[string]*toolResultSummaryFuture)
+
 	for iteration := 0; iteration < maxIter; iteration++ {
 		if ctx.Err() != nil {
 			return
 		}
 
-		messages = evictStaleToolResults(messages, keepRecentToolResults, func(toolName, content string) string {
-			return a.summarizeForEviction(ctx, req, usageByModel, toolName, content)
+		messages = evictStaleToolResults(messages, keepRecentToolResults, func(toolCallID, toolName, content string) string {
+			if future, ok := pendingSummaries[toolCallID]; ok {
+				delete(pendingSummaries, toolCallID)
+				return future.wait(ctx)
+			}
+			// No background future found (shouldn't normally happen since every
+			// non-error tool result starts one on append) — fall back to a
+			// synchronous summary so eviction still completes correctly.
+			return a.summarizeForEviction(ctx, req, usageByModel, &usageMu, toolName, content)
 		}, func(toolCallID string) bool {
 			return toolResultIsError[toolCallID]
 		})
@@ -206,12 +228,14 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 		}
 
 		if resp.Usage != nil {
+			usageMu.Lock()
 			usage := usageByModel[effectiveModel]
 			usage.Model = effectiveModel
 			usage.PromptTokens += resp.Usage.PromptTokens
 			usage.CompletionTokens += resp.Usage.CompletionTokens
 			usage.TotalTokens += resp.Usage.TotalTokens
 			usageByModel[effectiveModel] = usage
+			usageMu.Unlock()
 		}
 
 		msg := resp.Choices[0].Message
@@ -275,12 +299,14 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 					Data: ContentEvent{Content: msg.Content},
 				})
 			}
+			usageMu.Lock()
 			var promptTokens, completionTokens, totalTokens int64
 			for _, u := range usageByModel {
 				promptTokens += int64(u.PromptTokens)
 				completionTokens += int64(u.CompletionTokens)
 				totalTokens += int64(u.TotalTokens)
 			}
+			usageMu.Unlock()
 			a.send(ctx, eventCh, SSEEvent{
 				Type: "done",
 				Data: DoneEvent{
@@ -342,6 +368,18 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 			})
 			toolResultIsError[tc.ID] = isError
 
+			// Kick off this result's eviction summary now, in the background,
+			// instead of waiting until it's actually stale. Error results are
+			// never LLM-summarized (see evictStaleToolResults), so skip them.
+			if !isError {
+				future := newToolResultSummaryFuture()
+				pendingSummaries[tc.ID] = future
+				toolName, toolResultContent := tc.Function.Name, toolContent
+				go func() {
+					future.resolve(a.summarizeForEviction(ctx, req, usageByModel, &usageMu, toolName, toolResultContent))
+				}()
+			}
+
 			if !mcpUnavailableEmitted && len(transportFailedTools) >= 2 {
 				mcpUnavailableEmitted = true
 				a.send(ctx, eventCh, SSEEvent{
@@ -373,6 +411,34 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 	})
 }
 
+// toolResultSummaryFuture carries the result of a summarizeForEviction call
+// started in the background as soon as a tool result is appended to history.
+// wait blocks until the goroutine resolves it (or ctx is cancelled) — in
+// steady state this is a no-op because keepRecentToolResults gives the
+// summary several iterations' worth of head start before it's actually needed.
+type toolResultSummaryFuture struct {
+	done   chan struct{}
+	result string
+}
+
+func newToolResultSummaryFuture() *toolResultSummaryFuture {
+	return &toolResultSummaryFuture{done: make(chan struct{})}
+}
+
+func (f *toolResultSummaryFuture) resolve(result string) {
+	f.result = result
+	close(f.done)
+}
+
+func (f *toolResultSummaryFuture) wait(ctx context.Context) string {
+	select {
+	case <-f.done:
+		return f.result
+	case <-ctx.Done():
+		return ""
+	}
+}
+
 // summarizeForEviction condenses a stale tool result with a cheap ("base")
 // model call before evictStaleToolResults drops the raw content, so the model
 // keeps the gist of earlier evidence instead of nothing. Any failure (network
@@ -380,7 +446,10 @@ func (a *AgentLoop) Run(ctx context.Context, req LoopRequest, eventCh chan<- SSE
 // truncation of the original content rather than surfacing an error — this is
 // a cost optimization on top of an already-working eviction path, not a
 // critical request, so degrading quietly is preferable to failing the run.
-func (a *AgentLoop) summarizeForEviction(ctx context.Context, req LoopRequest, usageByModel map[string]ModelUsage, toolName, content string) string {
+// usageMu guards usageByModel: this now runs concurrently from a background
+// goroutine per tool result (see the Run loop) as well as, in the fallback
+// path, the main loop goroutine itself.
+func (a *AgentLoop) summarizeForEviction(ctx context.Context, req LoopRequest, usageByModel map[string]ModelUsage, usageMu *sync.Mutex, toolName, content string) string {
 	fallback := truncateWhitespace(content, evictionSummaryFallbackChars)
 
 	trimmed := strings.TrimSpace(content)
@@ -405,12 +474,14 @@ func (a *AgentLoop) summarizeForEviction(ctx context.Context, req LoopRequest, u
 	}
 
 	if resp.Usage != nil {
+		usageMu.Lock()
 		usage := usageByModel["base"]
 		usage.Model = "base"
 		usage.PromptTokens += resp.Usage.PromptTokens
 		usage.CompletionTokens += resp.Usage.CompletionTokens
 		usage.TotalTokens += resp.Usage.TotalTokens
 		usageByModel["base"] = usage
+		usageMu.Unlock()
 	}
 
 	if len(resp.Choices) == 0 {

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -23,6 +23,9 @@ type Proxy struct {
 	// perUserToken, when set, is passed to every Client so OAuth-enabled
 	// servers can inject a per-user bearer on outbound MCP requests.
 	perUserToken PerUserTokenProvider
+	// resultCache holds short-lived results for the slow, read-only tool
+	// calls named in cacheableToolTTL — see result_cache.go.
+	resultCache *resultCache
 }
 
 // SetPerUserTokenProvider registers the provider for per-user OAuth tokens
@@ -39,9 +42,10 @@ func (p *Proxy) SetPerUserTokenProvider(provider PerUserTokenProvider) {
 // NewProxy creates a new MCP proxy
 func NewProxy(ctx context.Context, logger log.Logger) *Proxy {
 	p := &Proxy{
-		clients: make(map[string]*Client),
-		logger:  logger,
-		ctx:     ctx,
+		clients:     make(map[string]*Client),
+		logger:      logger,
+		ctx:         ctx,
+		resultCache: newResultCache(),
 	}
 	p.healthMonitor = NewHealthMonitor(p, logger)
 	return p
@@ -199,7 +203,23 @@ func (p *Proxy) CallToolWithContext(ctx context.Context, toolName string, argume
 
 	p.logger.Debug("Calling tool on MCP server", "tool", toolName, "server", serverID, "orgID", orgID, "orgName", orgName, "scopeOrgId", scopeOrgId)
 
-	return client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
+	ttl, cacheable := cacheableTTL(toolName)
+	if !cacheable {
+		return client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
+	}
+
+	userID, _ := UserIDFromContext(ctx)
+	key := cacheKey(toolName, orgID, scopeOrgId, userID, arguments)
+	if cached, hit := p.resultCache.get(key); hit {
+		p.logger.Debug("Serving cached MCP tool result", "tool", toolName, "server", serverID)
+		return cached, nil
+	}
+
+	result, err := client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgId)
+	if err == nil && result != nil && !result.IsError {
+		p.resultCache.set(key, result, ttl)
+	}
+	return result, err
 }
 
 // HandleMCPRequest handles an MCP JSON-RPC request

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -174,6 +174,34 @@ func (p *Proxy) CallTool(toolName string, arguments map[string]interface{}) (*Ca
 	return p.CallToolWithContext(context.Background(), toolName, arguments, "", "", "")
 }
 
+// NewStandaloneClient returns a fresh Client for the named server, entirely
+// independent of the shared pool's session state. Client.CallToolWithContext
+// with a non-empty org context ALWAYS tears down and replaces the shared
+// session (connectMCPWithOrgContext) on every call, by design, so a
+// long-running or backgrounded caller sharing the pooled Client with a live
+// request risks closing the session out from under that request's in-flight
+// tool call. Use a standalone client for exactly that case — background
+// prefetch/cache-warming that must not race with concurrent foreground
+// traffic on the same server. Callers must Close() the returned client.
+func (p *Proxy) NewStandaloneClient(id string) (*Client, bool) {
+	p.mu.RLock()
+	existing, ok := p.clients[id]
+	p.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	sdkHTTPClient, err := p.sdkClient()
+	if err != nil {
+		return nil, false
+	}
+	c := NewClient(p.ctx, existing.config, p.logger, sdkHTTPClient)
+	if p.perUserToken != nil {
+		c.SetPerUserTokenProvider(p.perUserToken)
+	}
+	return c, true
+}
+
 // CallToolWithContext routes a tool call to the appropriate MCP server with additional context (e.g., Org ID, Org Name, Scope Org ID).
 // ctx carries the Grafana user ID (via mcp.WithUserID) for servers using per-user OAuth.
 func (p *Proxy) CallToolWithContext(ctx context.Context, toolName string, arguments map[string]interface{}, orgID string, orgName string, scopeOrgId string) (*CallToolResult, error) {

--- a/pkg/mcp/proxy_test.go
+++ b/pkg/mcp/proxy_test.go
@@ -128,3 +128,57 @@ func TestEnsureServerNoopWhenConfigMatchesExisting(t *testing.T) {
 		t.Fatal("expected existing client to be kept when config is unchanged")
 	}
 }
+
+// TestNewStandaloneClient_IsIsolatedFromPooledClient guards against a
+// regression where a background caller (e.g. the metric-namespace snapshot
+// prefetch) routes through the shared pooled Client and races with a live
+// request's CallToolWithContext: connectMCPWithOrgContext unconditionally
+// tears down and replaces the current session on every org-context call, so
+// two concurrent callers sharing one Client can close the session out from
+// under each other's in-flight tool call. NewStandaloneClient must return a
+// distinct Client with its own session state, never the pooled instance.
+func TestNewStandaloneClient_IsIsolatedFromPooledClient(t *testing.T) {
+	proxy := NewProxy(context.Background(), log.DefaultLogger)
+	serverID := "mcp-grafana"
+
+	if err := proxy.EnsureServer(ServerConfig{
+		ID:      serverID,
+		URL:     "http://example.invalid",
+		Type:    "streamable-http",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("failed to configure proxy: %v", err)
+	}
+
+	proxy.mu.RLock()
+	pooled := proxy.clients[serverID]
+	proxy.mu.RUnlock()
+
+	standalone, ok := proxy.NewStandaloneClient(serverID)
+	if !ok {
+		t.Fatal("expected NewStandaloneClient to find the registered server")
+	}
+	defer standalone.Close()
+
+	if standalone == pooled {
+		t.Fatal("expected NewStandaloneClient to return a distinct Client, got the pooled instance")
+	}
+	if standalone.config.URL != pooled.config.URL || standalone.config.Type != pooled.config.Type {
+		t.Fatalf("expected standalone client config to match the pooled server's config: standalone=%+v pooled=%+v", standalone.config, pooled.config)
+	}
+
+	// Two independent standalone clients for the same server must also not
+	// share state with each other.
+	standalone2, ok := proxy.NewStandaloneClient(serverID)
+	if !ok {
+		t.Fatal("expected a second NewStandaloneClient call to succeed")
+	}
+	defer standalone2.Close()
+	if standalone2 == standalone {
+		t.Fatal("expected each NewStandaloneClient call to return a fresh Client")
+	}
+
+	if _, ok := proxy.NewStandaloneClient("unknown-server"); ok {
+		t.Fatal("expected NewStandaloneClient to fail for an unregistered server")
+	}
+}

--- a/pkg/mcp/result_cache.go
+++ b/pkg/mcp/result_cache.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cacheableToolTTL maps a tool-name suffix (the part after the serverid_
+// prefix — server IDs vary, the underlying tool name doesn't) to how long a
+// successful result may be reused. Only read-only, deterministic-for-a-given-
+// input calls belong here.
+//
+// list_prometheus_metric_names was measured taking 20-30s per call in
+// production traces — a regex scan of a datasource's full metric catalog —
+// and accounted for the majority of all tool-call time in two separate
+// alert-investigation sessions (2026-09-01), because the agent frequently
+// re-issues it with the same or overlapping regex as it narrows its search.
+// Caching turns repeat scans within one investigation into a no-op.
+var cacheableToolTTL = map[string]time.Duration{
+	"list_prometheus_metric_names": 60 * time.Second,
+}
+
+// cacheableTTL returns the TTL for toolName if it's cacheable.
+func cacheableTTL(toolName string) (time.Duration, bool) {
+	for suffix, ttl := range cacheableToolTTL {
+		if strings.HasSuffix(toolName, suffix) {
+			return ttl, true
+		}
+	}
+	return 0, false
+}
+
+type resultCacheEntry struct {
+	result    *CallToolResult
+	expiresAt time.Time
+}
+
+// resultCache holds short-lived results for the tool calls named in
+// cacheableToolTTL, keyed by tool name, org, user, and arguments so entries
+// never cross an org or user boundary — see cacheKey.
+type resultCache struct {
+	mu      sync.Mutex
+	entries map[string]resultCacheEntry
+}
+
+func newResultCache() *resultCache {
+	return &resultCache{entries: make(map[string]resultCacheEntry)}
+}
+
+// cacheKey scopes cached results to (tool, org, scope org, user, arguments).
+// User is included even though this data is typically org-wide, not
+// per-user-ACL'd, as defense in depth for OAuth-enabled servers where a
+// user's token could scope results differently — the primary payoff (a
+// single investigation re-scanning the same datasource) is unaffected since
+// one investigation always runs as one user. json.Marshal on
+// map[string]interface{} sorts keys, so this is stable across calls with the
+// same argument set.
+func cacheKey(toolName, orgID, scopeOrgID string, userID int64, arguments map[string]interface{}) string {
+	argsJSON, _ := json.Marshal(arguments)
+	return strings.Join([]string{toolName, orgID, scopeOrgID, strconv.FormatInt(userID, 10), string(argsJSON)}, "|")
+}
+
+func (c *resultCache) get(key string) (*CallToolResult, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.result, true
+}
+
+func (c *resultCache) set(key string, result *CallToolResult, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	// Opportunistic cleanup instead of a background goroutine/ticker: bounds
+	// map growth without needing lifecycle coordination with Proxy.Close().
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	c.entries[key] = resultCacheEntry{result: result, expiresAt: now.Add(ttl)}
+}

--- a/pkg/mcp/result_cache_test.go
+++ b/pkg/mcp/result_cache_test.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheableTTL(t *testing.T) {
+	if ttl, ok := cacheableTTL("grafana_list_prometheus_metric_names"); !ok || ttl <= 0 {
+		t.Fatalf("expected grafana_list_prometheus_metric_names to be cacheable with a positive TTL, got ttl=%v ok=%v", ttl, ok)
+	}
+	if _, ok := cacheableTTL("otherserver_list_prometheus_metric_names"); !ok {
+		t.Fatal("expected cacheableTTL to match on tool-name suffix regardless of server id prefix")
+	}
+	if _, ok := cacheableTTL("grafana_query_prometheus"); ok {
+		t.Fatal("expected grafana_query_prometheus not to be cacheable")
+	}
+}
+
+func TestResultCache_GetSetRoundTrip(t *testing.T) {
+	c := newResultCache()
+	key := cacheKey("grafana_list_prometheus_metric_names", "24", "", 1, map[string]interface{}{"regex": ".*"})
+
+	if _, hit := c.get(key); hit {
+		t.Fatal("expected cache miss before any set")
+	}
+
+	want := &CallToolResult{Content: []ContentBlock{{Type: "text", Text: "metric_a\nmetric_b"}}}
+	c.set(key, want, time.Minute)
+
+	got, hit := c.get(key)
+	if !hit {
+		t.Fatal("expected cache hit after set")
+	}
+	if got != want {
+		t.Fatalf("expected cached result to be the same pointer set, got a different value: %+v", got)
+	}
+}
+
+func TestResultCache_ExpiresAfterTTL(t *testing.T) {
+	c := newResultCache()
+	key := cacheKey("grafana_list_prometheus_metric_names", "24", "", 1, map[string]interface{}{"regex": ".*"})
+
+	c.set(key, &CallToolResult{Content: []ContentBlock{{Type: "text", Text: "x"}}}, 1*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+
+	if _, hit := c.get(key); hit {
+		t.Fatal("expected cache entry to have expired")
+	}
+}
+
+func TestCacheKey_ScopesAcrossOrgUserAndArguments(t *testing.T) {
+	base := cacheKey("grafana_list_prometheus_metric_names", "24", "", 1, map[string]interface{}{"regex": ".*"})
+
+	cases := map[string]string{
+		"different org":       cacheKey("grafana_list_prometheus_metric_names", "38", "", 1, map[string]interface{}{"regex": ".*"}),
+		"different user":      cacheKey("grafana_list_prometheus_metric_names", "24", "", 2, map[string]interface{}{"regex": ".*"}),
+		"different arguments": cacheKey("grafana_list_prometheus_metric_names", "24", "", 1, map[string]interface{}{"regex": "aws_.*"}),
+		"different scope org": cacheKey("grafana_list_prometheus_metric_names", "24", "38", 1, map[string]interface{}{"regex": ".*"}),
+	}
+	for name, key := range cases {
+		if key == base {
+			t.Errorf("expected %s to produce a distinct cache key, but it matched the base key", name)
+		}
+	}
+
+	// Identical inputs, including map key insertion order, must produce the
+	// same key (json.Marshal on map[string]interface{} sorts keys).
+	same := cacheKey("grafana_list_prometheus_metric_names", "24", "", 1, map[string]interface{}{"regex": ".*"})
+	if same != base {
+		t.Fatalf("expected identical inputs to produce the same cache key: %q != %q", same, base)
+	}
+}

--- a/pkg/plugin/datasource_snapshot.go
+++ b/pkg/plugin/datasource_snapshot.go
@@ -171,24 +171,26 @@ func datasourceCacheTTL(snapshot string) time.Duration {
 	return dsCacheTTL
 }
 
-// renderDatasourceSnapshot parses list_datasources output into a stable bullet
-// list. The tool returns JSON but the exact shape varies across Grafana
-// versions — be defensive and fall open on parse failure rather than let the
-// LLM see a corrupted-looking block.
-func renderDatasourceSnapshot(raw string) string {
+// datasourceRow is one entry from list_datasources, normalized so callers
+// don't each re-implement the "which JSON shape did this Grafana version
+// return" defensiveness in parseDatasourceRows.
+type datasourceRow struct{ dsType, name, uid string }
+
+// parseDatasourceRows parses list_datasources output into normalized rows.
+// The tool returns JSON but the exact shape varies across Grafana versions —
+// accept either a top-level array or an object with a "datasources" key, and
+// return nil (not an error) on anything else so callers can fall open.
+func parseDatasourceRows(raw string) []datasourceRow {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return dsSnapshotFailOpen
+		return nil
 	}
 
 	var parsed interface{}
 	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		// Some MCP servers wrap arrays as {"datasources": [...]} or similar;
-		// if we can't parse, fall open.
-		return dsSnapshotFailOpen
+		return nil
 	}
 
-	// Accept either a top-level array or an object with "datasources".
 	var entries []map[string]interface{}
 	switch v := parsed.(type) {
 	case []interface{}:
@@ -207,12 +209,7 @@ func renderDatasourceSnapshot(raw string) string {
 		}
 	}
 
-	if len(entries) == 0 {
-		return dsSnapshotFailOpen
-	}
-
-	type row struct{ dsType, name, uid string }
-	var rows []row
+	var rows []datasourceRow
 	for _, e := range entries {
 		uid, _ := e["uid"].(string)
 		name, _ := e["name"].(string)
@@ -226,8 +223,16 @@ func renderDatasourceSnapshot(raw string) string {
 		if name == "" {
 			name = dsType
 		}
-		rows = append(rows, row{dsType: dsType, name: name, uid: uid})
+		rows = append(rows, datasourceRow{dsType: dsType, name: name, uid: uid})
 	}
+	return rows
+}
+
+// renderDatasourceSnapshot parses list_datasources output into a stable
+// bullet list, falling open on parse failure or an empty result rather than
+// let the LLM see a corrupted-looking block.
+func renderDatasourceSnapshot(raw string) string {
+	rows := parseDatasourceRows(raw)
 	if len(rows) == 0 {
 		return dsSnapshotFailOpen
 	}

--- a/pkg/plugin/iteration_budget.go
+++ b/pkg/plugin/iteration_budget.go
@@ -6,12 +6,25 @@ import "regexp"
 // in production (Alertmanager-triggered first turns). Case-insensitive.
 var firingPattern = regexp.MustCompile(`(?i)(\[FIRING[:\s]|alert investigation:|perform root cause analysis)`)
 
+// isAlertInvestigation reports whether a request should be treated as an
+// alert investigation — either explicitly (reqType == "investigation", set by
+// the alert-notification deep link) or because the raw message looks like a
+// firing-alert notification pasted directly into chat. Shared by
+// resolveMaxIterations (iteration budget) and BuildSystemPrompt (efficiency
+// guardrails) so a request that qualifies for the bigger iteration budget
+// always also gets the guardrails that keep it fast — a Sept 2026 production
+// incident found a chat-typed alert getting the former without the latter,
+// producing a 21-minute, 5M-token investigation.
+func isAlertInvestigation(reqType, message string) bool {
+	return reqType == "investigation" || firingPattern.MatchString(message)
+}
+
 // resolveMaxIterations picks the iteration budget for an agent run. Investigation
 // requests and alert-investigation patterns in the first user message get a
 // higher budget so the loop can finish a full multi-signal RCA without
 // tripping the limit (which in past sessions encouraged fabricated summaries).
 func resolveMaxIterations(reqType, message string) int {
-	if reqType == "investigation" || firingPattern.MatchString(message) {
+	if isAlertInvestigation(reqType, message) {
 		return AlertInvestigationMaxIter
 	}
 	return AgentMaxIterations

--- a/pkg/plugin/metric_namespace_snapshot.go
+++ b/pkg/plugin/metric_namespace_snapshot.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"consensys-asko11y-app/pkg/mcp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -94,7 +95,7 @@ func (p *Plugin) refreshMetricNamespaceSnapshot(cacheKey, orgID, orgName, scopeO
 		return
 	}
 
-	dsResult, err := p.mcpProxy.CallToolWithContext(ctx, dsToolName, map[string]interface{}{}, orgID, orgName, scopeOrgID)
+	dsResult, err := p.callToolStandalone(ctx, dsToolName, map[string]interface{}{}, orgID, orgName, scopeOrgID)
 	if err != nil || dsResult == nil || dsResult.IsError || len(dsResult.Content) == 0 {
 		p.logger.Warn("metricNamespaceSnapshot: list_datasources failed", "orgID", orgID)
 		return
@@ -130,7 +131,7 @@ func (p *Plugin) fetchMetricNames(ctx context.Context, toolName, datasourceUID, 
 	callCtx, cancel := context.WithTimeout(ctx, msFetchTimeout)
 	defer cancel()
 
-	result, err := p.mcpProxy.CallToolWithContext(callCtx, toolName, map[string]interface{}{
+	result, err := p.callToolStandalone(callCtx, toolName, map[string]interface{}{
 		"datasourceUid": datasourceUID,
 		"regex":         ".*",
 		"limit":         msFetchLimit,
@@ -145,6 +146,28 @@ func (p *Plugin) fetchMetricNames(ctx context.Context, toolName, datasourceUID, 
 		return nil
 	}
 	return names
+}
+
+// callToolStandalone calls toolName via a fresh, standalone Client for its
+// server (see mcp.Proxy.NewStandaloneClient) instead of the shared pool.
+// The background metric-namespace refresh runs concurrently with whatever
+// live agent-loop tool calls the request that triggered it is making on the
+// same server; routing through the shared pool would let either side's
+// connectMCPWithOrgContext (which tears down and replaces the session on
+// every org-context call, by design) close the session out from under the
+// other's in-flight call.
+func (p *Plugin) callToolStandalone(ctx context.Context, toolName string, arguments map[string]interface{}, orgID, orgName, scopeOrgID string) (*mcp.CallToolResult, error) {
+	serverID, _, ok := strings.Cut(toolName, "_")
+	if !ok {
+		return nil, fmt.Errorf("invalid tool name %q: expected serverid_toolname", toolName)
+	}
+	client, ok := p.mcpProxy.NewStandaloneClient(serverID)
+	if !ok {
+		return nil, fmt.Errorf("no MCP client registered for server %q", serverID)
+	}
+	defer client.Close()
+
+	return client.CallToolWithContext(ctx, toolName, arguments, orgID, orgName, scopeOrgID)
 }
 
 // deriveNamespaces buckets metric names by their first one or two

--- a/pkg/plugin/metric_namespace_snapshot.go
+++ b/pkg/plugin/metric_namespace_snapshot.go
@@ -1,0 +1,251 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// msCacheTTL bounds staleness of the per-org metric-namespace snapshot.
+	// Metric catalogs change far less often than the fetch is expensive, so
+	// this is much longer than dsCacheTTL.
+	msCacheTTL = 15 * time.Minute
+
+	// msFetchTimeout bounds a single list_prometheus_metric_names call in the
+	// background refresh. Production traces (2026-09-01) showed this tool
+	// taking 20-30s on a broad regex; give it real room since this runs off
+	// the request path, not the 2s fail-open budget datasourceSnapshot uses.
+	msFetchTimeout = 45 * time.Second
+
+	// msFetchLimit is the page size requested per datasource. Large enough to
+	// cover real-world catalogs in one page (a sampled production datasource
+	// had 4,622 metric names) without needing pagination for a best-effort
+	// namespace hint.
+	msFetchLimit = 5000
+
+	// msMaxNamespacesPerDatasource caps how many namespace bullets are
+	// rendered per datasource, keeping the whole snapshot at a few KB instead
+	// of the ~35-50K tokens a full per-metric listing would cost (measured
+	// against a real datasource — see the PR this shipped in).
+	msMaxNamespacesPerDatasource = 40
+)
+
+// metricNamespaceSnapshot returns a compact list of metric-name namespaces
+// (prefixes, not full names) per Prometheus-type datasource, to inject into
+// the system prompt for alert investigations so the agent can build a
+// targeted regex on its first list_prometheus_metric_names call instead of
+// guessing blind across several datasources and regex attempts — the pattern
+// that dominated tool-call time in production traces.
+//
+// Unlike datasourceSnapshot, this never blocks the request: the underlying
+// fetch (one list_prometheus_metric_names call per Prometheus datasource) can
+// take 20-30s each, far past any budget worth making a user wait on. A cache
+// hit returns immediately; a miss returns "" for this request and kicks off
+// a background refresh (deduplicated via msInFlight) so the next request
+// within msCacheTTL gets the real snapshot.
+func (p *Plugin) metricNamespaceSnapshot(orgID, orgName, scopeOrgID string) string {
+	cacheKey := orgID
+	if cacheKey == "" {
+		cacheKey = orgName
+	}
+	if cacheKey == "" {
+		cacheKey = "__default__"
+	}
+
+	if snap, ok := p.lookupMetricNamespaceCache(cacheKey); ok {
+		return snap
+	}
+
+	p.msCacheMu.Lock()
+	if p.msInFlight == nil {
+		p.msInFlight = make(map[string]bool)
+	}
+	alreadyRefreshing := p.msInFlight[cacheKey]
+	if !alreadyRefreshing {
+		p.msInFlight[cacheKey] = true
+	}
+	p.msCacheMu.Unlock()
+
+	if !alreadyRefreshing {
+		go p.refreshMetricNamespaceSnapshot(cacheKey, orgID, orgName, scopeOrgID)
+	}
+	return ""
+}
+
+func (p *Plugin) refreshMetricNamespaceSnapshot(cacheKey, orgID, orgName, scopeOrgID string) {
+	defer func() {
+		p.msCacheMu.Lock()
+		delete(p.msInFlight, cacheKey)
+		p.msCacheMu.Unlock()
+	}()
+
+	ctx := context.Background()
+
+	toolName, ok := p.findMetricNamesListTool()
+	if !ok {
+		return
+	}
+	dsToolName, ok := p.findDatasourceListTool()
+	if !ok {
+		return
+	}
+
+	dsResult, err := p.mcpProxy.CallToolWithContext(ctx, dsToolName, map[string]interface{}{}, orgID, orgName, scopeOrgID)
+	if err != nil || dsResult == nil || dsResult.IsError || len(dsResult.Content) == 0 {
+		p.logger.Warn("metricNamespaceSnapshot: list_datasources failed", "orgID", orgID)
+		return
+	}
+
+	rows := parseDatasourceRows(dsResult.Content[0].Text)
+	var promRows []datasourceRow
+	for _, r := range rows {
+		if r.dsType == "prometheus" {
+			promRows = append(promRows, r)
+		}
+	}
+	if len(promRows) == 0 {
+		return
+	}
+
+	sections := make(map[string][]string, len(promRows))
+	for _, r := range promRows {
+		names := p.fetchMetricNames(ctx, toolName, r.uid, orgID, orgName, scopeOrgID)
+		if len(names) > 0 {
+			sections[r.uid] = names
+		}
+	}
+	if len(sections) == 0 {
+		return
+	}
+
+	snapshot := renderMetricNamespaceSnapshot(promRows, sections)
+	p.storeMetricNamespaceCache(cacheKey, snapshot)
+}
+
+func (p *Plugin) fetchMetricNames(ctx context.Context, toolName, datasourceUID, orgID, orgName, scopeOrgID string) []string {
+	callCtx, cancel := context.WithTimeout(ctx, msFetchTimeout)
+	defer cancel()
+
+	result, err := p.mcpProxy.CallToolWithContext(callCtx, toolName, map[string]interface{}{
+		"datasourceUid": datasourceUID,
+		"regex":         ".*",
+		"limit":         msFetchLimit,
+	}, orgID, orgName, scopeOrgID)
+	if err != nil || result == nil || result.IsError || len(result.Content) == 0 {
+		p.logger.Warn("metricNamespaceSnapshot: list_prometheus_metric_names failed", "datasourceUid", datasourceUID, "error", err)
+		return nil
+	}
+
+	var names []string
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &names); err != nil {
+		return nil
+	}
+	return names
+}
+
+// deriveNamespaces buckets metric names by their first one or two
+// underscore-delimited segments (e.g. "aws_applicationelb_request_count_sum"
+// -> "aws_applicationelb"), counting how many metrics share each bucket.
+func deriveNamespaces(names []string) map[string]int {
+	counts := make(map[string]int)
+	for _, name := range names {
+		segments := strings.Split(name, "_")
+		n := 2
+		if len(segments) < 2 {
+			n = len(segments)
+		}
+		prefix := strings.Join(segments[:n], "_")
+		if prefix == "" {
+			continue
+		}
+		counts[prefix]++
+	}
+	return counts
+}
+
+// renderMetricNamespaceSnapshot renders one section per datasource: a header
+// naming the datasource and its total metric count, then up to
+// msMaxNamespacesPerDatasource namespace bullets sorted alphabetically.
+func renderMetricNamespaceSnapshot(rows []datasourceRow, namesByUID map[string][]string) string {
+	nameByUID := make(map[string]string, len(rows))
+	for _, r := range rows {
+		nameByUID[r.uid] = r.name
+	}
+
+	uids := make([]string, 0, len(namesByUID))
+	for uid := range namesByUID {
+		uids = append(uids, uid)
+	}
+	sort.Strings(uids)
+
+	var b strings.Builder
+	for _, uid := range uids {
+		names := namesByUID[uid]
+		counts := deriveNamespaces(names)
+
+		prefixes := make([]string, 0, len(counts))
+		for prefix := range counts {
+			prefixes = append(prefixes, prefix)
+		}
+		sort.Strings(prefixes)
+		if len(prefixes) > msMaxNamespacesPerDatasource {
+			prefixes = prefixes[:msMaxNamespacesPerDatasource]
+		}
+
+		fmt.Fprintf(&b, "Datasource %s (uid=%s), %d total metrics:\n", nameByUID[uid], uid, len(names))
+		for _, prefix := range prefixes {
+			fmt.Fprintf(&b, "- %s_* (%d)\n", prefix, counts[prefix])
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// findMetricNamesListTool searches all registered MCP servers for a tool
+// whose base name (the part after the server-id prefix) is
+// "list_prometheus_metric_names" — mirrors findDatasourceListTool.
+func (p *Plugin) findMetricNamesListTool() (string, bool) {
+	tools, err := p.mcpProxy.ListTools()
+	if err != nil {
+		return "", false
+	}
+	for _, t := range tools {
+		parts := strings.SplitN(t.Name, "_", 2)
+		if len(parts) == 2 && parts[1] == "list_prometheus_metric_names" {
+			return t.Name, true
+		}
+	}
+	return "", false
+}
+
+func (p *Plugin) lookupMetricNamespaceCache(key string) (string, bool) {
+	p.msCacheMu.Lock()
+	defer p.msCacheMu.Unlock()
+	if p.msCache == nil {
+		return "", false
+	}
+	entry, ok := p.msCache[key]
+	if !ok {
+		return "", false
+	}
+	ttl := entry.ttl
+	if ttl <= 0 {
+		ttl = msCacheTTL
+	}
+	if time.Since(entry.fetchedAt) > ttl {
+		return "", false
+	}
+	return entry.snapshot, true
+}
+
+func (p *Plugin) storeMetricNamespaceCache(key, snapshot string) {
+	p.msCacheMu.Lock()
+	defer p.msCacheMu.Unlock()
+	if p.msCache == nil {
+		p.msCache = make(map[string]dsCacheEntry)
+	}
+	p.msCache[key] = dsCacheEntry{snapshot: snapshot, fetchedAt: time.Now(), ttl: msCacheTTL}
+}

--- a/pkg/plugin/metric_namespace_snapshot_test.go
+++ b/pkg/plugin/metric_namespace_snapshot_test.go
@@ -1,0 +1,218 @@
+package plugin
+
+import (
+	"consensys-asko11y-app/pkg/mcp"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+func TestDeriveNamespaces(t *testing.T) {
+	names := []string{
+		"aws_applicationelb_request_count_sum",
+		"aws_applicationelb_healthy_host_count_average",
+		"kube_pod_status_phase",
+		"up",
+	}
+	counts := deriveNamespaces(names)
+
+	if counts["aws_applicationelb"] != 2 {
+		t.Errorf("expected 2 aws_applicationelb metrics, got %d", counts["aws_applicationelb"])
+	}
+	if counts["kube_pod"] != 1 {
+		t.Errorf("expected 1 kube_pod metric, got %d", counts["kube_pod"])
+	}
+	if counts["up"] != 1 {
+		t.Errorf("expected single-segment metric name to be its own bucket, got %d", counts["up"])
+	}
+}
+
+func TestRenderMetricNamespaceSnapshot_CapsAndSorts(t *testing.T) {
+	rows := []datasourceRow{{dsType: "prometheus", name: "mimir", uid: "ds1"}}
+	var names []string
+	for i := 0; i < msMaxNamespacesPerDatasource+20; i++ {
+		names = append(names, "zprefix"+itoa(i)+"_metric")
+	}
+	namesByUID := map[string][]string{"ds1": names}
+
+	got := renderMetricNamespaceSnapshot(rows, namesByUID)
+
+	lines := strings.Split(got, "\n")
+	// One header line + capped namespace bullets.
+	bulletLines := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- ") {
+			bulletLines++
+		}
+	}
+	if bulletLines > msMaxNamespacesPerDatasource {
+		t.Fatalf("expected at most %d namespace bullets, got %d", msMaxNamespacesPerDatasource, bulletLines)
+	}
+	if !strings.Contains(got, "uid=ds1") {
+		t.Fatalf("expected datasource uid in header, got:\n%s", got)
+	}
+}
+
+func TestMetricNamespaceSnapshot_CacheHitSkipsFetch(t *testing.T) {
+	p := &Plugin{
+		logger:  log.DefaultLogger,
+		msCache: map[string]dsCacheEntry{"1": {snapshot: "cached-snapshot", fetchedAt: time.Now(), ttl: msCacheTTL}},
+	}
+
+	got := p.metricNamespaceSnapshot("1", "Org1", "")
+	if got != "cached-snapshot" {
+		t.Fatalf("expected cached snapshot to be returned directly, got %q", got)
+	}
+}
+
+// newMetricNamespaceSnapshotServer fakes an MCP server exposing both
+// list_datasources (one Prometheus datasource) and
+// list_prometheus_metric_names (a fixed metric list), counting calls to the
+// metric-names tool so tests can assert the background refresh ran once.
+func newMetricNamespaceSnapshotServer(t *testing.T, metricNamesCallCount *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mcp/list-tools":
+			_ = json.NewEncoder(w).Encode(struct {
+				Tools []mcp.Tool `json:"tools"`
+			}{Tools: []mcp.Tool{
+				{Name: "list_datasources", InputSchema: map[string]interface{}{}},
+				{Name: "list_prometheus_metric_names", InputSchema: map[string]interface{}{}},
+			}})
+		case "/mcp/call-tool":
+			var req mcp.MCPRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("failed to decode request: %v", err)
+				return
+			}
+			var params mcp.CallToolParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				t.Errorf("failed to decode call params: %v", err)
+				return
+			}
+			switch params.Name {
+			case "list_datasources":
+				_ = json.NewEncoder(w).Encode(mcp.CallToolResult{
+					Content: []mcp.ContentBlock{{
+						Type: "text",
+						Text: `[{"uid":"ds1","name":"mimir","type":"prometheus"},{"uid":"ds2","name":"loki","type":"loki"}]`,
+					}},
+				})
+			case "list_prometheus_metric_names":
+				metricNamesCallCount.Add(1)
+				_ = json.NewEncoder(w).Encode(mcp.CallToolResult{
+					Content: []mcp.ContentBlock{{
+						Type: "text",
+						Text: `["aws_applicationelb_request_count_sum","aws_applicationelb_healthy_host_count_average","kube_pod_status_phase"]`,
+					}},
+				})
+			default:
+				t.Errorf("unexpected tool call: %s", params.Name)
+			}
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+}
+
+func TestMetricNamespaceSnapshot_MissReturnsEmptyThenBackgroundFillsCache(t *testing.T) {
+	var metricNamesCalls atomic.Int32
+	server := newMetricNamespaceSnapshotServer(t, &metricNamesCalls)
+	defer server.Close()
+
+	proxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
+	if err := proxy.EnsureServer(mcp.ServerConfig{
+		ID: "mcp-grafana", Name: "Grafana", URL: server.URL, Type: "standard", Enabled: true,
+	}); err != nil {
+		t.Fatalf("failed to configure proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	p := &Plugin{
+		logger:   log.DefaultLogger,
+		mcpProxy: proxy,
+	}
+
+	// First call: cache miss. Must return "" immediately (never block on the
+	// slow underlying fetch) and only queue a background refresh.
+	got := p.metricNamespaceSnapshot("1", "Org1", "")
+	if got != "" {
+		t.Fatalf("expected empty snapshot on cache miss, got %q", got)
+	}
+
+	// The background refresh should populate the cache shortly after.
+	deadline := time.Now().Add(2 * time.Second)
+	var snapshot string
+	for time.Now().Before(deadline) {
+		if s, ok := p.lookupMetricNamespaceCache("1"); ok {
+			snapshot = s
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !strings.Contains(snapshot, "aws_applicationelb") {
+		t.Fatalf("expected background-refreshed snapshot to contain aws_applicationelb namespace, got %q", snapshot)
+	}
+	// Only the Prometheus-type datasource (ds1) should have been queried, not
+	// the Loki one (ds2).
+	if calls := metricNamesCalls.Load(); calls != 1 {
+		t.Fatalf("expected exactly 1 list_prometheus_metric_names call (one Prometheus datasource), got %d", calls)
+	}
+
+	// A second call once cached must not trigger another fetch.
+	got2 := p.metricNamespaceSnapshot("1", "Org1", "")
+	if got2 != snapshot {
+		t.Fatalf("expected second call to return the cached snapshot, got %q", got2)
+	}
+	if calls := metricNamesCalls.Load(); calls != 1 {
+		t.Fatalf("expected cache hit not to trigger another fetch, got %d total calls", calls)
+	}
+}
+
+func TestMetricNamespaceSnapshot_DedupesConcurrentRefreshes(t *testing.T) {
+	var metricNamesCalls atomic.Int32
+	server := newMetricNamespaceSnapshotServer(t, &metricNamesCalls)
+	defer server.Close()
+
+	proxy := mcp.NewProxy(context.Background(), log.DefaultLogger)
+	if err := proxy.EnsureServer(mcp.ServerConfig{
+		ID: "mcp-grafana", Name: "Grafana", URL: server.URL, Type: "standard", Enabled: true,
+	}); err != nil {
+		t.Fatalf("failed to configure proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	p := &Plugin{logger: log.DefaultLogger, mcpProxy: proxy}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.metricNamespaceSnapshot("1", "Org1", "")
+		}()
+	}
+	wg.Wait()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := p.lookupMetricNamespaceCache("1"); ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if calls := metricNamesCalls.Load(); calls != 1 {
+		t.Fatalf("expected concurrent misses to dedupe into a single background refresh, got %d calls", calls)
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -197,6 +197,11 @@ type Plugin struct {
 	// system prompt. See datasource_snapshot.go.
 	dsCache   map[string]dsCacheEntry
 	dsCacheMu sync.Mutex
+	// msCache memoises the per-org metric-namespace snapshot injected into the
+	// system prompt for alert investigations. See metric_namespace_snapshot.go.
+	msCache    map[string]dsCacheEntry
+	msCacheMu  sync.Mutex
+	msInFlight map[string]bool
 }
 
 func NewPlugin(ctx context.Context, settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
@@ -885,6 +890,12 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 	toolCtx.ConversationType = req.Type
 	toolCtx.IsAlertInvestigation = isAlertInvestigation(req.Type, req.Message)
 	toolCtx.DatasourceSnapshot = p.datasourceSnapshot(orgID, req.OrgName, req.ScopeOrgID)
+	if toolCtx.IsAlertInvestigation {
+		// Only fetched for alert investigations: the underlying fetch is a
+		// (cached, backgrounded) scan of each Prometheus datasource's metric
+		// catalog, not worth the overhead for plain chat.
+		toolCtx.MetricNamespaceSnapshot = p.metricNamespaceSnapshot(orgID, req.OrgName, req.ScopeOrgID)
+	}
 
 	systemPrompt, err := p.promptRegistry.BuildSystemPrompt(toolCtx)
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -883,6 +883,7 @@ func (p *Plugin) handleAgentRun(w http.ResponseWriter, r *http.Request) {
 
 	toolCtx := BuildToolContext(req.OrgName, userRole)
 	toolCtx.ConversationType = req.Type
+	toolCtx.IsAlertInvestigation = isAlertInvestigation(req.Type, req.Message)
 	toolCtx.DatasourceSnapshot = p.datasourceSnapshot(orgID, req.OrgName, req.ScopeOrgID)
 
 	systemPrompt, err := p.promptRegistry.BuildSystemPrompt(toolCtx)

--- a/pkg/plugin/prompt_defaults.go
+++ b/pkg/plugin/prompt_defaults.go
@@ -88,6 +88,17 @@ This keeps each tool call payload small and reliable.
 
 {{.DatasourceSnapshot}}
 {{end}}
+{{if .MetricNamespaceSnapshot}}
+
+## Known Metric Namespaces (this run)
+
+These are metric-name PREFIXES, not full metric names — use one to build a
+targeted regex for ` + "`list_prometheus_metric_names`" + ` (e.g. a namespace
+"aws_applicationelb" suggests trying the regex "aws_applicationelb.*")
+instead of scanning a datasource with a broad ".*" regex.
+
+{{.MetricNamespaceSnapshot}}
+{{end}}
 
 ---
 

--- a/pkg/plugin/prompts.go
+++ b/pkg/plugin/prompts.go
@@ -23,6 +23,13 @@ type PromptContext struct {
 	// Used to append mode-specific system instructions (e.g. tighter tool discipline for investigations).
 	ConversationType string
 
+	// IsAlertInvestigation mirrors resolveMaxIterations' isAlertInvestigation
+	// check (reqType == "investigation" OR the message looks like a firing-alert
+	// notification pasted into chat). Gates DefaultInvestigationModeSystemAddendum
+	// so a request that gets the bigger iteration budget always also gets the
+	// efficiency guardrails that keep it fast — see isAlertInvestigation's comment.
+	IsAlertInvestigation bool
+
 	AvailableTools []ToolInfo
 	DisabledTools  []ToolInfo
 	FailedTools    []ToolInfo
@@ -99,7 +106,7 @@ func (r *PromptRegistry) BuildSystemPrompt(ctx PromptContext) (string, error) {
 		return "", err
 	}
 	out := system + tools
-	if ctx.ConversationType == "investigation" {
+	if ctx.IsAlertInvestigation {
 		out += "\n\n---\n\n" + DefaultInvestigationModeSystemAddendum
 	}
 	return out, nil

--- a/pkg/plugin/prompts.go
+++ b/pkg/plugin/prompts.go
@@ -41,6 +41,15 @@ type PromptContext struct {
 	// injected at session start so the LLM cannot hallucinate UIDs. Empty string
 	// renders no block.
 	DatasourceSnapshot string
+
+	// MetricNamespaceSnapshot is a compact, per-Prometheus-datasource list of
+	// metric-name namespaces (prefixes, not full names) injected for alert
+	// investigations so the agent can build a targeted regex on its first
+	// list_prometheus_metric_names call instead of guessing across several
+	// datasources and regex attempts. Empty string renders no block — either
+	// there are no Prometheus datasources, or the snapshot hasn't finished its
+	// background refresh yet (see metricNamespaceSnapshot).
+	MetricNamespaceSnapshot string
 }
 
 type PromptRegistry struct {

--- a/pkg/plugin/prompts_test.go
+++ b/pkg/plugin/prompts_test.go
@@ -16,6 +16,7 @@ func TestBuildSystemPrompt_InvestigationAppendsAddendum(t *testing.T) {
 	}
 	ctx := BuildToolContext("Org1", "Admin")
 	ctx.ConversationType = "investigation"
+	ctx.IsAlertInvestigation = true
 	withAdd, err := r.BuildSystemPrompt(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -25,6 +26,30 @@ func TestBuildSystemPrompt_InvestigationAppendsAddendum(t *testing.T) {
 	}
 	if len(withAdd) <= len(base) {
 		t.Fatalf("investigation prompt should be longer than base; base=%d with=%d", len(base), len(withAdd))
+	}
+}
+
+// TestBuildSystemPrompt_FiringMessageInChatAppendsAddendum guards against the
+// Sept 2026 production incident: a user pasted a raw "[FIRING:1] ..." alert
+// notification into plain chat (reqType "chat", not the "investigation" deep
+// link), which got the bigger AlertInvestigationMaxIter budget via
+// isAlertInvestigation but not these efficiency guardrails, because the two
+// were gated on different conditions. IsAlertInvestigation must now be
+// computed from the same helper for both, so this case gets the addendum too.
+func TestBuildSystemPrompt_FiringMessageInChatAppendsAddendum(t *testing.T) {
+	r, err := NewPromptRegistry(PluginSettings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := BuildToolContext("Org1", "Admin")
+	ctx.ConversationType = "chat"
+	ctx.IsAlertInvestigation = isAlertInvestigation("chat", "Prometheus]: [FIRING:1] mmcx-prd alb P2 (SecurityAlertsApiTrafficNearZero prd mmcx noc)")
+	out, err := r.BuildSystemPrompt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, DefaultInvestigationModeSystemAddendum) {
+		t.Fatal("expected investigation system addendum for a firing-alert message pasted into plain chat")
 	}
 }
 


### PR DESCRIPTION
## Summary

Speeds up Ask O11y alert investigations after a production incident where a single alert lookup took **21 minutes and ~5.2M tokens** (session `ybSzUfzvsCcXCj6Bz2dJ-rOzJer4GkfhUeeVVVocFqE`, reported via Slack). Root-caused via the session/run records in Redis (`w3f-o11y-prod-us`, `monitoring` namespace) and the corresponding Tempo traces, then generalized after checking several other production sessions and traces for the same patterns.

Six independent, additive fixes, each backed by a specific measurement from real traces:

### 1. Investigation efficiency guardrails now match the iteration-budget gate
`resolveMaxIterations` grants alert-style requests (`reqType == investigation` OR a `[FIRING:...]`-style regex match on the raw message) a 60-iteration budget instead of 50. But `BuildSystemPrompt` only appended the efficiency guardrails (runbook-first, narrow scoping, batch queries, conclude early) when `reqType` was *exactly* `"investigation"`. A firing alert pasted directly into chat — rather than opened via the alert-notification deep link — got the bigger iteration budget with **none** of the guardrails meant to keep it fast, which is exactly what happened in the incident session. Both checks now share a single `isAlertInvestigation` helper so they can't drift apart again.

### 2. Eviction summarization moved off the hot path
Stale tool-result summarization used to run as a *blocking* base-model LLM call at the top of every loop iteration, serializing ~130-200s into long runs. It now kicks off in the background as soon as each tool result is appended to history, using a small future resolved by a goroutine — by the time a summary is actually needed (`keepRecentToolResults` iterations later), it's almost always already done.

### 3. Fixed a data race on the run's usage map
`DoneEvent` handed out the *live* `usageByModel` map, but background eviction-summary goroutines for never-evicted tail tool results could still be writing to it after the event crossed into the SSE-consuming goroutine — a real concurrent map access. Now snapshotted under lock before being handed off. *(Found by Cursor Bugbot.)*

### 4. Token estimation tightened for structured content
`EstimateTokens` used a flat chars/4 ratio tuned for English prose. A production trace showed a single LLM call actually billed **291K prompt tokens** against a 180K configured ceiling, because dense JSON tool-result content — the dominant source of context growth — tokenizes far worse than prose, so the trim pass never triggered early enough. Structured content (detected via letter-density) now estimates at a tighter ratio, and `trimToolResponses`' truncation length uses that same ratio so a single trim pass actually converges instead of falling through to more aggressive truncation. *(The second half found by Cursor Bugbot.)*

### 5. Cached the single slowest tool call
`grafana_list_prometheus_metric_names` was the largest tool-latency cost in every sampled trace — individual calls took 20-30s (a regex scan of a datasource's full metric catalog), and 4 calls alone accounted for 81% of all tool-call time in one trace. Added a 60-second result cache in the MCP proxy for this tool, scoped by tool name, org, scope org, and user so cached data never crosses those boundaries.

### 6. Metric-namespace snapshot for alert investigations
Investigations repeatedly burned multiple slow, blind regex attempts hunting for the right metric name across several Prometheus datasources. A full metric-catalog dump into the system prompt was considered and ruled out by measurement — one real datasource returned 4,622 metric names (213KB, ~35-50K tokens), and that content would sit in the prompt unevicted for the whole run since eviction only ever touches tool-role messages. Instead, injects a compact per-datasource list of metric-name *namespaces* (prefixes like `aws_applicationelb`, not full names) so the agent can build a targeted first regex. Mirrors `datasourceSnapshot` but never blocks the request — the underlying fetch (one call per Prometheus datasource, 20-30s each) runs entirely in the background (deduplicated, 15-minute cache), scoped to alert investigations only.

Also fixed: the background refresh initially routed through the shared, pooled MCP client — the same client the live agent loop uses for its own tool calls. `Client.CallToolWithContext` with org context always tears down and reconnects the session on every call by design, so the two concurrent callers could close the session out from under each other's in-flight call. Added `Proxy.NewStandaloneClient` so the background refresh uses an isolated connection. *(Found by Cursor Bugbot.)*

## Root cause analysis

Traced the incident session via Redis (`session:*` / `run:*` keys, `w3f-o11y-prod-us` / `monitoring` / `redis-664d5d478d-p79fs`) and its Tempo trace: ~19 of the 21 minutes were LLM inference time, driven by prompt sizes reaching 70K-291K tokens per call across up to 57 iterations, vs. ~2 minutes of actual tool-call latency — confirming the fixes needed to target iteration count and context growth, not raw tool round-trip time. Checked several other alert-investigation sessions from the same time window (before and after partial fixes) to confirm these patterns (missing guardrails, datasource/rule discovery thrashing, slow metric-name scans) recurred across different alerts, orgs, and users rather than being a one-off.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/...`
- [x] `go test -race ./pkg/...` (full backend suite, repeated after every fix)
- [x] New/updated tests: `TestBuildSystemPrompt_FiringMessageInChatAppendsAddendum`, `TestEstimateTokens_StructuredContentGetsTighterRatio`, `TestTrimToolResponses_StructuredContentConvergesInOnePass`, result-cache tests (`TestCacheableTTL`, `TestResultCache_*`, `TestCacheKey_*`), metric-namespace snapshot tests (cache hit/miss/background-fill/concurrent-dedup), `TestNewStandaloneClient_IsIsolatedFromPooledClient`
- [x] `gofmt -l` clean on every file touched
- [x] Verified two Cursor Bugbot-reported regressions with a manual revert-and-rerun (structured-content trim convergence: 4806 tokens without the fix vs. under 3000 with it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
