### PR TITLE
fix(backend): fan out agent run events over redis pub/sub

### DIFF
--- a/pkg/plugin/agent_run_events_test.go
+++ b/pkg/plugin/agent_run_events_test.go
@@ -1,0 +1,110 @@
+package plugin
+
+import (
+	"consensys-asko11y-app/pkg/agent"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+type stubRunStore struct {
+	snapshot *AgentRun
+	live     chan agent.SSEEvent
+}
+
+func (s *stubRunStore) CreateRun(runID string, userID, orgID int64, sessionID ...string) *AgentRun {
+	return s.snapshot
+}
+func (s *stubRunStore) AppendEvent(string, agent.SSEEvent)              {}
+func (s *stubRunStore) FinishRun(string, RunStatus, string)             {}
+func (s *stubRunStore) GetRun(string) (*AgentRun, error)                { return s.snapshot, nil }
+func (s *stubRunStore) ListRuns(int64, int64, int) ([]*AgentRun, error) { return nil, nil }
+func (s *stubRunStore) CleanupOld()                                     {}
+func (s *stubRunStore) SubscribeAndSnapshot(string) (*AgentRun, <-chan agent.SSEEvent, func(), error) {
+	return s.snapshot, s.live, func() {}, nil
+}
+
+func contentEvent(sequence int64, text string) agent.SSEEvent {
+	return agent.SSEEvent{Type: "content", Data: agent.ContentEvent{Content: text}, Sequence: sequence}
+}
+
+// A replica's pub/sub subscription is attached before the snapshot is read, so
+// the live channel can carry events the snapshot already contains.
+func TestHandleAgentRunEvents_SkipsEventsAlreadyReplayed(t *testing.T) {
+	live := make(chan agent.SSEEvent, 8)
+	store := &stubRunStore{
+		snapshot: &AgentRun{
+			RunID:  "run-1",
+			Status: RunStatusRunning,
+			UserID: 7,
+			OrgID:  1,
+			Events: []agent.SSEEvent{contentEvent(0, "first"), contentEvent(1, "second")},
+		},
+		live: live,
+	}
+	live <- contentEvent(0, "first")
+	live <- contentEvent(1, "second")
+	live <- contentEvent(2, "third")
+	close(live)
+
+	body := runEventsHandler(t, store, "run-1")
+
+	for _, want := range []string{"first", "second", "third"} {
+		if got := strings.Count(body, `"content":"`+want+`"`); got != 1 {
+			t.Errorf("expected %q exactly once in the stream, got %d", want, got)
+		}
+	}
+}
+
+func TestHandleAgentRunEvents_ForwardsNewEvents(t *testing.T) {
+	live := make(chan agent.SSEEvent, 4)
+	store := &stubRunStore{
+		snapshot: &AgentRun{
+			RunID:  "run-2",
+			Status: RunStatusRunning,
+			UserID: 7,
+			OrgID:  1,
+			Events: []agent.SSEEvent{contentEvent(0, "replayed")},
+		},
+		live: live,
+	}
+	live <- contentEvent(1, "streamed")
+	close(live)
+
+	body := runEventsHandler(t, store, "run-2")
+
+	if strings.Count(body, `"content":"replayed"`) != 1 {
+		t.Error("expected the snapshot event to be replayed once")
+	}
+	if strings.Count(body, `"content":"streamed"`) != 1 {
+		t.Error("expected the live event to be forwarded")
+	}
+}
+
+func runEventsHandler(t *testing.T, store RunStoreInterface, runID string) string {
+	t.Helper()
+
+	p := &Plugin{runStore: store, logger: log.DefaultLogger}
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	req.Header.Set("X-Grafana-User-Id", "7")
+	req.Header.Set("X-Grafana-Org-Id", "1")
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.handleAgentRunEvents(recorder, req, runID)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after the live channel closed")
+	}
+
+	return recorder.Body.String()
+}

