### PR TITLE
ci(ci): publish installable plugin artifact on every commit

### DIFF
--- a/.github/actions/build-plugin/action.yml
+++ b/.github/actions/build-plugin/action.yml
@@ -1,9 +1,16 @@
 # Vendored from grafana/plugin-actions/build-plugin
 # Source commit: 2ecc2ba7168309f04010b5b637530b877d67e4ff
 # Reason: the org policy "Require actions pinned to a full-length commit SHA"
-# rejects the upstream transitive `package-plugin@main` ref. We vendor this
+# rejects the upstream action's transitive `package-plugin@main` ref. We vendor this
 # composite action and pin that nested ref to a SHA. Re-sync from upstream when
 # bumping; keep all nested `uses:` pinned to SHAs.
+#
+# Local modifications (preserve when re-syncing from upstream):
+#   - Added `create_release` input (default "true"); the "Create Github release"
+#     step is gated on it so branch builds can skip release creation.
+#   - The "Check package version" step is gated on tag refs
+#     (startsWith(github.ref, 'refs/tags/')) since on branch pushes the "tag"
+#     is the branch name and the check would always fail.
 name: "Grafana Build Plugin"
 description: "Builds a Grafana plugin"
 
@@ -54,6 +61,10 @@ inputs:
     description: "Create a verifiable attestation for the plugin using Github OIDC. Requires id-token: write and attestations: writes permissions"
     required: false
     default: "false"
+  create_release:
+    description: "Create a GitHub draft release with the plugin archive. Set to false to only build the artifact."
+    required: false
+    default: "true"
   use_changelog_generator:
     description: "Whether to generate a changelog for the plugin"
     required: false
@@ -114,6 +125,7 @@ runs:
       shell: bash
 
     - name: Check package version
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: if [ "v${PLUGIN_VERSION}" != "${GITHUB_TAG}" ]; then printf "\033[0;31mPlugin version doesn't match tag name. The tag should be v${PLUGIN_VERSION} \033[0m\n"; exit 1; fi
       shell: bash
       env:
@@ -144,6 +156,7 @@ runs:
         PLUGIN_VERSION: ${{ steps.package-plugin.outputs.plugin-version }}
 
     - name: Create Github release
+      if: ${{ inputs.create_release == 'true' }}
       uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7 # v2.3.4
       with:
         draft: true

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,42 @@
+name: Artifact
+
+# Builds an installable plugin archive (zip) on every commit, without creating
+# a GitHub release. The archive is published as a GitHub Actions artifact
+# (retention: 15 days). Tag pushes are excluded on purpose: they are handled by
+# the Release workflow (.github/workflows/release.yml).
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write # required by actions/upload-artifact
+
+concurrency:
+  group: artifact-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - id: build
+        uses: ./.github/actions/build-plugin
+        with:
+          node-version: '22'
+          go-version: '1.26.6'
+          create_release: false # no GitHub release, artifact only
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: consensys-asko11y-app-${{ github.sha }}
+          path: |
+            ${{ steps.build.outputs.archive }}
+            ${{ steps.build.outputs.archive-sha1sum }}
+          retention-days: 15


### PR DESCRIPTION
## Summary

Every commit now produces an installable plugin archive (zip) as a GitHub Actions artifact, without creating a GitHub release. Previously only version tags produced a zip (via the draft release).

## Changes

- **New `.github/workflows/artifact.yml`**
  - Triggers on push to any branch (tag pushes excluded — they still go through `release.yml`) plus `workflow_dispatch`
  - Builds the plugin (unsigned, no attestation) and uploads the zip + sha1sum as an artifact named `consensys-asko11y-app-<commit-sha>` with 15-day retention
  - `concurrency` per ref with cancel-in-progress to avoid queued duplicate builds
  - Permissions: `contents: read` + `actions: write` (required by upload-artifact)
- **`.github/actions/build-plugin/action.yml`** (vendored)
  - New `create_release` input (default `true` → `release.yml` behavior unchanged, draft release still created on tags); gates the "Create Github release" step
  - "Check package version" (tag must equal version) is now scoped to tag refs only, since on branch pushes the "tag" is the branch name and the check would always fail
  - Header comment documents these local modifications to preserve when re-syncing from upstream

## Plugin version

No version changes (Option A): the version stays release-please-managed from `package.json`. Between releases, all commits produce the same zip version (e.g. 0.3.9); artifacts are distinguished by the commit SHA in the artifact name.

## Verification

- `actionlint` passes on both workflows (remaining full-repo warnings are pre-existing in ci.yml / e2e.yml / is-compatible.yml)
- All touched YAML files parse cleanly
- No TypeScript/JS code changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes with read-scoped artifact workflow permissions; release path unchanged via default `create_release: true`.
> 
> **Overview**
> Adds an **Artifact** workflow that builds the Grafana plugin on every branch push (and `workflow_dispatch`) and uploads the zip plus sha1sum as a GitHub Actions artifact (`consensys-asko11y-app-<sha>`, 15-day retention), without creating a release. Tag pushes stay on the existing release workflow.
> 
> The vendored **`build-plugin`** composite action gains a **`create_release`** input (default `true`, so release behavior is unchanged). The draft release step runs only when that input is true; the new artifact workflow passes `create_release: false`. **Check package version** now runs only on tag refs so branch builds are not failed when the ref “tag” is the branch name.
> 
> Header comments document these local forks for future upstream re-syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88afc0b00d4ef68c7d0226ec6beb70b84d05c065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->