### PR TITLE
fix(mcp): keep the sdk tracing middleware mid-chain via context enrichment

### DIFF
--- a/pkg/mcp/trace_propagation.go
+++ b/pkg/mcp/trace_propagation.go
@@ -52,17 +52,28 @@ var w3cPropagator = propagation.TraceContext{}
 
 func (t *tracePropagationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
-	if sc, ok := callerSpanContextFromContext(ctx); ok {
+	switch sc, hasStash := callerSpanContextFromContext(ctx); {
+	case hasStash:
 		// Preferred path: the caller's span stashed across mergeUserCtx.
+		// Enrich the CONTEXT (not just the headers): the grafana-sdk tracing
+		// middleware deeper in this chain then starts its
+		// "HTTP Outgoing Request" span as a child of the caller span and
+		// propagates from it, keeping the middleware in the middle of
+		// asko11y -> mcp-grafana -> Grafana core instead of re-rooting.
 		ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
-	} else if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+	case trace.SpanContextFromContext(ctx).IsValid():
 		// Fallback: contexts that were never rebuilt by mergeUserCtx carry
 		// their span directly.
-		ctx = trace.ContextWithSpanContext(ctx, sc)
+		ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
+	default:
+		// Nothing to propagate — pass the request through untouched so
+		// receivers keep rooting their own traces.
+		return t.base.RoundTrip(req)
 	}
-	// http.RoundTripper must not mutate the caller's request: clone with the
-	// (possibly span-enriched) context and inject into the copy.
+	// Clone: http.RoundTripper must not mutate the caller's request.
 	clone := req.Clone(ctx)
+	// Direct injection as a fallback for chains whose inner middleware does
+	// not propagate: an inner traceparent (if any) overwrites this one.
 	w3cPropagator.Inject(clone.Context(), propagation.HeaderCarrier(clone.Header))
 	return t.base.RoundTrip(clone)
 }

--- a/pkg/mcp/trace_propagation_test.go
+++ b/pkg/mcp/trace_propagation_test.go
@@ -120,3 +120,42 @@ func TestTracePropagationTransport_MergedContextCallerSpan(t *testing.T) {
 		t.Fatalf("traceparent %q should reference the caller span %s", tpHeader, callerSpan.SpanContext().SpanID())
 	}
 }
+
+// TestTracePropagationTransport_EnrichesContextForInnerMiddleware asserts the
+// full-chain behavior: the transport hands the INNER middleware a context
+// whose active span is the caller's (as a remote parent), so the middleware's
+// own "HTTP Outgoing Request" span becomes a child of mcp_tool_call and the
+// chain grafana-frontend -> agent_run -> mcp_tool_call -> HTTP Outgoing ->
+// mcp-grafana stays in one trace instead of re-rooting at the middleware.
+func TestTracePropagationTransport_EnrichesContextForInnerMiddleware(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	callerCtx, callerSpan := tp.Tracer("test").Start(context.Background(), "mcp_tool_call")
+	defer callerSpan.End()
+
+	// Merged context: no live span, only the stash (mergeUserCtx result).
+	merged := WithCallerSpanContext(context.Background(), trace.SpanContextFromContext(callerCtx))
+
+	var innerCtx context.Context
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		innerCtx = req.Context()
+		return &http.Response{StatusCode: 200, Header: http.Header{}, Body: http.NoBody}, nil
+	})
+
+	req := (&http.Request{Method: "POST", Header: http.Header{}}).WithContext(merged)
+	if _, err := (&tracePropagationTransport{base: base}).RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+
+	inner := trace.SpanContextFromContext(innerCtx)
+	if !inner.IsValid() {
+		t.Fatal("inner middleware should receive a context with an active (remote caller) span")
+	}
+	if inner.TraceID() != callerSpan.SpanContext().TraceID() {
+		t.Fatalf("inner span trace %s should match the caller trace %s", inner.TraceID(), callerSpan.SpanContext().TraceID())
+	}
+	if inner.SpanID() != callerSpan.SpanContext().SpanID() {
+		t.Fatalf("inner span parent should be the caller span %s, got %s", callerSpan.SpanContext().SpanID(), inner.SpanID())
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #212. Verified live on prod (mcp-grafana 1.3.0 + plugin 0.3.13): asko11y and mcp-grafana spans now share a trace, but the `/mcp` span parents onto the `HTTP Outgoing Request` client span instead of `mcp_tool_call` — the grafana-sdk tracing middleware sits **outside** our injection wrapper, started its span from the span-less merged context (fresh root), and re-injected its own traceparent.

## Fix

The transport now **enriches the request context** with the caller's SpanContext (`trace.ContextWithRemoteSpanContext`) before the middleware runs. The middleware then creates its span as a child of `mcp_tool_call` and propagates from it itself, restoring the full chain the plugin had before:

```
grafana-frontend → agent_run → mcp_tool_call → HTTP Outgoing Request → mcp-grafana /mcp → Grafana core
```

- Direct header injection is kept as a fallback for chains without the middleware (an inner traceparent overwrites ours, so behavior is consistent).
- Span-less requests pass through untouched.
- New test: `TestTracePropagationTransport_EnrichesContextForInnerMiddleware` (asserts the inner middleware receives the caller's trace/span as its parent).

## After merge

Release-please cuts 0.3.14; bump the w3f-observability plugin download to v0.3.14 and roll — then the next session's trace shows the full chain end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to MCP HTTP client trace propagation; no auth, data, or request semantics changes beyond skipping clone/inject when there is nothing to propagate.
> 
> **Overview**
> Fixes distributed tracing so **grafana-sdk’s “HTTP Outgoing Request” span** parents off **`mcp_tool_call`** instead of starting a new root when the tool context was rebuilt by `mergeUserCtx`.
> 
> **`tracePropagationTransport`** now uses a three-way switch: stashed caller span → **`trace.ContextWithRemoteSpanContext`** on the cloned request context (so inner middleware sees the caller as remote parent); valid span already on context → **`ContextWithSpanContext`**; **no span → early return** without cloning or injecting headers. W3C **`traceparent` injection on the clone** remains as a fallback for stacks without propagating middleware.
> 
> Adds **`TestTracePropagationTransport_EnrichesContextForInnerMiddleware`** to assert the inner handler receives the caller’s trace/span on `req.Context()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0673271e5e8efa073479b5746f6217fd82e0d99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->