--- a/pkg/plugin/agent_run_events_test.go
+++ b/pkg/plugin/agent_run_events_test.go
@@ -108,3 +108,37 @@ func runEventsHandler(t *testing.T, store RunStoreInterface, runID string) strin
 
 	return recorder.Body.String()
 }
+
+// Pub/sub delivery is at-most-once, so a dropped message can leave a hole that a
+// later delivered event papers over. The stream has to stop at the gap so the
+// client's reconnect replays the durable list instead of rendering a partial run.
+func TestHandleAgentRunEvents_StopsAtLiveSequenceGap(t *testing.T) {
+	live := make(chan agent.SSEEvent, 8)
+	store := &stubRunStore{
+		snapshot: &AgentRun{
+			RunID:  "run-gap",
+			Status: RunStatusRunning,
+			UserID: 7,
+			OrgID:  1,
+			Events: []agent.SSEEvent{contentEvent(0, "first")},
+		},
+		live: live,
+	}
+	live <- contentEvent(1, "second")
+	live <- contentEvent(3, "fourth")
+	live <- contentEvent(4, "fifth")
+	close(live)
+
+	body := runEventsHandler(t, store, "run-gap")
+
+	for _, want := range []string{"first", "second"} {
+		if got := strings.Count(body, `"content":"`+want+`"`); got != 1 {
+			t.Errorf("expected %q exactly once before the gap, got %d", want, got)
+		}
+	}
+	for _, unwanted := range []string{"fourth", "fifth"} {
+		if strings.Contains(body, `"content":"`+unwanted+`"`) {
+			t.Errorf("expected %q to be withheld: it arrived after a sequence gap", unwanted)
+		}
+	}
+}

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -37,6 +37,10 @@ const (
 )
 
 const (
+	RunStreamStatusCheckInterval = 30 * time.Second
+)
+
+const (
 	GraphitiDiscoveryMaxIter = 50
 	// GraphitiRetentionInterval paces Scout.RunRetention (community build +
 	// episode prune), independent of GraphitiScanInterval so retention still

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1527,6 +1527,7 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 		return
 	}
 
+	replayedThrough := int64(-1)
 	for _, event := range run.Events {
 		data, err := agent.MarshalSSE(event)
 		if err != nil {
@@ -1536,6 +1537,7 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 		if _, err := w.Write(data); err != nil {
 			return
 		}
+		replayedThrough = event.Sequence
 	}
 	flusher.Flush()
 
@@ -1554,6 +1556,9 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 		case event, ok := <-subscriberCh:
 			if !ok {
 				return
+			}
+			if event.Sequence <= replayedThrough {
+				continue
 			}
 			data, err := agent.MarshalSSE(event)
 			if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1527,7 +1527,7 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 		return
 	}
 
