### PR TITLE
fix(mcp): build graphiti from source, drop unused provider extras (6.4GB -> 218MB)

### DIFF
--- a/docker/graphiti/Dockerfile
+++ b/docker/graphiti/Dockerfile
@@ -1,4 +1,53 @@
-FROM zepai/knowledge-graph-mcp:1.1.0-standalone
+# Builds the Graphiti MCP server from source instead of consuming
+# zepai/knowledge-graph-mcp:1.1.0-standalone, which bakes in the mcp_server
+# "providers" and "azure" extras (anthropic/groq/voyageai/google-genai and,
+# via sentence-transformers, PyTorch) regardless of which provider is
+# actually configured. We only ever use provider: "openai" (routed through
+# litellm — see provisioning/.config/graphiti.yaml), which is a base
+# dependency needing none of that, so building without those extras drops
+# the image from ~6.4GB back to roughly its original ~200MB.
+FROM python:3.11-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never \
+    MCP_SERVER_HOST="0.0.0.0" \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app/mcp
+
+# Pins graphiti-core (via pyproject.toml, below) and the mcp_server source
+# tree (via git clone) to the same release train.
+ARG GRAPHITI_CORE_VERSION=0.30.1
+ARG MCP_SERVER_REF=mcp-v1.1.0
+
+RUN git clone --depth 1 --branch ${MCP_SERVER_REF} https://github.com/getzep/graphiti.git /tmp/graphiti \
+    && cp -r /tmp/graphiti/mcp_server/. /app/mcp/ \
+    && rm -rf /tmp/graphiti /app/mcp/tests \
+    && echo "3.11" > /app/mcp/.python-version
+
+# Remove the local path override for graphiti-core, pin to the PyPI release
+# with only the neo4j/falkordb graph-driver extras, and regenerate the lock
+# file against that — mirrors getzep's own Dockerfile.standalone, minus the
+# --extra providers --extra azure flags that pull in the unused SDKs/PyTorch.
+RUN sed -i '/\[tool\.uv\.sources\]/,/graphiti-core/d' pyproject.toml \
+    && sed -i "s/graphiti-core\[falkordb\][>=]\+[0-9]\+\.[0-9]\+\.[0-9]\+/graphiti-core[neo4j,falkordb]==${GRAPHITI_CORE_VERSION}/" pyproject.toml \
+    && rm -f uv.lock \
+    && uv lock
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --no-group dev
+
 RUN groupadd --system --gid 1000 graphiti \
     && useradd --system --uid 1000 --gid graphiti --home-dir /tmp --shell /usr/sbin/nologin graphiti \
     && cp /root/.local/bin/uv /usr/local/bin/uv \
@@ -12,3 +61,6 @@ ENV HOME=/tmp \
     PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
 
 USER 1000:1000
+
+EXPOSE 8000
+CMD ["uv", "run", "--no-sync", "main.py"]


### PR DESCRIPTION
## Summary

`zepai/knowledge-graph-mcp:1.1.0-standalone` bakes in mcp_server's `providers` and `azure` optional-dependency groups (anthropic, groq, voyageai, google-genai, sentence-transformers, azure-identity) regardless of which provider is actually configured. `sentence-transformers` alone pulls in PyTorch, which is why the pinned base image jumped from 196MB (0.2.22) to 6.37GB (0.3.10).

We only ever use `provider: "openai"` (routed through litellm -- see `provisioning/.config/graphiti.yaml`), which is a base mcp_server dependency (`openai>=2.41.0` in `pyproject.toml`, not gated behind any extra). None of the other providers' SDKs are reachable from our config.

Replaced `FROM zepai/knowledge-graph-mcp:1.1.0-standalone` with a build from the same mcp_server source (pinned to `mcp-v1.1.0` / graphiti-core 0.30.1), using getzep's own `Dockerfile.standalone` recipe minus the `--extra providers --extra azure` flags.

## Verification

Built locally, ran the same MCP client round trip used to validate the earlier litellm switch:
- `add_memory` -> episode processed via real litellm calls
- `search_memory_facts` -> correctly returned the extracted fact

Image size: 664MB uncompressed locally / 218MB pushed to ECR, vs 6.37GB before. Pushed to the same ECR tag (`891417867496.dkr.ecr.eu-west-2.amazonaws.com/ask-o11y-plugin/graphiti:0.3.10-nonroot-20260904`, confirmed `linux/arm64`) that [Consensys/w3f-observability#630](https://github.com/Consensys/w3f-observability/pull/630) already references -- no changes needed there.

## Test plan
- [x] Local docker build + real MCP smoke test (see above)
- [x] `go build ./pkg/...` (no Go changes in this PR, sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Supply-chain and build-time dependency resolution (git clone, `uv lock`) replace a pinned vendor image; runtime is still the MCP server on port 8000 with a slimmer dependency set, so regressions would show up as failed builds or broken LLM/graph driver behavior rather than silent auth changes.
> 
> **Overview**
> **Replaces the pre-built `zepai/knowledge-graph-mcp:1.1.0-standalone` base image** with a multi-stage-style build on `python:3.11-slim-bookworm` that clones getzep’s `mcp_server` at **`mcp-v1.1.0`**, pins **`graphiti-core[neo4j,falkordb]==0.30.1`**, and runs **`uv sync` without the `providers` / `azure` optional groups**—so unused Anthropic/Groq/Voyage/Google/Azure SDKs and **PyTorch (via sentence-transformers)** never land in the image.
> 
> The **non-root `graphiti` user (uid/gid 1000)** and runtime env (`HOME`, `UV_CACHE_DIR`, etc.) are preserved; **`EXPOSE 8000`** and **`CMD ["uv", "run", "--no-sync", "main.py"]`** are added explicitly. Intended behavior is unchanged for deployments that only use **`provider: "openai"`** through litellm (`provisioning/.config/graphiti.yaml`); the main win is **image size (~6.4GB → ~200MB class)** and faster pulls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7902c5ff037750e36de9adc545b3e06cd6f5bf68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->