### PR TITLE
fix: preserve concurrent Redis session writes

### DIFF
--- a/pkg/plugin/sessionstore_redis.go
+++ b/pkg/plugin/sessionstore_redis.go
@@ -21,13 +21,12 @@ func sessionCurrentKey(userID, orgID int64) string {
 }
 
 // sessionStatsKey is a separate hash from the main session blob so
-// IncrementStats can HINCRBY atomically instead of racing with the
-// read-modify-write cycle every other session mutator uses on the blob.
+// IncrementStats can HINCRBY atomically without rewriting the session blob.
 func sessionStatsKey(id string) string { return fmt.Sprintf("session:%s:stats", id) }
 
 // redisSession is the on-wire format stored in Redis (includes owner fields).
 // Usage-stats fields live in a separate hash (sessionStatsKey) so they never
-// round-trip through this struct's read-modify-write cycle — see IncrementStats.
+// round-trip through session blob updates — see IncrementStats.
 type redisSession struct {
 	ID           string           `json:"id"`
 	Title        string           `json:"title"`
@@ -185,14 +184,54 @@ func (s *RedisSessionStore) getSessionRaw(sessionID string) (*redisSession, erro
 	return &rs, nil
 }
 
-func (s *RedisSessionStore) saveSession(session *ChatSession) error {
-	data, err := json.Marshal(toRedis(session))
-	if err != nil {
-		return fmt.Errorf("failed to marshal session: %w", err)
-	}
+// mutateSession applies a read-modify-write under Redis optimistic locking.
+// If another writer changes the session between GET and EXEC, WATCH makes the
+// transaction fail and the mutation is retried against the latest value.
+func (s *RedisSessionStore) mutateSession(sessionID string, userID, orgID int64, mutate func(*ChatSession)) error {
+	key := sessionKey(sessionID)
 	ctx, cancel := redisContext(s.ctx, RedisOpTimeout)
 	defer cancel()
-	return s.client.Set(ctx, sessionKey(session.ID), data, s.sessionTTL).Err()
+
+	for {
+		err := s.client.Watch(ctx, func(tx *redis.Tx) error {
+			data, err := tx.Get(ctx, key).Result()
+			if err == redis.Nil {
+				return fmt.Errorf("session not found")
+			}
+			if err != nil {
+				return fmt.Errorf("failed to get session: %w", err)
+			}
+
+			var rs redisSession
+			if err := json.Unmarshal([]byte(data), &rs); err != nil {
+				return fmt.Errorf("failed to unmarshal session: %w", err)
+			}
+			if rs.UserID != userID || rs.OrgID != orgID {
+				return fmt.Errorf("session not found")
+			}
+
+			session := fromRedis(&rs)
+			mutate(session)
+
+			updated, err := json.Marshal(toRedis(session))
+			if err != nil {
+				return fmt.Errorf("failed to marshal session: %w", err)
+			}
+
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, key, updated, s.sessionTTL)
+				return nil
+			})
+			return err
+		}, key)
+		if err == redis.TxFailedErr {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			continue
+		}
+		return err
+	}
 }
 
 func (s *RedisSessionStore) GetSession(sessionID string, userID, orgID int64) (*ChatSession, error) {
@@ -294,48 +333,30 @@ func (s *RedisSessionStore) ListSessions(userID, orgID int64) ([]SessionMetadata
 }
 
 func (s *RedisSessionStore) UpdateSession(sessionID string, userID, orgID int64, update SessionUpdate) error {
-	rs, err := s.getSessionRaw(sessionID)
-	if err != nil {
-		return err
-	}
-	if rs.UserID != userID || rs.OrgID != orgID {
-		return fmt.Errorf("session not found")
-	}
-
-	session := fromRedis(rs)
-	if update.Messages != nil {
-		session.Messages = update.Messages
-		session.MessageCount = len(update.Messages)
-	}
-	if update.Title != nil {
-		session.Title = *update.Title
-	}
-	if update.Summary != nil {
-		session.Summary = *update.Summary
-	}
-	if update.Model != nil {
-		session.Model = *update.Model
-	}
-	session.UpdatedAt = time.Now()
-
-	return s.saveSession(session)
+	return s.mutateSession(sessionID, userID, orgID, func(session *ChatSession) {
+		if update.Messages != nil {
+			session.Messages = update.Messages
+			session.MessageCount = len(update.Messages)
+		}
+		if update.Title != nil {
+			session.Title = *update.Title
+		}
+		if update.Summary != nil {
+			session.Summary = *update.Summary
+		}
+		if update.Model != nil {
+			session.Model = *update.Model
+		}
+		session.UpdatedAt = time.Now()
+	})
 }
 
 func (s *RedisSessionStore) AppendMessages(sessionID string, userID, orgID int64, messages []SessionMessage) error {
-	rs, err := s.getSessionRaw(sessionID)
-	if err != nil {
-		return err
-	}
-	if rs.UserID != userID || rs.OrgID != orgID {
-		return fmt.Errorf("session not found")
-	}
-
-	session := fromRedis(rs)
-	session.Messages = append(session.Messages, messages...)
-	session.MessageCount = len(session.Messages)
-	session.UpdatedAt = time.Now()
-
-	return s.saveSession(session)
+	return s.mutateSession(sessionID, userID, orgID, func(session *ChatSession) {
+		session.Messages = append(session.Messages, messages...)
+		session.MessageCount = len(session.Messages)
+		session.UpdatedAt = time.Now()
+	})
 }
 
 func (s *RedisSessionStore) DeleteSession(sessionID string, userID, orgID int64) error {
@@ -429,39 +450,21 @@ func (s *RedisSessionStore) ClearCurrentSessionID(userID, orgID int64) error {
 }
 
 func (s *RedisSessionStore) SetActiveRunID(sessionID string, userID, orgID int64, runID string) error {
-	rs, err := s.getSessionRaw(sessionID)
-	if err != nil {
-		return err
-	}
-	if rs.UserID != userID || rs.OrgID != orgID {
-		return fmt.Errorf("session not found")
-	}
-
-	session := fromRedis(rs)
-	session.ActiveRunID = runID
-	session.UpdatedAt = time.Now()
-	return s.saveSession(session)
+	return s.mutateSession(sessionID, userID, orgID, func(session *ChatSession) {
+		session.ActiveRunID = runID
+		session.UpdatedAt = time.Now()
+	})
 }
 
 func (s *RedisSessionStore) ClearActiveRunID(sessionID string, userID, orgID int64) error {
-	rs, err := s.getSessionRaw(sessionID)
-	if err != nil {
-		return err
-	}
-	if rs.UserID != userID || rs.OrgID != orgID {
-		return fmt.Errorf("session not found")
-	}
-
-	session := fromRedis(rs)
-	session.ActiveRunID = ""
-	return s.saveSession(session)
+	return s.mutateSession(sessionID, userID, orgID, func(session *ChatSession) {
+		session.ActiveRunID = ""
+	})
 }
 
 // IncrementStats applies delta via HINCRBY on a hash separate from the main
-// session blob, so it can't race with the read-modify-write cycle every other
-// mutator (AppendMessages, SetActiveRunID, ...) uses — concurrent runs on the
-// same session (e.g. two tabs, or an automation retriggering a run) can't
-// silently drop a delta the way a read-modify-write on the blob would.
+// session blob. Concurrent runs on the same session can update their counters
+// independently without contending with session metadata or message writes.
 func (s *RedisSessionStore) IncrementStats(sessionID string, userID, orgID int64, delta SessionStatsDelta) error {
 	rs, err := s.getSessionRaw(sessionID)
 	if err != nil {
@@ -487,6 +490,6 @@ func (s *RedisSessionStore) IncrementStats(sessionID string, userID, orgID int64
 }
 
 func (s *RedisSessionStore) CleanupOld() {
-	// Sessions expire natively via the TTL set on every write (see
-	// saveSession) — no periodic sweep needed.
+	// Sessions expire natively via the TTL refreshed on every session write —
+	// no periodic sweep needed.
 }

--- a/pkg/plugin/sessionstore_redis_test.go
+++ b/pkg/plugin/sessionstore_redis_test.go
@@ -2,11 +2,54 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/redis/go-redis/v9"
 )
+
+type redisGetBarrierHook struct {
+	key     string
+	mu      sync.Mutex
+	hits    int
+	release chan struct{}
+}
+
+func (h *redisGetBarrierHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h *redisGetBarrierHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		if err != nil || cmd.Name() != "get" || len(cmd.Args()) < 2 || fmt.Sprint(cmd.Args()[1]) != h.key {
+			return err
+		}
+
+		h.mu.Lock()
+		if h.hits >= 2 {
+			h.mu.Unlock()
+			return nil
+		}
+		h.hits++
+		if h.hits == 2 {
+			close(h.release)
+		}
+		release := h.release
+		h.mu.Unlock()
+
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (h *redisGetBarrierHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
 
 func TestRedisSessionStore_ModelRoundTrip(t *testing.T) {
 	client := createTestRedisClient(t)
@@ -37,6 +80,65 @@ func TestRedisSessionStore_ModelRoundTrip(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].Model != "large" {
 		t.Fatalf("expected listed session model large, got %+v", sessions)
+	}
+}
+
+func TestRedisSessionStore_AppendMessages_ConcurrentNoLostUpdates(t *testing.T) {
+	client := createTestRedisClient(t)
+	defer client.Close()
+
+	store := NewRedisSessionStore(context.Background(), client, log.DefaultLogger, resolveTTLDays(0, DefaultSessionTTLDays))
+	session, err := store.CreateSession(1, 1, "test", []SessionMessage{{Role: "user", Content: "initial"}})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	// Hold the first two session GETs until both have read the same value. This
+	// makes the lost-update window deterministic instead of relying on timing.
+	client.AddHook(&redisGetBarrierHook{
+		key:     sessionKey(session.ID),
+		release: make(chan struct{}),
+	})
+
+	messages := []SessionMessage{
+		{Role: "assistant", Content: "from first writer"},
+		{Role: "assistant", Content: "from second writer"},
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(messages))
+	for _, message := range messages {
+		message := message
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := store.AppendMessages(session.ID, 1, 1, []SessionMessage{message}); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("AppendMessages failed: %v", err)
+	}
+
+	got, err := store.GetSession(session.ID, 1, 1)
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got.MessageCount != 3 || len(got.Messages) != 3 {
+		t.Fatalf("lost concurrent append: got %d messages, want 3", len(got.Messages))
+	}
+
+	seen := map[string]bool{}
+	for _, message := range got.Messages {
+		seen[message.Content] = true
+	}
+	for _, message := range messages {
+		if !seen[message.Content] {
+			t.Fatalf("lost concurrent append: missing %q", message.Content)
+		}
 	}
 }
 


### PR DESCRIPTION
Redis session mutations currently do a GET followed by a full SET of the session blob. If the same session is updated concurrently, both writers can read the same value and the last write can overwrite the other update.

This uses Redis WATCH with a transaction retry so conflicting writes are reapplied against the latest session value instead of being dropped.

I added a regression test that forces two message appends to read the same starting value. It fails on the old implementation with one message missing and passes with the retry in place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session persistence concurrency for all blob mutators; incorrect WATCH/retry logic could cause write failures or stale reads under load.
> 
> **Overview**
> Concurrent updates to the same chat session in Redis could **lose writes** because mutators did a plain GET → modify → SET on the session JSON blob.
> 
> This PR replaces that pattern with **`mutateSession`**, which uses Redis **`WATCH`** and retries the transaction when another writer changes the key first, so **`UpdateSession`**, **`AppendMessages`**, **`SetActiveRunID`**, and **`ClearActiveRunID`** reapply on the latest value instead of overwriting it. Comments around the separate stats hash are tightened; **`IncrementStats`** stays on atomic **`HINCRBY`** and is unchanged in behavior.
> 
> A regression test **`TestRedisSessionStore_AppendMessages_ConcurrentNoLostUpdates`** uses a Redis hook to force two concurrent appends to read the same starting session and asserts all three messages remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8974b79561867948f6be6ee5adcaa6e393cd486e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->