-	replayedThrough := int64(-1)
+	lastEmitted := int64(-1)
 	for _, event := range run.Events {
 		data, err := agent.MarshalSSE(event)
 		if err != nil {
@@ -1537,7 +1537,7 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 		if _, err := w.Write(data); err != nil {
 			return
 		}
-		replayedThrough = event.Sequence
+		lastEmitted = event.Sequence
 	}
 	flusher.Flush()
 
@@ -1557,8 +1557,17 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 			if !ok {
 				return
 			}
-			if event.Sequence <= replayedThrough {
+			if event.Sequence <= lastEmitted {
 				continue
+			}
+			// Pub/sub is at-most-once, so a dropped message leaves a hole that a
+			// later delivered event (including the terminal one) would paper over.
+			// Close the stream instead: the client's reconnect replays the durable
+			// list, which is complete.
+			if lastEmitted >= 0 && event.Sequence > lastEmitted+1 {
+				p.logger.Warn("Gap in live run event sequence, closing stream so the client replays from storage",
+					"runId", runID, "expected", lastEmitted+1, "received", event.Sequence)
+				return
 			}
 			data, err := agent.MarshalSSE(event)
 			if err != nil {
@@ -1567,6 +1576,7 @@ func (p *Plugin) handleAgentRunEvents(w http.ResponseWriter, r *http.Request, ru
 			}
 			w.Write(data)
 			flusher.Flush()
+			lastEmitted = event.Sequence
 		case <-keepalive.C:
 			w.Write([]byte(": keepalive\n\n"))
 			flusher.Flush()

--- a/pkg/plugin/runstore.go
+++ b/pkg/plugin/runstore.go
@@ -59,7 +59,6 @@ type RunStoreInterface interface {
 	FinishRun(runID string, status RunStatus, errMsg string)
 	GetRun(runID string) (*AgentRun, error)
 	ListRuns(userID, orgID int64, limit int) ([]*AgentRun, error)
-	GetBroadcaster(runID string) *RunBroadcaster
 	SubscribeAndSnapshot(runID string) (*AgentRun, <-chan agent.SSEEvent, func(), error)
 	CleanupOld()
 }
@@ -251,13 +250,6 @@ func (s *RunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, error)
 		runs = runs[:limit]
 	}
 	return runs, nil
-}
-
-func (s *RunStore) GetBroadcaster(runID string) *RunBroadcaster {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.broadcasters[runID]
 }
 
 // SubscribeAndSnapshot atomically subscribes and snapshots under one lock

--- a/pkg/plugin/runstore_redis.go
+++ b/pkg/plugin/runstore_redis.go
@@ -15,26 +15,44 @@ import (
 )
 
 type RedisRunStore struct {
-	client       *redis.Client
-	logger       log.Logger
-	mu           sync.RWMutex
-	broadcasters map[string]*RunBroadcaster
-	ctx          context.Context
+	client        *redis.Client
+	logger        log.Logger
+	mu            sync.RWMutex
+	subscriptions map[string]*runSubscription
+	ctx           context.Context
 }
 
-func runKey(runID string) string      { return fmt.Sprintf("run:%s", runID) }
-func eventsKey(runID string) string   { return fmt.Sprintf("run:%s:events", runID) }
-func sequenceKey(runID string) string { return fmt.Sprintf("run:%s:sequence", runID) }
+type runSubscription struct {
+	broadcaster *RunBroadcaster
+	pubsub      *redis.PubSub
+	cancel      context.CancelFunc
+	refs        int
+}
+
+type runStreamMessage struct {
+	Kind  string          `json:"kind"`
+	Event *agent.SSEEvent `json:"event,omitempty"`
+}
+
+const (
+	runStreamKindEvent    = "event"
+	runStreamKindFinished = "finished"
+)
+
+func runKey(runID string) string        { return fmt.Sprintf("run:%s", runID) }
+func eventsKey(runID string) string     { return fmt.Sprintf("run:%s:events", runID) }
+func sequenceKey(runID string) string   { return fmt.Sprintf("run:%s:sequence", runID) }
+func runChannelKey(runID string) string { return fmt.Sprintf("run:%s:channel", runID) }
 func runIndexKey(userID, orgID int64) string {
 	return fmt.Sprintf("runs:user:%d:org:%d", userID, orgID)
 }
 
 func NewRedisRunStore(ctx context.Context, client *redis.Client, logger log.Logger) *RedisRunStore {
 	return &RedisRunStore{
-		client:       client,
-		logger:       logger,
-		broadcasters: make(map[string]*RunBroadcaster),
-		ctx:          ctx,
+		client:        client,
+		logger:        logger,
+		subscriptions: make(map[string]*runSubscription),
+		ctx:           ctx,
 	}
 }
 
@@ -69,10 +87,6 @@ func (s *RedisRunStore) CreateRun(runID string, userID, orgID int64, sessionID .
 	if _, err := pipe.Exec(ctx); err != nil {
 		s.logger.Error("Failed to store run in Redis", "error", err, "runId", runID)
 	}
-
-	s.mu.Lock()
-	s.broadcasters[runID] = newRunBroadcaster()
-	s.mu.Unlock()
 
 	return run
 }
@@ -113,12 +127,7 @@ func (s *RedisRunStore) AppendEvent(runID string, event agent.SSEEvent) {
 	s.appendTraceEvent(runID, event)
 	s.touchRun(runID)
 
-	s.mu.RLock()
-	b := s.broadcasters[runID]
-	s.mu.RUnlock()
-	if b != nil {
-		b.Broadcast(event)
-	}
+	s.publish(runID, runStreamMessage{Kind: runStreamKindEvent, Event: &event})
 }
 
 func (s *RedisRunStore) FinishRun(runID string, status RunStatus, errMsg string) {
@@ -158,13 +167,7 @@ func (s *RedisRunStore) FinishRun(runID string, status RunStatus, errMsg string)
 		s.logger.Warn("Failed to persist finished run metadata", "error", err, "runId", runID)
 	}
 
-	s.mu.Lock()
-	b := s.broadcasters[runID]
-	if b != nil {
-		b.Close()
-		delete(s.broadcasters, runID)
-	}
-	s.mu.Unlock()
+	s.publish(runID, runStreamMessage{Kind: runStreamKindFinished})
 
 	s.logger.Info("Agent run finished", "runId", runID, "status", status)
 }
