### PR TITLE
fix(backend): fail agent runs abandoned by a dead replica

### DIFF
--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -34,6 +34,8 @@ const (
 	RunMaxAge                 = 1 * time.Hour
 	RunCleanupInterval        = 5 * time.Minute
 	RunMaxEventsPerRun        = 500
+	RunHeartbeatInterval      = 30 * time.Second
+	RunHeartbeatTTL           = 90 * time.Second
 )
 
 const (

--- a/pkg/plugin/runstore_redis.go
+++ b/pkg/plugin/runstore_redis.go
@@ -19,6 +19,7 @@ type RedisRunStore struct {
 	logger        log.Logger
 	mu            sync.RWMutex
 	subscriptions map[string]*runSubscription
+	heartbeats    map[string]context.CancelFunc
 	ctx           context.Context
 }
 
@@ -39,10 +40,14 @@ const (
 	runStreamKindFinished = "finished"
 )
 
-func runKey(runID string) string        { return fmt.Sprintf("run:%s", runID) }
-func eventsKey(runID string) string     { return fmt.Sprintf("run:%s:events", runID) }
-func sequenceKey(runID string) string   { return fmt.Sprintf("run:%s:sequence", runID) }
-func runChannelKey(runID string) string { return fmt.Sprintf("run:%s:channel", runID) }
+const runInterruptedMessage = "agent run was interrupted before it completed"
+
+func runKey(runID string) string         { return fmt.Sprintf("run:%s", runID) }
+func eventsKey(runID string) string      { return fmt.Sprintf("run:%s:events", runID) }
+func sequenceKey(runID string) string    { return fmt.Sprintf("run:%s:sequence", runID) }
+func runChannelKey(runID string) string  { return fmt.Sprintf("run:%s:channel", runID) }
+func heartbeatKey(runID string) string   { return fmt.Sprintf("run:%s:heartbeat", runID) }
+func interruptedKey(runID string) string { return fmt.Sprintf("run:%s:interrupted", runID) }
 func runIndexKey(userID, orgID int64) string {
 	return fmt.Sprintf("runs:user:%d:org:%d", userID, orgID)
 }
@@ -52,6 +57,7 @@ func NewRedisRunStore(ctx context.Context, client *redis.Client, logger log.Logg
 		client:        client,
 		logger:        logger,
 		subscriptions: make(map[string]*runSubscription),
+		heartbeats:    make(map[string]context.CancelFunc),
 		ctx:           ctx,
 	}
 }
