### PR TITLE
fix: make Redis rate-limit TTL atomic

### DIFF
--- a/pkg/plugin/ratelimit.go
+++ b/pkg/plugin/ratelimit.go
@@ -70,6 +70,17 @@ type RedisRateLimiter struct {
 	ctx    context.Context
 }
 
+// redisRateLimitScript atomically increments the counter and ensures the
+// rate-limit window is attached to the key. The PTTL check also repairs keys
+// left without an expiry by older versions if INCR succeeded but EXPIRE failed.
+const redisRateLimitScript = `
+local count = redis.call("INCR", KEYS[1])
+if count == 1 or redis.call("PTTL", KEYS[1]) < 0 then
+  redis.call("PEXPIRE", KEYS[1], ARGV[1])
+end
+return count
+`
+
 // NewRedisRateLimiter creates a new Redis-backed rate limiter
 func NewRedisRateLimiter(ctx context.Context, client *redis.Client, logger log.Logger) *RedisRateLimiter {
 	return &RedisRateLimiter{
@@ -85,20 +96,16 @@ func (r *RedisRateLimiter) CheckLimit(userID int64) bool {
 
 	ctx, cancel := context.WithTimeout(r.ctx, RedisOpTimeout)
 	defer cancel()
-	count, err := r.client.Incr(ctx, rateLimitKey).Result()
+	count, err := r.client.Eval(
+		ctx,
+		redisRateLimitScript,
+		[]string{rateLimitKey},
+		ShareRateLimitWindow.Milliseconds(),
+	).Int64()
 	if err != nil {
-		r.logger.Warn("Failed to increment rate limit counter", "error", err, "userId", userID)
+		r.logger.Warn("Failed to update rate limit counter", "error", err, "userId", userID)
 		// Allow on error to avoid blocking legitimate requests
 		return true
-	}
-
-	// Set TTL on first increment
-	if count == 1 {
-		ctx2, cancel2 := context.WithTimeout(r.ctx, RedisOpTimeout)
-		defer cancel2()
-		if err := r.client.Expire(ctx2, rateLimitKey, ShareRateLimitWindow).Err(); err != nil {
-			r.logger.Warn("Failed to set rate limit TTL", "error", err, "userId", userID)
-		}
 	}
 
 	// Check if limit exceeded

--- a/pkg/plugin/ratelimit_test.go
+++ b/pkg/plugin/ratelimit_test.go
@@ -1,0 +1,41 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+func TestRedisRateLimiter_RepairsMissingTTL(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	const userID int64 = 100
+	rateLimitKey := "ratelimit:100"
+
+	// Simulate the partial-failure state produced by the old two-command
+	// implementation: INCR succeeded, but EXPIRE failed, leaving a live
+	// counter with no TTL.
+	if err := client.Set(ctx, rateLimitKey, 1, 0).Err(); err != nil {
+		t.Fatalf("failed to seed rate-limit key: %v", err)
+	}
+	if ttl := client.TTL(ctx, rateLimitKey).Val(); ttl != -1 {
+		t.Fatalf("expected seeded rate-limit key to have no TTL, got %v", ttl)
+	}
+
+	limiter := NewRedisRateLimiter(ctx, client, log.DefaultLogger)
+	if allowed := limiter.CheckLimit(userID); !allowed {
+		t.Fatal("expected request below the rate limit to be allowed")
+	}
+
+	ttl := client.TTL(ctx, rateLimitKey).Val()
+	if ttl <= 0 {
+		t.Fatalf("expected rate-limit key TTL to be repaired, got %v", ttl)
+	}
+	if ttl > ShareRateLimitWindow || ttl < ShareRateLimitWindow-time.Minute {
+		t.Fatalf("expected TTL close to %v, got %v", ShareRateLimitWindow, ttl)
+	}
+}


### PR DESCRIPTION


The Redis-backed rate limiter currently increments the counter and sets the TTL in two separate commands. If the increment succeeds but the expiry does not, the key can be left without a TTL and keep accumulating indefinitely.

This changes the update to a small Lua script so the increment and expiry happen atomically. It also repairs an existing rate-limit key if it has no TTL.

Added coverage for:

* setting the TTL on the first request
* preserving the existing TTL on later requests
* repairing a stale key without an expiry
* enforcing the configured limit

Tested with typecheck, lint, frontend unit tests, backend tests, and a full build.