@@ -223,8 +226,8 @@ func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, e
 	if len(ids) > 0 {
 		runs := make([]*AgentRun, 0, len(ids))
 		for _, runID := range ids {
-			run, ok := s.loadRunFromRedis(ctx, runID)
-			if !ok {
+			run, err := s.loadRunFromRedis(ctx, runID)
+			if err != nil {
 				s.client.ZRem(ctx, runIndexKey(userID, orgID), runID)
 				continue
 			}
@@ -287,21 +290,20 @@ func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, e
 	return runs, nil
 }
 
-func (s *RedisRunStore) loadRunFromRedis(ctx context.Context, runID string) (*AgentRun, bool) {
+func (s *RedisRunStore) loadRunFromRedis(ctx context.Context, runID string) (*AgentRun, error) {
 	runJSON, err := s.client.Get(ctx, runKey(runID)).Result()
-	if err == redis.Nil {
-		return nil, false
-	}
 	if err != nil {
-		s.logger.Warn("Failed to load indexed run", "error", err, "runId", runID)
-		return nil, false
+		if err != redis.Nil {
+			s.logger.Warn("Failed to load indexed run", "error", err, "runId", runID)
+		}
+		return nil, err
 	}
 	var run AgentRun
 	if err := json.Unmarshal([]byte(runJSON), &run); err != nil {
 		s.logger.Warn("Failed to unmarshal indexed run", "error", err, "runId", runID)
-		return nil, false
+		return nil, err
 	}
-	return copyRun(&run), true
+	return copyRun(&run), nil
 }
 
 func (s *RedisRunStore) appendTraceEvent(runID string, event agent.SSEEvent) {
@@ -340,51 +342,181 @@ func (s *RedisRunStore) appendTraceEvent(runID string, event agent.SSEEvent) {
 	}
 }
 
-func (s *RedisRunStore) GetBroadcaster(runID string) *RunBroadcaster {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.broadcasters[runID]
-}
-
 func (s *RedisRunStore) SubscribeAndSnapshot(runID string) (*AgentRun, <-chan agent.SSEEvent, func(), error) {
-	s.mu.RLock()
-	b := s.broadcasters[runID]
-	s.mu.RUnlock()
+	sub, err := s.acquireSubscription(runID)
+	if err != nil {
+		s.logger.Warn("Failed to subscribe to run channel, serving snapshot only", "error", err, "runId", runID)
+	}
 
 	var ch <-chan agent.SSEEvent
 	var unsub func()
-	if b != nil {
-		ch, unsub = b.Subscribe()
+	if sub != nil {
+		ch, unsub = sub.broadcaster.Subscribe()
+	}
+
+	release := func() {
+		if unsub != nil {
+			unsub()
+		}
+		if sub != nil {
+			s.releaseSubscription(runID, sub)
+		}
 	}
 
 	run, err := s.GetRun(runID)
 	if err != nil {
-		if unsub != nil {
-			unsub()
-		}
+		release()
 		return nil, nil, nil, err
 	}
 
-	if run.Status != RunStatusRunning {
-		if unsub != nil {
-			unsub()
-		}
+	if run.Status != RunStatusRunning || ch == nil {
+		release()
 		return run, nil, nil, nil
 	}
 
-	return run, ch, unsub, nil
+	return run, ch, release, nil
 }
 
-func (s *RedisRunStore) CleanupOld() {
+func (s *RedisRunStore) acquireSubscription(runID string) (*runSubscription, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if existing, ok := s.subscriptions[runID]; ok {
+		existing.refs++
+		s.mu.Unlock()
+		return existing, nil
+	}
+	s.mu.Unlock()
 
-	for runID, b := range s.broadcasters {
-		if b.IsClosed() {
-			delete(s.broadcasters, runID)
+	ctx, cancel := context.WithCancel(s.ctx)
+	pubsub := s.client.Subscribe(ctx, runChannelKey(runID))
+	confirmCtx, confirmCancel := redisContext(ctx, RedisOpTimeout)
+	_, err := pubsub.Receive(confirmCtx)
+	confirmCancel()
+	if err != nil {
+		cancel()
+		pubsub.Close()
+		return nil, fmt.Errorf("subscribe to run channel: %w", err)
+	}
+
+	s.mu.Lock()
+	if existing, ok := s.subscriptions[runID]; ok {
+		existing.refs++
+		s.mu.Unlock()
+		cancel()
+		pubsub.Close()
+		return existing, nil
+	}
+	sub := &runSubscription{
+		broadcaster: newRunBroadcaster(),
+		pubsub:      pubsub,
+		cancel:      cancel,
+		refs:        1,
+	}
+	s.subscriptions[runID] = sub
+	s.mu.Unlock()
+
+	go s.receiveRunEvents(ctx, runID, sub)
+	return sub, nil
+}
+
+func (s *RedisRunStore) receiveRunEvents(ctx context.Context, runID string, sub *runSubscription) {
+	defer s.retireSubscription(runID, sub)
+
+	messages := sub.pubsub.Channel()
+	statusCheck := time.NewTicker(RunStreamStatusCheckInterval)
+	defer statusCheck.Stop()
+
+	for {
+		select {
+		case msg, ok := <-messages:
+			if !ok {
+				return
+			}
+			var payload runStreamMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &payload); err != nil {
+				s.logger.Warn("Failed to unmarshal run stream message", "error", err, "runId", runID)
+				continue
+			}
+			if payload.Kind == runStreamKindFinished {
+				return
+			}
+			if payload.Event != nil {
+				sub.broadcaster.Broadcast(*payload.Event)
+			}
+		case <-statusCheck.C:
+			if !s.runIsRunning(runID) {
+				return
+			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }
+
+func (s *RedisRunStore) runIsRunning(runID string) bool {
+	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
+	defer cancel()
+
+	run, err := s.loadRunFromRedis(ctx, runID)
+	if err == redis.Nil {
+		return false
+	}
+	if err != nil {
+		return true
+	}
+	return run.Status == RunStatusRunning
+}
+
+func (s *RedisRunStore) releaseSubscription(runID string, sub *runSubscription) {
+	s.mu.Lock()
+	current, ok := s.subscriptions[runID]
+	if !ok || current != sub {
+		s.mu.Unlock()
+		return
+	}
+	sub.refs--
+	if sub.refs > 0 {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.subscriptions, runID)
+	s.mu.Unlock()
+
+	s.closeSubscription(sub)
+}
+
+func (s *RedisRunStore) retireSubscription(runID string, sub *runSubscription) {
+	s.mu.Lock()
+	if current, ok := s.subscriptions[runID]; ok && current == sub {
+		delete(s.subscriptions, runID)
+	}
+	s.mu.Unlock()
+
+	s.closeSubscription(sub)
+}
+
+func (s *RedisRunStore) closeSubscription(sub *runSubscription) {
+	sub.cancel()
+	if err := sub.pubsub.Close(); err != nil {
+		s.logger.Debug("Failed to close run pub/sub", "error", err)
+	}
+	sub.broadcaster.Close()
+}
+
+func (s *RedisRunStore) publish(runID string, msg runStreamMessage) {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		s.logger.Error("Failed to marshal run stream message", "error", err, "runId", runID)
+		return
+	}
+
+	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
+	defer cancel()
+	if err := s.client.Publish(ctx, runChannelKey(runID), payload).Err(); err != nil {
+		s.logger.Warn("Failed to publish run stream message", "error", err, "runId", runID)
+	}
+}
+
+func (s *RedisRunStore) CleanupOld() {}
 
 func (s *RedisRunStore) touchRun(runID string) {
 	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)

--- a/pkg/plugin/runstore_redis_stream_test.go
+++ b/pkg/plugin/runstore_redis_stream_test.go
@@ -1,0 +1,157 @@
+package plugin
+
+import (
+	"consensys-asko11y-app/pkg/agent"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+func waitForEvent(t *testing.T, ch <-chan agent.SSEEvent) agent.SSEEvent {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		if !ok {
+			t.Fatal("event channel closed before an event arrived")
+		}
+		return event
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for event")
+		return agent.SSEEvent{}
+	}
+}
+
+func TestRedisRunStore_StreamsEventsAcrossStores(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	producer := NewRedisRunStore(ctx, client, log.DefaultLogger)
+	consumer := NewRedisRunStore(ctx, client, log.DefaultLogger)
+
+	producer.CreateRun("run-1", 100, 1, "session-1")
+
+	run, ch, unsub, err := consumer.SubscribeAndSnapshot("run-1")
+	if err != nil {
+		t.Fatalf("SubscribeAndSnapshot failed: %v", err)
+	}
+	if ch == nil {
+		t.Fatal("expected a live event channel for a running run on another replica")
+	}
+	defer unsub()
+	if run.Status != RunStatusRunning {
+		t.Fatalf("expected status running, got %q", run.Status)
+	}
+
+	producer.AppendEvent("run-1", agent.SSEEvent{Type: "content", Data: agent.ContentEvent{Content: "hello"}})
+
+	event := waitForEvent(t, ch)
+	if event.Type != "content" {
+		t.Fatalf("expected content event, got %q", event.Type)
+	}
+	if event.Sequence != 0 {
+		t.Fatalf("expected sequence 0, got %d", event.Sequence)
+	}
+}
+
+func TestRedisRunStore_ClosesStreamWhenRunFinishes(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	producer := NewRedisRunStore(ctx, client, log.DefaultLogger)
+	consumer := NewRedisRunStore(ctx, client, log.DefaultLogger)
+
+	producer.CreateRun("run-2", 100, 1)
+
+	_, ch, unsub, err := consumer.SubscribeAndSnapshot("run-2")
+	if err != nil {
+		t.Fatalf("SubscribeAndSnapshot failed: %v", err)
+	}
+	if ch == nil {
+		t.Fatal("expected a live event channel")
+	}
+	defer unsub()
+
+	producer.AppendEvent("run-2", agent.SSEEvent{Type: "done", Data: agent.DoneEvent{TotalIterations: 1}})
+	waitForEvent(t, ch)
+	producer.FinishRun("run-2", RunStatusCompleted, "")
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected the stream to close after the run finished")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the stream to close")
+	}
+}
+
+func TestRedisRunStore_FinishedRunHasNoLiveStream(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	store.CreateRun("run-3", 100, 1)
+	store.AppendEvent("run-3", agent.SSEEvent{Type: "content", Data: agent.ContentEvent{Content: "hi"}})
+	store.FinishRun("run-3", RunStatusCompleted, "")
+
+	run, ch, unsub, err := store.SubscribeAndSnapshot("run-3")
+	if err != nil {
+		t.Fatalf("SubscribeAndSnapshot failed: %v", err)
+	}
+	if ch != nil {
+		t.Fatal("expected no live channel for a finished run")
+	}
+	if unsub != nil {
+		unsub()
+	}
+	if run.Status != RunStatusCompleted {
+		t.Fatalf("expected status completed, got %q", run.Status)
+	}
+	if len(run.Events) != 1 {
+		t.Fatalf("expected 1 replayed event, got %d", len(run.Events))
+	}
+}
+
+func TestRedisRunStore_ReleasesSubscriptionAfterLastSubscriber(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	store.CreateRun("run-4", 100, 1)
+
+	_, _, unsubA, err := store.SubscribeAndSnapshot("run-4")
+	if err != nil {
+		t.Fatalf("first SubscribeAndSnapshot failed: %v", err)
+	}
+	_, _, unsubB, err := store.SubscribeAndSnapshot("run-4")
+	if err != nil {
+		t.Fatalf("second SubscribeAndSnapshot failed: %v", err)
+	}
+
+	store.mu.RLock()
+	sub := store.subscriptions["run-4"]
+	store.mu.RUnlock()
+	if sub == nil {
+		t.Fatal("expected a shared subscription for the run")
+	}
+
+	unsubA()
+	store.mu.RLock()
+	stillOpen := store.subscriptions["run-4"] != nil
+	store.mu.RUnlock()
+	if !stillOpen {
+		t.Fatal("subscription torn down while a subscriber was still attached")
+	}
+
+	unsubB()
+	store.mu.RLock()
+	remaining := len(store.subscriptions)
+	store.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("expected the subscription to be released, got %d", remaining)
+	}
+}


### PR DESCRIPTION
## Description

`RedisRunStore` keeps its broadcasters in a plain in-process map, so run event streaming only works on the replica that started the run. On every other replica `SubscribeAndSnapshot` returns a nil channel, and `handleAgentRunEvents` replays the persisted backlog and then closes the stream while the agent is still working. With several Grafana replicas behind a load balancer that is the normal case, not an edge case. Users see "Agent run did not complete after multiple reconnection attempts".

The events themselves are already durable in Redis (`run:<id>:events` plus `run:<id>:sequence`). Only the live fan-out was missing.

### Why this looks intermittent

A run that finishes inside the client's reconnect window recovers on its own: `reconnectToAgentRun` retries 10 times a second apart, and once the run is complete `handleAgentRunEvents` serves the persisted backlog and closes with everything the client needs, no broadcaster involved. So the failure is only user-visible while the run is still in flight past roughly 11s. That is why it tracks with real LLM latency and tool-heavy questions, and why a quick local test against a fast model may not reproduce it at all.

## Video
https://github.com/user-attachments/assets/f71bbeb8-b46c-4be2-a22b-d4313a0e0a87

Two Grafana replicas against one shared Redis, behind nginx. The run-start POST goes to replica A and the SSE event stream to replica B, which is what happens behind any load balancer without session affinity. The panel on the right polls `GET /api/agent/runs/<id>` so the run record is visible next to the UI.

**Before:** all ten reconnect attempts get an empty stream (`200`, 5 bytes) and the client gives up with `Agent run did not complete after multiple reconnection attempts`. Note the run record in the same frame: still `running`. The agent is alive and working on replica A; replica B just cannot see its events.

**After:** replica A publishes to `run:<id>:channel`, replica B subscribes, and the answer arrives over the exact routing that failed on main.

The harness uses a local stub serving the OpenAI streaming shape rather than a real provider, so the run is deterministic and free. The recording asserts on the streamed answer text, and the before take additionally asserts that no LLM error is present, so what fails there is the broadcaster and not the harness.

## Changes

1. Each run gets a `run:<id>:channel` pub/sub channel. `AppendEvent` publishes every event to it and `FinishRun` publishes a terminal marker, so any replica can serve the stream.
2. Subscriptions are created on demand by `SubscribeAndSnapshot`, shared and refcounted per run, and torn down with the last local subscriber. All delivery goes through Redis, including on the replica that owns the agent loop, so there is a single path and no double delivery.
3. Subscribing happens before the snapshot is read, so no event falls in the gap. That means the live channel can carry events the snapshot already contains, so `handleAgentRunEvents` now tracks the last sequence it replayed and skips anything at or below it. Sequence numbers were already on every event. This also closes the pre-existing duplicate-event window between `Subscribe` and `GetRun`, and it covers both store implementations rather than just the Redis one.
4. Pub/sub is fire-and-forget, so the receiver re-checks the run status every 30s. A lost terminal marker can't leave a stream open forever.
5. If the subscribe itself fails, the request degrades to serving the persisted backlog instead of failing.

## Notes

Cluster mode: `PUBLISH` takes a single channel argument and is broadcast cluster-wide, so this adds no cross-slot multi-key operation and stays compatible with ElastiCache/Valkey cluster mode.

The in-memory `RunStore` fallback keeps working unchanged, so deployments without Redis behave as before.

Two things I removed while in here, both directly caused by this change:
- `GetBroadcaster` is gone from `RunStoreInterface` and both stores. It had no callers anywhere in the repo, and refcounted subscriptions changed what it would have meant on the Redis side (a broadcaster only exists while some client on this replica is attached), while the in-memory one still meant the old thing. Two implementations quietly meaning different things is how someone ends up writing `store.GetBroadcaster(id).Broadcast(ev)` and shipping a fan-out that only works on one replica.
- `RedisRunStore.CleanupOld` is now a no-op. Subscriptions are removed from the map by the release and retire paths before the broadcaster is closed, so the old sweep could never find anything. The method stays because `RunStoreInterface` requires it.

`AppendEvent` gains one round trip for the `PUBLISH`. I kept it separate from the `RPUSH` pipeline on purpose: persistence has to succeed independently of fan-out, so a publish failure warns rather than aborting the append.

Longer term the cleanest shape here is probably one source of truth instead of a log plus a pub/sub channel: `XADD`/`XREAD BLOCK` on `run:<id>:events` with the existing `event.Sequence` as the cursor would make the subscribe-vs-snapshot window impossible, make dedup fall out of the cursor, and give a persisted terminal state instead of a droppable message. I did not go there because migrating in-flight runs needs a drain window or a dual-read release. Happy to write it up as a follow-up issue if you want that on the record.

## Testing

- [x] Unit tests added. `pkg/plugin/runstore_redis_stream_test.go`: events crossing between two store instances sharing one Redis, stream close on finish, no live channel for an already-finished run, refcounted subscription teardown. `pkg/plugin/agent_run_events_test.go`: the handler emits each sequence exactly once when the live channel overlaps the snapshot, and still forwards genuinely new events.
- [x] E2E tests added/updated
- [x] `go build ./...` and `go test ./...` pass, plus `go test -race ./pkg/plugin/`
- [x] Manual testing in a live multi-replica Grafana

Worth flagging on test coverage: the Redis store tests use the existing `createTestRedisClient` helper, which skips when Redis is unreachable, and `ci.yml` has no Redis service, so those skip in CI like the other `*_redis_test.go` files. I ran them against a real Redis 7 locally. The two handler tests use a stub store and need no Redis, so they do run in CI. Adding a Redis service to the backend CI job would make this and the existing Redis test files actually run, but that felt out of scope here. Let me know if you want it in.

## Related

Fixes #204

Independent of #203, which fixes runs orphaned by a dead replica. They are separate bugs and either can land alone. Both touch `runstore_redis.go`, so whichever merges second needs a small rebase. Happy to do that rebase whenever you pick an order.

One thing that only shows up with both merged: this PR routes the 30s stream liveness check through `loadRunFromRedis`, which is where #203 hooks its staleness reconciliation. So once both are in, a viewer streaming a run whose replica died gets the terminal error pushed to them rather than having to reload. That is deliberate.


