### PR TITLE
feat(mcp): propagate W3C trace context on outgoing MCP requests

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -273,7 +273,7 @@ func (c *Client) baseTransport() http.RoundTripper {
 
 func (c *Client) sdkHTTPClientWithTransport(transport http.RoundTripper) *http.Client {
 	client := *c.httpClient
-	client.Transport = transport
+	client.Transport = &tracePropagationTransport{base: transport}
 	return &client
 }
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -716,8 +716,11 @@ func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arg
 
 	// The caller ctx contributes per-request values (Grafana user ID for
 	// OAuth token injection); the timeout stays rooted at the client ctx so
-	// the session outlives short-lived caller contexts.
-	ctx, cancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), c.toolCallTimeout())
+	// the session outlives short-lived caller contexts. mergeUserCtx copies
+	// only known values, dropping the caller's active span (mcp_tool_call) —
+	// re-attach it explicitly so trace propagation can parent the MCP
+	// server's span onto the caller's trace.
+	ctx, cancel := context.WithTimeout(withCallerSpan(mergeUserCtx(c.ctx, callerCtx), callerCtx), c.toolCallTimeout())
 	defer cancel()
 
 	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -757,7 +760,7 @@ func (c *Client) callMCPToolOnce(callerCtx context.Context, toolName string, arg
 				return nil, fmt.Errorf("session not established after reconnection")
 			}
 
