### PR TITLE
fix(mcp): route local Graphiti through litellm, drop Ollama, fix config substitution

### DIFF
--- a/docker-compose-full.yaml
+++ b/docker-compose-full.yaml
@@ -38,13 +38,11 @@ services:
     ports:
       - '127.0.0.1:8002:8000'
     environment:
-      ANTHROPIC_API_KEY: ${LLM_API_KEY:-}
-      LLM_MODEL: ${GRAPHITI_LLM_MODEL:-claude-haiku-4-5-20251001}
-      OPENAI_API_KEY: ollama
-      OPENAI_BASE_URL: http://ollama:11434/v1
-      OLLAMA_URL: http://ollama:11434/v1
-      EMBEDDING_MODEL: ${GRAPHITI_EMBEDDING_MODEL:-nomic-embed-text}
-      EMBEDDING_DIM: ${GRAPHITI_EMBEDDING_DIM:-768}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-https://litellm.consensys.info}
+      LLM_MODEL: ${GRAPHITI_LLM_MODEL:-gemini-3.8-flash}
+      EMBEDDING_MODEL: ${GRAPHITI_EMBEDDING_MODEL:-text-embedding-3-large}
+      EMBEDDING_DIM: ${GRAPHITI_EMBEDDING_DIM:-1024}
       GRAPHITI_GROUP_ID: ${GRAPHITI_GROUP_ID:-main}
       NEO4J_URI: bolt://neo4j:${NEO4J_PORT:-7687}
       NEO4J_USER: ${NEO4J_USER}
@@ -56,15 +54,6 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
-      ollama:
-        condition: service_started
-
-  ollama:
-    image: ollama/ollama
-    ports:
-      - '127.0.0.1:11434:11434'
-    volumes:
-      - ollama_data:/root/.ollama
 
   neo4j:
     image: neo4j:5.26.0
@@ -111,4 +100,3 @@ volumes:
   redis-data:
   neo4j_data:
   neo4j_logs:
-  ollama_data:

--- a/docker/graphiti/Dockerfile
+++ b/docker/graphiti/Dockerfile
@@ -1,6 +1,5 @@
 FROM zepai/knowledge-graph-mcp:1.1.0-standalone
-RUN pip install --no-cache-dir --target=/app/mcp/.venv/lib/python3.11/site-packages anthropic \
-    && groupadd --system --gid 1000 graphiti \
+RUN groupadd --system --gid 1000 graphiti \
     && useradd --system --uid 1000 --gid graphiti --home-dir /tmp --shell /usr/sbin/nologin graphiti \
     && cp /root/.local/bin/uv /usr/local/bin/uv \
     && cp /root/.local/bin/uvx /usr/local/bin/uvx \

--- a/provisioning/.config/graphiti.yaml
+++ b/provisioning/.config/graphiti.yaml
@@ -9,39 +9,55 @@ server:
     - "127.0.0.1"
 
 llm:
-  provider: "anthropic"
-  model: ${LLM_MODEL:-claude-haiku-4-5-20251001}
+  # Routed through the shared litellm gateway (OpenAI-compatible) rather than
+  # a native anthropic provider, matching Consensys/w3f-observability#630 —
+  # avoids needing an anthropic client in the image at all.
+  #
+  # NOTE: this config loader's ${VAR:default} substitution (YamlSettingsSource
+  # in the MCP server) only supports a single colon, not bash's ${VAR:-default}
+  # — the regex is `\$\{([^:}]+)(:([^}]*))?\}`, so a stray dash right after the
+  # colon becomes part of the literal default string. Every default below is
+  # deliberately written as `:default`, not `:-default`.
+  provider: "openai"
+  # litellm's OpenAI-compatible /v1 surface expects the plain model id from
+  # GET /v1/models (e.g. "gemini-3.8-flash") — the "gemini/" provider-prefixed
+  # form is litellm's own SDK routing syntax, not what the proxy accepts here.
+  model: ${LLM_MODEL:gemini-3.8-flash}
   temperature: 1.0
   max_tokens: 8192
   providers:
