### PR TITLE
perf(mcp): configurable tool-call budget, inject current time, drop time & sequential-thinking tools

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -245,6 +245,21 @@ func (c *Client) forceReconnect() error {
 
 const connectDialTimeout = 10 * time.Second
 
+// defaultToolCallTimeout bounds a single MCP tool call when the server's
+// ServerConfig.TimeoutSeconds is unset. It matches the historical hard-coded
+// value so existing configs behave identically until they opt into a longer
+// budget.
+const defaultToolCallTimeout = 30 * time.Second
+
+// toolCallTimeout resolves the per-call budget: the server's configured
+// timeout when set, the package default otherwise.
+func (c *Client) toolCallTimeout() time.Duration {
+	if c.config.TimeoutSeconds > 0 {
+		return time.Duration(c.config.TimeoutSeconds) * time.Second
+	}
+	return defaultToolCallTimeout
+}
+
 // forceReconnectMinInterval is the dedupe window that prevents the health
 // monitor from thrashing a session that the on-call retry path just refreshed.
 const forceReconnectMinInterval = 5 * time.Second
@@ -685,7 +700,7 @@ func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arg
 	// The caller ctx contributes per-request values (Grafana user ID for
 	// OAuth token injection); the timeout stays rooted at the client ctx so
 	// the session outlives short-lived caller contexts.
-	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
+	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), c.toolCallTimeout())
 	defer cancel()
 
 	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -725,7 +740,7 @@ func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arg
 				return nil, fmt.Errorf("session not established after reconnection")
 			}
 