-			retryCtx, retryCancel := context.WithTimeout(mergeUserCtx(c.ctx, callerCtx), c.toolCallTimeout())
+			retryCtx, retryCancel := context.WithTimeout(withCallerSpan(mergeUserCtx(c.ctx, callerCtx), callerCtx), c.toolCallTimeout())
 			defer retryCancel()
 
 			result, err = session.CallTool(retryCtx, &mcpsdk.CallToolParams{

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // PerUserTokenProvider supplies the Authorization bearer value for a given
@@ -45,6 +47,17 @@ func mergeUserCtx(base, caller context.Context) context.Context {
 		return WithUserID(base, userID)
 	}
 	return base
+}
+
+// withCallerSpan re-attaches the caller's active span onto a context rebuilt
+// by mergeUserCtx, which copies only known values and would otherwise drop
+// it. Trace propagation then parents the MCP server's span onto the
+// caller's trace instead of rooting a disjoint one.
+func withCallerSpan(ctx, caller context.Context) context.Context {
+	if sc := trace.SpanContextFromContext(caller); sc.IsValid() {
+		return WithCallerSpanContext(ctx, sc)
+	}
+	return ctx
 }
 
 // userTokenRoundTripper wraps an http.RoundTripper for servers with an OAuth

--- a/pkg/mcp/trace_propagation.go
+++ b/pkg/mcp/trace_propagation.go
@@ -1,10 +1,31 @@
 package mcp
 
 import (
+	"context"
 	"net/http"
 
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// callerSpanContextKey carries the caller's SpanContext across mergeUserCtx,
+// which rebuilds the tool-call context from the long-lived client context and
+// copies only the user identity — dropping the caller's active span. Without
+// this, the outgoing MCP request would have no span to propagate from.
+type callerSpanContextKey struct{}
+
+// WithCallerSpanContext attaches the caller's SpanContext to ctx so
+// tracePropagationTransport can inject it after the context merge.
+func WithCallerSpanContext(ctx context.Context, sc trace.SpanContext) context.Context {
+	return context.WithValue(ctx, callerSpanContextKey{}, sc)
+}
+
+// callerSpanContextFromContext returns the caller SpanContext stashed by
+// WithCallerSpanContext, if valid.
+func callerSpanContextFromContext(ctx context.Context) (trace.SpanContext, bool) {
+	sc, ok := ctx.Value(callerSpanContextKey{}).(trace.SpanContext)
+	return sc, ok && sc.IsValid()
+}
 
 // tracePropagationTransport injects W3C trace context (traceparent/tracestate)
 // from the request's span context into outgoing MCP requests.
@@ -30,6 +51,18 @@ type tracePropagationTransport struct {
 var w3cPropagator = propagation.TraceContext{}
 
 func (t *tracePropagationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	w3cPropagator.Inject(req.Context(), propagation.HeaderCarrier(req.Header))
-	return t.base.RoundTrip(req)
+	ctx := req.Context()
+	if sc, ok := callerSpanContextFromContext(ctx); ok {
+		// Preferred path: the caller's span stashed across mergeUserCtx.
+		ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
+	} else if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		// Fallback: contexts that were never rebuilt by mergeUserCtx carry
+		// their span directly.
+		ctx = trace.ContextWithSpanContext(ctx, sc)
+	}
+	// http.RoundTripper must not mutate the caller's request: clone with the
+	// (possibly span-enriched) context and inject into the copy.
+	clone := req.Clone(ctx)
+	w3cPropagator.Inject(clone.Context(), propagation.HeaderCarrier(clone.Header))
+	return t.base.RoundTrip(clone)
 }

--- a/pkg/mcp/trace_propagation.go
+++ b/pkg/mcp/trace_propagation.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// tracePropagationTransport injects W3C trace context (traceparent/tracestate)
+// from the request's span context into outgoing MCP requests.
+//
+// mcp-grafana reads an inbound traceparent header and parents its server span
+// onto it, so asko11y's mcp_tool_call span, mcp-grafana's /mcp span, and the
+// Grafana-core spans below it form one connected trace in Tempo. Without the
+// injection each hop rooted its own trace and the tool-call could only be
+// corroborated by correlating wall-clock windows across three disjoint
+// traces.
+//
+// The W3C propagator is used directly instead of otel.GetTextMapPropagator():
+// the global is replaced with an inert value by an SDK init in the plugin's
+// import graph (verified by test: direct injection works where the global
+// injects nothing), and mcp-grafana speaks W3C exclusively.
+//
+// Injection is a no-op when the request context carries no span, and extra
+// headers are ignored by receivers that don't propagate.
+type tracePropagationTransport struct {
+	base http.RoundTripper
+}
+
+var w3cPropagator = propagation.TraceContext{}
+
+func (t *tracePropagationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	w3cPropagator.Inject(req.Context(), propagation.HeaderCarrier(req.Header))
+	return t.base.RoundTrip(req)
+}

--- a/pkg/mcp/trace_propagation_test.go
+++ b/pkg/mcp/trace_propagation_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// TestTracePropagationTransport_InjectsTraceparent verifies that a request
+// made inside an active span carries a W3C traceparent header whose span ID
+// is that span — mcp-grafana parents its server span onto it, stitching
+// asko11y -> mcp-grafana -> Grafana core into one trace.
+func TestTracePropagationTransport_InjectsTraceparent(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "mcp_tool_call")
+	defer span.End()
+
+	var got http.Header
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Clone()
+		return &http.Response{StatusCode: 200, Header: http.Header{}, Body: http.NoBody}, nil
+	})
+
+	req := (&http.Request{Method: "POST", Header: http.Header{}}).WithContext(ctx)
+	resp, err := (&tracePropagationTransport{base: base}).RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpHeader := got.Get("Traceparent")
+	if tpHeader == "" {
+		t.Fatal("expected traceparent header to be injected")
+	}
+	parts := strings.Split(tpHeader, "-")
+	if len(parts) != 4 || parts[0] != "00" {
+		t.Fatalf("malformed traceparent %q", tpHeader)
+	}
+	if parts[2] != span.SpanContext().SpanID().String() {
+		t.Fatalf("traceparent span ID %s should match the active span %s", parts[2], span.SpanContext().SpanID().String())
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+}
+
+// TestTracePropagationTransport_NoSpan makes sure a span-less context is not
+// polluted with a fake traceparent — receivers must keep rooting their own
+// traces in that case.
+func TestTracePropagationTransport_NoSpan(t *testing.T) {
+	var got http.Header
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Clone()
+		return &http.Response{StatusCode: 200, Header: http.Header{}, Body: http.NoBody}, nil
+	})
+
+	req := (&http.Request{Method: "POST", Header: http.Header{}}).WithContext(context.Background())
+	if _, err := (&tracePropagationTransport{base: base}).RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+	if got.Get("Traceparent") != "" {
+		t.Fatal("no active span: traceparent must not be injected")
+	}
+}

--- a/pkg/mcp/trace_propagation_test.go
+++ b/pkg/mcp/trace_propagation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -62,10 +63,60 @@ func TestTracePropagationTransport_NoSpan(t *testing.T) {
 	})
 
 	req := (&http.Request{Method: "POST", Header: http.Header{}}).WithContext(context.Background())