@@ -82,13 +88,54 @@ func (s *RedisRunStore) CreateRun(runID string, userID, orgID int64, sessionID .
 	defer cancel()
 	pipe := s.client.Pipeline()
 	pipe.Set(ctx, runKey(runID), runJSON, RunMaxAge)
+	pipe.Set(ctx, heartbeatKey(runID), "1", RunHeartbeatTTL)
 	pipe.ZAdd(ctx, runIndexKey(userID, orgID), redis.Z{Score: float64(now.UnixNano()), Member: runID})
 	pipe.Expire(ctx, runIndexKey(userID, orgID), RunMaxAge)
 	if _, err := pipe.Exec(ctx); err != nil {
 		s.logger.Error("Failed to store run in Redis", "error", err, "runId", runID)
 	}
 
+	s.startHeartbeat(runID)
+
 	return run
+}
+
+func (s *RedisRunStore) startHeartbeat(runID string) {
+	ctx, cancel := context.WithCancel(s.ctx)
+
+	s.mu.Lock()
+	s.heartbeats[runID] = cancel
+	s.mu.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(RunHeartbeatInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				beatCtx, beatCancel := redisContext(ctx, RedisOpTimeout)
+				err := s.client.Set(beatCtx, heartbeatKey(runID), "1", RunHeartbeatTTL).Err()
+				beatCancel()
+				if err != nil {
+					s.logger.Warn("Failed to refresh run heartbeat", "error", err, "runId", runID)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (s *RedisRunStore) stopHeartbeat(runID string) {
+	s.mu.Lock()
+	cancel, ok := s.heartbeats[runID]
+	delete(s.heartbeats, runID)
+	s.mu.Unlock()
+
+	if ok {
+		cancel()
+	}
 }
 
 func (s *RedisRunStore) AppendEvent(runID string, event agent.SSEEvent) {
@@ -131,6 +178,8 @@ func (s *RedisRunStore) AppendEvent(runID string, event agent.SSEEvent) {
 }
 
 func (s *RedisRunStore) FinishRun(runID string, status RunStatus, errMsg string) {
+	s.stopHeartbeat(runID)
+
 	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
 	defer cancel()
 
@@ -160,6 +209,7 @@ func (s *RedisRunStore) FinishRun(runID string, status RunStatus, errMsg string)
 	defer cancel2()
 	pipe := s.client.Pipeline()
 	pipe.Set(ctx2, runKey(runID), updatedJSON, RunMaxAge)
+	pipe.Del(ctx2, heartbeatKey(runID))
 	pipe.Expire(ctx2, eventsKey(runID), RunMaxAge)
 	pipe.ZAdd(ctx2, runIndexKey(run.UserID, run.OrgID), redis.Z{Score: float64(run.UpdatedAt.UnixNano()), Member: runID})
 	pipe.Expire(ctx2, runIndexKey(run.UserID, run.OrgID), RunMaxAge)
@@ -189,6 +239,8 @@ func (s *RedisRunStore) GetRun(runID string) (*AgentRun, error) {
 		return nil, fmt.Errorf("failed to unmarshal run: %w", err)
 	}
 
+	s.reconcileStalledRun(&run)
+
 	ctx2, cancel2 := redisContext(s.ctx, RedisBulkOpTimeout)
 	defer cancel2()
 
@@ -209,6 +261,42 @@ func (s *RedisRunStore) GetRun(runID string) (*AgentRun, error) {
 	}
 
 	return &run, nil
+}
+
+func (s *RedisRunStore) reconcileStalledRun(run *AgentRun) {
+	if run.Status != RunStatusRunning {
+		return
+	}
+	if time.Since(run.UpdatedAt) < RunHeartbeatTTL {
+		return
+	}
+
+	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
+	defer cancel()
+
+	alive, err := s.client.Exists(ctx, heartbeatKey(run.RunID)).Result()
+	if err != nil {
+		s.logger.Warn("Failed to check run heartbeat", "error", err, "runId", run.RunID)
+		return
+	}
+	if alive > 0 {
+		return
+	}
+
+	claimed, err := s.client.SetNX(ctx, interruptedKey(run.RunID), "1", RunMaxAge).Result()
+	if err != nil {
+		s.logger.Warn("Failed to claim interrupted run", "error", err, "runId", run.RunID)
+		return
+	}
+	if claimed {
+		s.logger.Warn("Marking abandoned agent run as failed", "runId", run.RunID)
+		errorEvent := agent.SSEEvent{Type: "error", Data: agent.ErrorEvent{Message: runInterruptedMessage}}
+		s.AppendEvent(run.RunID, errorEvent)
+		s.FinishRun(run.RunID, RunStatusFailed, runInterruptedMessage)
+	}
+
+	run.Status = RunStatusFailed
+	run.Error = runInterruptedMessage
 }
 
 func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, error) {
@@ -251,7 +339,7 @@ func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, e
 		cursor = nextCursor
 
 		for _, key := range keys {
-			if strings.Contains(key, ":events") || strings.Contains(key, ":sequence") {
+			if strings.Count(key, ":") != 1 {
 				continue
 			}
 			runJSON, err := s.client.Get(ctx, key).Result()
@@ -271,6 +359,7 @@ func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, e
 			if run.UserID != userID || run.OrgID != orgID {
 				continue
 			}
+			s.reconcileStalledRun(&run)
 			runs = append(runs, copyRun(&run))
 			s.client.ZAdd(ctx, runIndexKey(userID, orgID), redis.Z{Score: float64(run.UpdatedAt.UnixNano()), Member: run.RunID})
 		}
@@ -303,6 +392,7 @@ func (s *RedisRunStore) loadRunFromRedis(ctx context.Context, runID string) (*Ag
 		s.logger.Warn("Failed to unmarshal indexed run", "error", err, "runId", runID)
 		return nil, err
 	}
+	s.reconcileStalledRun(&run)
 	return copyRun(&run), nil
 }
 

--- a/pkg/plugin/runstore_redis.go
+++ b/pkg/plugin/runstore_redis.go
@@ -297,6 +297,9 @@ func (s *RedisRunStore) reconcileStalledRun(run *AgentRun) {
 
 	run.Status = RunStatusFailed
 	run.Error = runInterruptedMessage
+	// Callers index and sort on UpdatedAt, so leaving it stale would re-index this
+	// run behind the score FinishRun just wrote and sort it as if nothing changed.
+	run.UpdatedAt = time.Now()
 }
 
 func (s *RedisRunStore) ListRuns(userID, orgID int64, limit int) ([]*AgentRun, error) {

--- a/pkg/plugin/runstore_redis_heartbeat_test.go
+++ b/pkg/plugin/runstore_redis_heartbeat_test.go
@@ -1,0 +1,204 @@
+package plugin
+
+import (
+	"consensys-asko11y-app/pkg/agent"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
+)
+
+func seedRunningRun(t *testing.T, client *redis.Client, runID string, age time.Duration) {
+	t.Helper()
+
+	updatedAt := time.Now().Add(-age)
+	run := AgentRun{
+		RunID:     runID,
+		Status:    RunStatusRunning,
+		UserID:    100,
+		OrgID:     1,
+		CreatedAt: updatedAt,
+		UpdatedAt: updatedAt,
+		Events:    []agent.SSEEvent{},
+		Trace:     &AgentRunTrace{},
+	}
+	payload, err := json.Marshal(run)
+	if err != nil {
+		t.Fatalf("failed to marshal seeded run: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := client.Set(ctx, runKey(runID), payload, RunMaxAge).Err(); err != nil {
+		t.Fatalf("failed to seed run: %v", err)
+	}
+	if err := client.ZAdd(ctx, runIndexKey(100, 1), redis.Z{Score: float64(updatedAt.UnixNano()), Member: runID}).Err(); err != nil {
+		t.Fatalf("failed to index seeded run: %v", err)
+	}
+}
+
+func TestRedisRunStore_CreateRunWritesHeartbeat(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	store.CreateRun("run-hb-1", 100, 1)
+
+	ttl, err := client.TTL(context.Background(), heartbeatKey("run-hb-1")).Result()
+	if err != nil {
+		t.Fatalf("TTL failed: %v", err)
+	}
+	if ttl <= 0 || ttl > RunHeartbeatTTL {
+		t.Fatalf("expected a heartbeat TTL within %s, got %s", RunHeartbeatTTL, ttl)
+	}
+}
+
+func TestRedisRunStore_FinishRunClearsHeartbeat(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	store.CreateRun("run-hb-2", 100, 1)
+	store.FinishRun("run-hb-2", RunStatusCompleted, "")
+
+	exists, err := client.Exists(context.Background(), heartbeatKey("run-hb-2")).Result()
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
+	if exists != 0 {
+		t.Fatal("expected the heartbeat to be cleared when the run finished")
+	}
+}
+
+func TestRedisRunStore_FinishRunStopsHeartbeatWhenRunIsGone(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	store.CreateRun("run-hb-3", 100, 1)
+	if err := client.Del(context.Background(), runKey("run-hb-3")).Err(); err != nil {
+		t.Fatalf("failed to drop the run key: %v", err)
+	}
+
+	store.FinishRun("run-hb-3", RunStatusCompleted, "")
+
+	store.mu.RLock()
+	remaining := len(store.heartbeats)
+	store.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("expected the heartbeat refresher to stop even when the run could not be loaded, got %d", remaining)
+	}
+}
+
+func TestRedisRunStore_GetRunFailsAbandonedRun(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-orphan", 2*RunHeartbeatTTL)
+
+	run, err := store.GetRun("run-orphan")
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if run.Status != RunStatusFailed {
+		t.Fatalf("expected status failed, got %q", run.Status)
+	}
+	if run.Error != runInterruptedMessage {
+		t.Fatalf("expected the interrupted message, got %q", run.Error)
+	}
+	if len(run.Events) != 1 || run.Events[0].Type != "error" {
+		t.Fatalf("expected a single terminal error event, got %+v", run.Events)
+	}
+
+	stored, err := store.GetRun("run-orphan")
+	if err != nil {
+		t.Fatalf("second GetRun failed: %v", err)
+	}
+	if stored.Status != RunStatusFailed {
+		t.Fatalf("expected the failure to be persisted, got %q", stored.Status)
+	}
+	if len(stored.Events) != 1 {
+		t.Fatalf("expected the error event to be appended once, got %d", len(stored.Events))
+	}
+}
+
+func TestRedisRunStore_GetRunKeepsHeartbeatingRunRunning(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-slow", 2*RunHeartbeatTTL)
+	if err := client.Set(context.Background(), heartbeatKey("run-slow"), "1", RunHeartbeatTTL).Err(); err != nil {
+		t.Fatalf("failed to seed heartbeat: %v", err)
+	}
+
+	run, err := store.GetRun("run-slow")
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if run.Status != RunStatusRunning {
+		t.Fatalf("a heartbeating run must stay running, got %q", run.Status)
+	}
+}
+
+func TestRedisRunStore_GetRunKeepsRecentRunRunning(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-fresh", time.Second)
+
+	run, err := store.GetRun("run-fresh")
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if run.Status != RunStatusRunning {
+		t.Fatalf("a recently updated run must stay running, got %q", run.Status)
+	}
+}
+
+func TestRedisRunStore_ListRunsFailsAbandonedRun(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-orphan-list", 2*RunHeartbeatTTL)
+
+	runs, err := store.ListRuns(100, 1, 10)
+	if err != nil {
+		t.Fatalf("ListRuns failed: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Status != RunStatusFailed {
+		t.Fatalf("expected status failed, got %q", runs[0].Status)
+	}
+}
+
+func TestRedisRunStore_ReconcileIsClaimedOnce(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	storeA := NewRedisRunStore(ctx, client, log.DefaultLogger)
+	storeB := NewRedisRunStore(ctx, client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-orphan-race", 2*RunHeartbeatTTL)
+
+	if _, err := storeA.GetRun("run-orphan-race"); err != nil {
+		t.Fatalf("storeA GetRun failed: %v", err)
+	}
+	runB, err := storeB.GetRun("run-orphan-race")
+	if err != nil {
+		t.Fatalf("storeB GetRun failed: %v", err)
+	}
+	if runB.Status != RunStatusFailed {
+		t.Fatalf("expected status failed on the second replica, got %q", runB.Status)
+	}
+	if len(runB.Events) != 1 {
+		t.Fatalf("expected exactly one terminal error event, got %d", len(runB.Events))
+	}
+}

--- a/pkg/plugin/runstore_redis_heartbeat_test.go
+++ b/pkg/plugin/runstore_redis_heartbeat_test.go
@@ -202,3 +202,34 @@ func TestRedisRunStore_ReconcileIsClaimedOnce(t *testing.T) {
 		t.Fatalf("expected exactly one terminal error event, got %d", len(runB.Events))
 	}
 }
+
+// ListRuns re-indexes on UpdatedAt and sorts on it, so a reconciled run has to
+// carry a fresh timestamp or it lands behind the score FinishRun wrote and is
+// returned as though nothing changed.
+func TestRedisRunStore_ReconcileRefreshesUpdatedAt(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisRunStore(context.Background(), client, log.DefaultLogger)
+	seedRunningRun(t, client, "run-updated-at", 5*time.Minute)
+
+	before := time.Now()
+	run, err := store.GetRun("run-updated-at")
+	if err != nil {
+		t.Fatalf("GetRun failed: %v", err)
+	}
+	if run.Status != RunStatusFailed {
+		t.Fatalf("expected the abandoned run to be failed, got %s", run.Status)
+	}
+	if run.UpdatedAt.Before(before) {
+		t.Fatalf("expected UpdatedAt to be refreshed at reconcile, got %s (before %s)", run.UpdatedAt, before)
+	}
+
+	score, err := client.ZScore(context.Background(), runIndexKey(100, 1), "run-updated-at").Result()
+	if err != nil {
+		t.Fatalf("ZScore failed: %v", err)
+	}
+	if int64(score) < before.UnixNano() {
+		t.Fatalf("expected the run index score to advance past %d, got %d", before.UnixNano(), int64(score))
+	}
+}


### PR DESCRIPTION
## Description

If the replica running an agent loop dies (spot reclaim, node consolidation, rollout), nothing marks the run finished. `FinishRun` is only ever called by the in-process loop, `RedisRunStore.CleanupOld` only prunes the local broadcaster map, and `GetRun` reads the stored status back verbatim with no staleness check. So the run sits `status: running` in Redis until `RunMaxAge` expires the keys an hour later, and the UI shows a run that never completes and never errors.

## Video
https://github.com/user-attachments/assets/b8d65a6b-1c17-4967-b063-4e80e2e13689

Two replicas, one shared Redis. The run executes on replica A, which is killed mid-run with `docker kill`; nginx fails the client over to replica B. The panel on the right polls `GET /api/agent/runs/<id>`, so what you are watching is the run record itself rather than the UI's own error handling.

**Before:** the run is still `running` 149s after the replica that owned it died. Nothing reconciles it, so it stays a live run in every list, for every viewer, until `RunMaxAge` expires the keys an hour later.

**After:** once the 90s heartbeat TTL lapses, the next read marks it `failed` and appends `agent run was interrupted before it completed`.

The `network error` in the chat pane is the replica being killed underneath the open stream, not the thing being demonstrated. Playback is 2x. The harness uses a local LLM stub, no real provider.

## Changes

1. The replica driving a run refreshes `run:<id>:heartbeat` every 30s with a 90s TTL. It is written at `CreateRun` and deleted at `FinishRun`. The refresher goroutine dies with the process, so an abandoned run stops heartbeating within the TTL.
2. `GetRun` and `ListRuns` reconcile on read. A run still marked running with no live heartbeat _and_ no activity for at least the heartbeat TTL is failed with a terminal `error` event appended, so reconnecting clients see a real failure instead of a stream that just stops.
3. Both conditions are required on purpose. A slow LLM call keeps heartbeating even when it isn't appending events, so it is never mistaken for an abandoned run. The two guards are ordered cheapest first, so a healthy or already-finished run costs zero extra Redis calls.
4. Reconciliation is claimed with `SETNX` on `run:<id>:interrupted`, so when several replicas notice the same orphan at once only one appends the error event and persists the status.
5. Reconcile runs before the event list is read in `GetRun`, so the error event this call appends comes back with its proper sequence number.

## Notes

Cluster mode: every new key is a single-key operation under the existing `run:<id>` prefix. No new multi-key access, so nothing changes for ElastiCache/Valkey cluster mode.

The in-memory `RunStore` is untouched. It dies with the process it belongs to, so it has no orphans to reconcile.

The `ListRuns` SCAN fallback used to identify run records by excluding known key suffixes, and my first cut just added `:heartbeat` and `:interrupted` to that list. That is a trap for the next person who adds a per-run key, so it now accepts the run record positively instead (`strings.Count(key, ":") != 1`). Run IDs come from `generateShareID`, so they are base64 RawURLEncoding and contain no colon. That is closed under any future `run:<id>:<suffix>` key.

`FinishRun` stops the heartbeat refresher as its first statement rather than partway down. It was previously after three error returns, so a Redis hiccup on the finish path would leak the ticker goroutine and keep refreshing the heartbeat for a run that was already over, which would also have blocked that run from ever being reconciled. Stopping first also means a finish we could not persist still gets reconciled to failed within the TTL, which is the outcome you want.

90s is a guess at a sane default. If you'd rather have it configurable via `PluginSettings` instead of a const, say so and I'll move it.

## Testing

- [x] Unit tests added (`pkg/plugin/runstore_redis_heartbeat_test.go`): heartbeat written on create and cleared on finish, the refresher stopped even when the run record is gone, an abandoned run failed on `GetRun` and on `ListRuns`, a heartbeating run left running, a recently updated run left running, and the error event appended exactly once across two replicas.
- [x] E2E tests added/updated
- [x] `go build ./...` and `go test ./...` pass, plus `go test -race ./pkg/plugin/`
- [x] Manual testing against a real pod eviction

Same caveat as #202: these tests use the existing `createTestRedisClient` helper and skip when Redis is unreachable, and `ci.yml` has no Redis service, so they skip in CI like the other `*_redis_test.go` files. Ran them against a real Redis 7 locally.

## Related

Fixes #205

Independent of #202, which fixes live event fan-out across replicas. They are separate bugs and either can land alone. Both touch `runstore_redis.go`, so whichever merges second needs a small rebase. Happy to do that rebase whenever you pick an order.

Two small consolidations worth doing once both are in, not worth doing blind now: #202 gives `loadRunFromRedis` an error return and routes the stream liveness check through it, which would let the reconcile hook here collapse from three call sites to one. And the liveness check could then probe `EXISTS run:<id>:heartbeat` instead of loading and unmarshalling the whole run record to read one status field.