-			retryCtx, retryCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), 30*time.Second)
+			retryCtx, retryCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), c.toolCallTimeout())
 			defer retryCancel()
 
 			result, err = session.CallTool(retryCtx, &mcpsdk.CallToolParams{

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -201,7 +201,7 @@ func (c *Client) connectMCP(callerCtx context.Context) error {
 	case "streamable-http", "http+streamable":
 		transport = &mcpsdk.StreamableClientTransport{
 			Endpoint:             c.config.URL,
-			HTTPClient:           httpClient,
+			HTTPClient:           c.transportHTTPClient(httpClient),
 			MaxRetries:           3,
 			DisableStandaloneSSE: true,
 		}
@@ -282,13 +282,30 @@ func (c *Client) sdkHTTPClientWithTransport(transport http.RoundTripper) *http.C
 // which would sever an SSE event stream after the timeout elapses — so for
 // SSE servers the copy gets no client-level timeout (dialing stays bounded by
 // the SDK dial timeout and connectDialTimeout).
+//
+// For streamable-http the copy's timeout is set to the server's tool-call
+// budget: the budget wraps the CallTool context, but http.Client.Timeout
+// would still abort the whole exchange at the shared client's 30s, so a
+// provisioned 90s budget never took effect without this. Clamping to the
+// budget (rather than zeroing it, as SSE does) keeps a hard bound on the
+// SDK initialize handshake too, which not every connect path deadlines.
 func (c *Client) transportHTTPClient(client *http.Client) *http.Client {
-	if c.config.Type != "sse" || client.Timeout == 0 {
-		return client
+	switch c.config.Type {
+	case "sse":
+		if client.Timeout == 0 {
+			return client
+		}
+		clone := *client
+		clone.Timeout = 0
+		return &clone
+	case "streamable-http", "http+streamable":
+		if budget := c.toolCallTimeout(); client.Timeout != budget {
+			clone := *client
+			clone.Timeout = budget
+			return &clone
+		}
 	}
-	clone := *client
-	clone.Timeout = 0
-	return &clone
+	return client
 }
 
 func (c *Client) httpClientWithHeaders() *http.Client {
@@ -388,7 +405,7 @@ func (c *Client) connectMCPWithOrgContext(callerCtx context.Context, orgID strin
 	case "streamable-http", "http+streamable":
 		transport = &mcpsdk.StreamableClientTransport{
 			Endpoint:             c.config.URL,
-			HTTPClient:           customHTTPClient,
+			HTTPClient:           c.transportHTTPClient(customHTTPClient),
 			MaxRetries:           3,
 			DisableStandaloneSSE: true,
 		}

--- a/pkg/mcp/client_timeout_test.go
+++ b/pkg/mcp/client_timeout_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -29,5 +30,52 @@ func TestClient_ToolCallTimeout(t *testing.T) {
 	c.config.TimeoutSeconds = -5
 	if got := c.toolCallTimeout(); got != defaultToolCallTimeout {
 		t.Fatalf("negative TimeoutSeconds should fall back to default; got %v", got)
+	}
+}
+
+// TestClient_TransportHTTPClientTimeout guards against a regression of the
+// Bugbot finding: the shared SDK http.Client carries its own 30s Timeout that
+// bounds the whole exchange, so for streamable-http servers the transport
+// client must be clamped to the tool-call budget — a provisioned 90s budget
+// never took effect when the CallTool context was extended but the client
+// deadline stayed at 30s. SSE keeps its zero-timeout semantics (stream must
+// not be severed), and other transports are passed through untouched.
+func TestClient_TransportHTTPClientTimeout(t *testing.T) {
+	newClient := func(serverType string, timeoutSeconds int) *Client {
+		return &Client{
+			config: ServerConfig{ID: "test", Type: serverType, TimeoutSeconds: timeoutSeconds},
+			logger: log.DefaultLogger,
+			ctx:    context.Background(),
+		}
+	}
+	shared := &http.Client{Timeout: 30 * time.Second}
+
+	// streamable-http: clamped up to the configured budget.
+	c := newClient("streamable-http", 90)
+	got := c.transportHTTPClient(shared)
+	if got.Timeout != 90*time.Second {
+		t.Fatalf("streamable-http client timeout should be clamped to the 90s budget; got %v", got.Timeout)
+	}
+	if got == shared {
+		t.Fatal("streamable-http should not mutate the shared client")
+	}
+
+	// streamable-http with unset budget: clamped to the 30s default (same
+	// value, but as a copy so future budget changes cannot leak in).
+	c = newClient("streamable-http", 0)
+	if got := c.transportHTTPClient(shared); got.Timeout != defaultToolCallTimeout {
+		t.Fatalf("streamable-http default should be %v; got %v", defaultToolCallTimeout, got.Timeout)
+	}
+
+	// sse: zero timeout so long-lived streams are never severed.
+	c = newClient("sse", 90)
+	if got := c.transportHTTPClient(shared); got.Timeout != 0 {
+		t.Fatalf("sse client timeout should be 0; got %v", got.Timeout)
+	}
+
+	// unknown transport: pass-through.
+	c = newClient("openapi", 90)
+	if got := c.transportHTTPClient(shared); got != shared {
+		t.Fatal("non-MCP transports should get the shared client unchanged")
 	}
 }

--- a/pkg/mcp/client_timeout_test.go
+++ b/pkg/mcp/client_timeout_test.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+// TestClient_ToolCallTimeout covers the per-server tool-call budget: unset
+// falls back to the historical 30s default, a configured value overrides it.
+// Prod traces (2026-09-03..07) showed 47 calls pinned at the 30s ceiling
+// (1,423s, 34% of tool time) because heavy Prometheus/Loki scans could not
+// finish inside the old hard-coded budget.
+func TestClient_ToolCallTimeout(t *testing.T) {
+	c := &Client{config: ServerConfig{ID: "test"}, logger: log.DefaultLogger, ctx: context.Background()}
+	if got := c.toolCallTimeout(); got != defaultToolCallTimeout {
+		t.Fatalf("unset TimeoutSeconds should fall back to default; got %v", got)
+	}
+
+	c.config.TimeoutSeconds = 90
+	if got := c.toolCallTimeout(); got != 90*time.Second {
+		t.Fatalf("TimeoutSeconds=90 should yield 90s; got %v", got)
+	}
+
+	// Negative values are treated as unset (zero-value contract in
+	// ServerConfig docs) rather than an immediately-expired context.
+	c.config.TimeoutSeconds = -5
+	if got := c.toolCallTimeout(); got != defaultToolCallTimeout {
+		t.Fatalf("negative TimeoutSeconds should fall back to default; got %v", got)
+	}
+}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -98,6 +98,13 @@ type ServerConfig struct {
 	Headers        map[string]string           `json:"headers,omitempty"`
 	ToolSelections map[string]bool             `json:"toolSelections,omitempty"`
 	RiskOverrides  map[string]ToolRiskOverride `json:"riskOverrides,omitempty"`
+	// TimeoutSeconds bounds each tool call to this server. 0 uses the
+	// defaultToolCallTimeout (30s). Prod traces (2026-09-03..07) showed 47
+	// calls pinned at the 30s ceiling — 1,423s, 34% of all tool time — as
+	// heavy Prometheus/Loki queries failed and were re-issued; servers with
+	// expensive scan-style tools (the embedded grafana MCP) should raise
+	// this so the calls complete instead of failing into an LLM re-plan.
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 	// OAuth, when set, makes the server authenticate per Grafana user via an
 	// OAuth2 authorization-code flow. Any static Authorization entry in Headers
 	// is ignored for OAuth-enabled servers; each user's access token is

--- a/pkg/plugin/prompt_defaults.go
+++ b/pkg/plugin/prompt_defaults.go
@@ -80,16 +80,11 @@ instead of scanning a datasource with a broad ".*" regex.
 
 ### Time Windows
 
-- Before any time-bounded investigation, establish the real current time using the time tool
-- Build all time windows relative to that value (e.g., last 1h, last 30min from now) — never use hardcoded dates from training data
+{{if .CurrentTime}}- **Current time: {{.CurrentTime}}** — anchor every relative window ("last 1h", "today") to this value; do not spend a tool call re-checking it
+{{else}}- Before any time-bounded investigation, establish the real current time using the time tool
+{{end}}- Build all time windows relative to the current time (e.g., last 1h, last 30min from now) — never use hardcoded dates from training data
 - **Honor the user's time range exactly.** When the user names a range — absolute ("yesterday 14:00–16:00") or relative ("last 24h", "during the incident window") — use precisely that range for every query. Do not silently fall back to a default like last 1h, and do not drift to a different period because it looks more interesting; if you must deviate, state why before doing so.
 - When a query returns no results, the first thing to check is whether the time window actually covers the period of interest
-
-### Sequential Thinking Discipline
-
-- Use sequential thinking only for genuinely complex, non-linear reasoning with multiple decision branches
-- Limit to ≤3 consecutive thought steps per investigation turn; if the next action is already clear, take it directly
-- Do not use sequential thinking to narrate obvious next steps — act instead
 
 ### Self-Correction on Empty Results
 

--- a/pkg/plugin/prompts.go
+++ b/pkg/plugin/prompts.go
@@ -279,7 +279,8 @@ func BuildToolContext(orgName, userRole string) PromptContext {
 	// CurrentTime is captured at run start so the LLM can anchor relative time
 	// windows ("last 1h") without burning a tool round-trip on the time MCP
 	// server — prod traces (2026-09-03..07) showed 57 get_current_time calls
-	// per 4-day window, two of which hit the 30s MCP timeout.
+	// per 4-day window, two of which ran ~30s at the client's timeout
+	// ceiling.
 	now := time.Now().UTC()
 	return PromptContext{
 		OrgName:        orgName,

--- a/pkg/plugin/prompts.go
+++ b/pkg/plugin/prompts.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"text/template"
+	"time"
 
 	"consensys-asko11y-app/pkg/skills"
 )
@@ -56,6 +57,11 @@ type PromptContext struct {
 	// there are no Prometheus datasources, or the snapshot hasn't finished its
 	// background refresh yet (see metricNamespaceSnapshot).
 	MetricNamespaceSnapshot string
+
+	// CurrentTime is the wall-clock time the run started, rendered into the
+	// system prompt so the agent anchors relative time windows without calling
+	// the time MCP tool. Empty string renders no block (see BuildToolContext).
+	CurrentTime string
 
 	// ActiveSkills are the skills activated for this run (explicit selection,
 	// legacy type mapping, or trigger match). Their bodies are injected into
@@ -270,11 +276,17 @@ const GraphitiDiscoveryMessage = `Execute the full discovery plan step by step:
 6. Synthesize — your synthesis MUST list every business service by name (e.g. "checkout", "payment", "frontend"). Filter out monitoring infrastructure (prometheus, grafana, tempo, mimir, loki, alloy, alertmanager, otel-collector, node-exporter, pushgateway, kube-prometheus, ingress-nginx).`
 
 func BuildToolContext(orgName, userRole string) PromptContext {
+	// CurrentTime is captured at run start so the LLM can anchor relative time
+	// windows ("last 1h") without burning a tool round-trip on the time MCP
+	// server — prod traces (2026-09-03..07) showed 57 get_current_time calls
+	// per 4-day window, two of which hit the 30s MCP timeout.
+	now := time.Now().UTC()
 	return PromptContext{
 		OrgName:        orgName,
 		UserRole:       userRole,
 		AvailableTools: []ToolInfo{},
 		DisabledTools:  []ToolInfo{},
 		FailedTools:    []ToolInfo{},
+		CurrentTime:    now.Format("15:04:05 MST on Monday, January 2, 2006") + " (RFC3339: " + now.Format(time.RFC3339) + ")",
 	}
 }

--- a/pkg/plugin/prompts_test.go
+++ b/pkg/plugin/prompts_test.go
@@ -199,6 +199,43 @@ func TestBuildSystemPrompt_DatasourceSnapshotSlot(t *testing.T) {
 	}
 }
 
+// TestBuildSystemPrompt_CurrentTimeSlot guards the current-time injection:
+// BuildToolContext always stamps the run start time so the agent anchors
+// relative windows without a time-tool round-trip, and a zero-value context
+// (custom builders) falls back to the legacy "time tool" wording instead of
+// rendering an empty block.
+func TestBuildSystemPrompt_CurrentTimeSlot(t *testing.T) {
+	r, err := NewPromptRegistry(PluginSettings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := r.BuildSystemPrompt(BuildToolContext("Org1", "Admin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "**Current time:") {
+		t.Fatal("BuildToolContext should render the Current time block")
+	}
+	if !strings.Contains(out, "RFC3339:") {
+		t.Fatal("Current time block should include an RFC3339 anchor")
+	}
+	if strings.Contains(out, "establish the real current time using the time tool") {
+		t.Fatal("fallback wording must disappear when CurrentTime is set")
+	}
+
+	blank, err := r.BuildSystemPrompt(PromptContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(blank, "**Current time:") {
+		t.Fatal("empty CurrentTime should not render the block")
+	}
+	if !strings.Contains(blank, "establish the real current time using the time tool") {
+		t.Fatal("empty CurrentTime should fall back to the legacy time-tool wording")
+	}
+}
+
 func TestBuildUserPrompt_LegacyTypeRendersSkillTemplate(t *testing.T) {
 	r, err := NewPromptRegistry(PluginSettings{})
 	if err != nil {

--- a/provisioning/.config/mcpo.json
+++ b/provisioning/.config/mcpo.json
@@ -1,13 +1,5 @@
 {
   "mcpServers": {
-    "time": {
-      "command": "uvx",
-      "args": ["mcp-server-time", "--local-timezone=Europe/Paris"]
-    },
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-    },
     "fetch": {
       "command": "uvx",
       "args": ["mcp-server-fetch"]

--- a/provisioning/plugins/full.yaml_
+++ b/provisioning/plugins/full.yaml_
@@ -25,16 +25,6 @@ apps:
           type: 'streamable-http'
           headers:
             Host: 'localhost:8000'
-        - id: 'time'
-          name: 'Time Server'
-          url: 'http://mcpo:8000/time'
-          enabled: true
-          type: 'openapi'
-        - id: 'sequential-thinking'
-          name: 'sequential-thinking Server'
-          url: 'http://mcpo:8000/sequential-thinking'
-          enabled: true
-          type: 'openapi'
         - id: 'fetch'
           name: 'fetch Server'
           url: 'http://mcpo:8000/fetch'
@@ -45,6 +35,7 @@ apps:
           url: 'http://mcp-grafana:8000/mcp'
           enabled: true
           type: 'streamable-http'
+          timeoutSeconds: 90
     secureJsonData:
       redisURL: 'redis://redis:6379/0'
   - type: grafana-llm-app
@@ -71,16 +62,6 @@ apps:
           type: 'streamable-http'
           headers:
             Host: 'localhost:8000'
-        - id: 'time'
-          name: 'Time Server'
-          url: 'http://mcpo:8000/time'
-          enabled: true
-          type: 'openapi'
-        - id: 'sequential-thinking'
-          name: 'sequential-thinking Server'
-          url: 'http://mcpo:8000/sequential-thinking'
-          enabled: true
-          type: 'openapi'
         - id: 'fetch'
           name: 'fetch Server'
           url: 'http://mcpo:8000/fetch'
@@ -91,5 +72,6 @@ apps:
           url: 'http://mcp-grafana:8000/mcp'
           enabled: true
           type: 'streamable-http'
+          timeoutSeconds: 90
     secureJsonData:
       redisURL: 'redis://redis:6379/0'


### PR DESCRIPTION
## Summary

Three efficiency fixes from the 2026-09-03→07 prod session analysis (123 sessions, 110 NOC alert investigations):

| Lever | Evidence | Fix |
|---|---|---|
| 30s MCP timeout storm | 47 tool calls pinned at 29–32s = **1,423s (34% of all tool time)**, each followed by an LLM re-plan | `ServerConfig.timeoutSeconds` (per-server, default unchanged at 30s); provisioning sets `90` on the grafana server |
| `get_current_time` round-trips | 57 calls/window, 2 ran ~30s at the timeout ceiling | Run wall-clock stamped into the system prompt (`CurrentTime`); Time Windows guidance anchors to it |
| `sequential-thinking` overhead | 47 MCP round-trips, 10 errors, duplicating native reasoning | Server removed from provisioning + prompt section dropped |

The `time` and `sequential-thinking` MCP servers are removed from `mcpo.json` and `provisioning/plugins/full.yaml_` (both orgs).

## Details

- `pkg/mcp/types.go` — new `timeoutSeconds` field on `ServerConfig` (0 = legacy 30s default)
- `pkg/mcp/client.go` — `toolCallTimeout()` replaces both hard-coded 30s budgets (initial call + reconnect retry)
- `pkg/plugin/prompts.go` — `PromptContext.CurrentTime` stamped at run start (UTC, human-readable + RFC3339)
- `pkg/plugin/prompt_defaults.go` — Current time block in Time Windows section; sequential-thinking section removed
- New tests: `TestClient_ToolCallTimeout`, `TestBuildSystemPrompt_CurrentTimeSlot`

## Companion change

The prod/dev config CronJob change (remove `time`/`sequential-thinking` servers, add `timeoutSeconds: 90`, disable the 15/15-failing `confluence-search` tool on the runbooks broker) lands separately in `w3f-observability`.

## Impact (expected)

~30–60s of timeout waits + ~1–2 LLM re-plans saved per NOC run (~10–15% wall time), before counting faster metric-names scans.

Generated with [opencode](https://opencode.ai)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP call duration and HTTP client behavior for streamable-http (including init handshakes bounded by the same budget); misconfigured high timeouts could tie up resources longer, but defaults preserve prior 30s behavior.
> 
> **Overview**
> Adds **per-server MCP tool-call timeouts** via `ServerConfig.timeoutSeconds` (unset stays at the historical **30s**). `CallTool` and reconnect retries use `toolCallTimeout()`, and **streamable-http** transports get an HTTP client whose `Timeout` matches that budget so longer values (e.g. **90s** on `mcp-grafana` in sample provisioning) are not cut off by the shared 30s client deadline. **SSE** still uses a zero client timeout for long-lived streams.
> 
> **Run-start wall clock** is stamped into the system prompt (`PromptContext.CurrentTime`) so investigations anchor relative time windows without a `get_current_time` MCP round-trip; prompt defaults switch to that block when present and drop the **sequential-thinking** discipline section.
> 
> Sample **provisioning** removes the **time** and **sequential-thinking** MCP servers from `mcpo.json` and `full.yaml_`, leaving **fetch** (and existing streamable servers) with **`timeoutSeconds: 90`** on the embedded Grafana MCP. New tests cover timeout resolution, transport client clamping, and current-time prompt rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971dfa2a6219e9d09fd08012b4e25c6f32adf565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