-    anthropic:
-      api_key: ${ANTHROPIC_API_KEY:-}
+    openai:
+      api_key: ${LITELLM_API_KEY:}
+      api_url: ${LITELLM_BASE_URL:https://litellm.consensys.info}
 
 embedder:
+  # Also routed through litellm (see llm.provider above) rather than a local
+  # Ollama container — nothing else in this stack needs Ollama, so this
+  # avoids an extra service + local model pull for zero functional gain.
+  # text-embedding-3-large defaults to 3072 dims; pinned to 1024 to match
+  # Consensys/w3f-observability#630's Neo4j vector index sizing. Same "no
+  # provider prefix" note as llm.model above — this is litellm's proxy-facing
+  # model id, not the "azure/text-embedding-3-large" SDK routing form.
   provider: "openai"
-  model: ${EMBEDDING_MODEL:-nomic-embed-text}
-  # Must match the container's EMBEDDING_DIM (nomic-embed-text is 768-dim, not the
-  # 1536-dim OpenAI default) — pydantic-settings only maps env vars via the
-  # EMBEDDER__DIMENSIONS nested-delimiter form, so EMBEDDING_DIM alone is a no-op
-  # unless referenced here through this config's own ${VAR} substitution.
-  dimensions: ${EMBEDDING_DIM:-768}
+  model: ${EMBEDDING_MODEL:text-embedding-3-large}
+  dimensions: ${EMBEDDING_DIM:1024}
   providers:
     openai:
-      api_key: "ollama"
-      api_url: ${OLLAMA_URL:-http://ollama:11434/v1}
+      api_key: ${LITELLM_API_KEY:}
+      api_url: ${LITELLM_BASE_URL:https://litellm.consensys.info}
 
 database:
   provider: "neo4j"
   providers:
     neo4j:
-      uri: ${NEO4J_URI:-bolt://neo4j:7687}
-      username: ${NEO4J_USER:-neo4j}
-      password: ${NEO4J_PASSWORD:-demodemo}
-      database: ${NEO4J_DATABASE:-neo4j}
+      uri: ${NEO4J_URI:bolt://neo4j:7687}
+      username: ${NEO4J_USER:neo4j}
+      password: ${NEO4J_PASSWORD:demodemo}
+      database: ${NEO4J_DATABASE:neo4j}
       use_parallel_runtime: false
 
 graphiti:
-  group_id: ${GRAPHITI_GROUP_ID:-main}
+  group_id: ${GRAPHITI_GROUP_ID:main}
   entity_types:
     - name: "Service"
       description: "A microservice, application, or workload identified by a service/job/app metric label or trace resource.service.name"


### PR DESCRIPTION
## Summary

Follow-up to #198 (already merged/released as v0.3.10). While building and validating the new pinned `1.1.0-standalone` Graphiti image end-to-end locally (real MCP add_memory + search_memory_facts round trip through litellm), found and fixed three issues:

- **Local dev now matches [Consensys/w3f-observability#630](https://github.com/Consensys/w3f-observability/pull/630)'s litellm-only setup.** Switched both LLM and embedder to litellm's OpenAI-compatible /v1 surface instead of direct Anthropic + local Ollama. Removed the now-unneeded `pip install anthropic` step from the Dockerfile, and removed the Ollama service/volume entirely -- nothing else in the stack used it.
- **Fixed a config-substitution bug that silently broke any unset env var default.** The MCP server's own YAML env-var substitution only supports `${VAR:default}` (single colon) -- the bash-style `${VAR:-default}` used throughout graphiti.yaml left a literal leading `-` in the fallback whenever the var was unset. This silently broke `NEO4J_DATABASE` (resolved to the nonexistent database `-neo4j`) and would have broken `LITELLM_BASE_URL` the same way. Fixed every default in the file.
- **Fixed the model-id format for litellm's proxy surface.** litellm's chat/embeddings endpoints expect the plain model id from its models list (`gemini-3.8-flash`, `text-embedding-3-large`), not the litellm-SDK routing form (`gemini/gemini-3.8-flash`, `azure/text-embedding-3-large`) used in the w3f-observability manifests -- the latter 400s on this surface. Fixed the local defaults and two stale `.env` overrides that still pointed at pre-litellm model names.

## Verification

Built the image locally, brought up neo4j + graphiti (no Ollama), and ran a real MCP client round trip:
- add_memory -> episode processed in ~18s via real litellm calls (chat/completions and embeddings both returned 200 OK)
- search_memory_facts -> correctly returned the extracted fact (checkout-service CALLS payments-service)

## Test plan
- [x] go build ./pkg/... / go test ./pkg/...
- [x] Local docker-compose-full.yaml build + real MCP smoke test (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Graphiti now depends on external LiteLLM credentials and URLs instead of local Ollama; the substitution fix prevents silent misconfiguration but embedding dimension defaults changed from 768 to 1024 for new local indexes.
> 
> **Overview**
> **Local full-stack Graphiti now uses the shared LiteLLM OpenAI-compatible gateway for both chat and embeddings**, aligning with the w3f-observability litellm-only setup. Compose drops the **Ollama** service, volume, and Graphiti’s dependency on it; the Graphiti image no longer installs the **Anthropic** client.
> 
> **`graphiti.yaml` switches LLM/embedder providers** to OpenAI-shaped LiteLLM endpoints with new defaults (`gemini-3.8-flash`, `text-embedding-3-large` at **1024** dimensions). Model ids are the plain proxy ids, not LiteLLM SDK routing prefixes.
> 
> **Config env substitution is corrected** from bash-style `${VAR:-default}` to `${VAR:default}` everywhere in that file, so unset vars no longer get a literal leading `-` in defaults (e.g. Neo4j database name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beadd67d0c97da2fc95194716cb39f4de7d674de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->