-	if _, err := (&tracePropagationTransport{base: base}).RoundTrip(req); err != nil {
+	resp, err := (&tracePropagationTransport{base: base}).RoundTrip(req)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if got.Get("Traceparent") != "" {
 		t.Fatal("no active span: traceparent must not be injected")
+	}
+	if resp != nil && resp.Request != nil && resp.Request != req && resp.Request.Header.Get("Traceparent") != "" {
+		// resp.Request is set by the http.Client layer, not raw transports —
+		// nothing to assert here; kept as a guard against accidental mutation.
+		t.Fatal("caller request must not be mutated")
+	}
+	if req.Header.Get("Traceparent") != "" {
+		t.Fatal("RoundTrip must not mutate the caller's request headers")
+	}
+}
+
+// TestTracePropagationTransport_MergedContextCallerSpan regression-covers the
+// Bugbot finding: CallTool rebuilds its context via mergeUserCtx, which
+// copies only the user ID and drops the caller's active span. The caller's
+// SpanContext must travel via WithCallerSpanContext and the injected
+// traceparent must reference it.
+func TestTracePropagationTransport_MergedContextCallerSpan(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	callerCtx, callerSpan := tp.Tracer("test").Start(context.Background(), "mcp_tool_call")
+	defer callerSpan.End()
+
+	// Simulate mergeUserCtx: brand-new context carrying only a user value.
+	merged := context.Background()
+	if !trace.SpanContextFromContext(merged).IsValid() && trace.SpanContextFromContext(callerCtx).IsValid() {
+		merged = WithCallerSpanContext(merged, trace.SpanContextFromContext(callerCtx))
+	}
+
+	var got http.Header
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Clone()
+		return &http.Response{StatusCode: 200, Header: http.Header{}, Body: http.NoBody}, nil
+	})
+
+	req := (&http.Request{Method: "POST", Header: http.Header{}}).WithContext(merged)
+	if _, err := (&tracePropagationTransport{base: base}).RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+	tpHeader := got.Get("Traceparent")
+	if tpHeader == "" {
+		t.Fatal("caller span stashed via WithCallerSpanContext must be injected even after the context merge")
+	}
+	parts := strings.Split(tpHeader, "-")
+	if len(parts) != 4 {
+		t.Fatalf("malformed traceparent %q", tpHeader)
+	}
+	if parts[2] != callerSpan.SpanContext().SpanID().String() {
+		t.Fatalf("traceparent %q should reference the caller span %s", tpHeader, callerSpan.SpanContext().SpanID())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #209, needed for the mcp-grafana OTel tracing deployed via w3f-observability#635.

**Verified live in prod:** mcp-grafana v1.0.0 with `OTEL_EXPORTER_OTLP_ENDPOINT` is exporting correctly — 100 `/mcp`-rooted traces landed in Tempo within the first hour. But each tool call is a **disjoint trace**: the MCP transports never injected a `traceparent` header, so mcp-grafana (which parents onto inbound W3C context) could not join the asko11y `mcp_tool_call` span. Correlating a tool call meant matching wall-clock windows across three separate traces.

## Fix

`sdkHTTPClientWithTransport` (used by both connect paths) now wraps the MCP client chain with a transport that injects `traceparent` from the active span — stitching `asko11y mcp_tool_call` → `mcp-grafana /mcp` → `Grafana core` into one trace.

## Note

- The W3C propagator is used **directly** instead of `otel.GetTextMapPropagator()`: the otel global propagator is inert in this import graph (an SDK init replaces it before Grafana core configures it — verified by test; direct injection works where the global injects nothing).
- Injection is a no-op without an active span; receivers that don't propagate ignore the extra headers.
- Tests: `TestTracePropagationTransport_InjectsTraceparent`, `TestTracePropagationTransport_NoSpan`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only HTTP header injection on the MCP client path; behavior is a no-op without an active span and does not change auth or tool semantics.
> 
> **Overview**
> Outgoing MCP HTTP traffic now carries **W3C `traceparent`** so mcp-grafana can parent its `/mcp` span onto asko11y's **`mcp_tool_call`** trace instead of starting a separate trace in Tempo.
> 
> **`tracePropagationTransport`** wraps the SDK client's transport chain and injects trace context with a direct **`propagation.TraceContext`** propagator (not the global OTel propagator, which is inert in this plugin's import graph). Requests are cloned before injection so caller headers are not mutated; injection is skipped when no span is present.
> 
> **`CallTool`** rebuilds context via **`mergeUserCtx`**, which previously dropped the caller's active span. **`withCallerSpan`** re-stashes the caller **`SpanContext`** (via **`WithCallerSpanContext`**) on the merged timeout context for both the initial call and the reconnect retry, so the transport can still inject the right parent.
> 
> Tests cover successful **`traceparent`** injection, no injection without a span, and the post-**`mergeUserCtx`** caller-span regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc36f8b4510db17c17610eae3b45ee99d4fc1bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->