### PR TITLE
ci: run plugin validator from official Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,21 +113,22 @@ jobs:
           PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
           PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
 
-      # The plugin-validator's "code-rules-*" analyzers shell out to `semgrep`
-      # and silently no-op when it is missing (they return no diagnostics, not
-      # an error). Without this the file-system / env / syscall code rules never
-      # run in CI even though the catalog review runs them on the published zip.
-      - name: Setup Python for semgrep
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: '3.13'
-
-      - name: Install semgrep
-        run: python3 -m pip install "setuptools<81" "semgrep==1.84.1"
-
+      # Run the validator from the official image, not `npx`. The npx wrapper
+      # only downloads the Go binary; the security analyzers (code-rules/semgrep,
+      # go-sec/gosec, govulncheck, virusscan/clamav) shell out to external tools
+      # and silently report NOTHING when those are absent. The Docker image
+      # bundles all of them, matching the environment the catalog review uses.
+      # Bump the image tag to track plugin-validator releases.
       - name: Validate plugin
         run: |
-          npx -y @grafana/plugin-validator@latest -config .github/plugin-validator.config.yaml -sourceCodeUri file://./ $PLUGIN_ARCHIVE
+          docker run --rm \
+            -v "$PWD:/source" \
+            -w /source \
+            -v "$PWD/$PLUGIN_ARCHIVE:/archive.zip" \
+            grafana/plugin-validator-cli:v0.49.1 \
+            -config /source/.github/plugin-validator.config.yaml \
+            -sourceCodeUri file:///source \
+            /archive.zip
         env:
           PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'tsconfig.json'
+              # Changes to the build/validation tooling must run the build too,
+              # otherwise e.g. an edit to ci.yml or the validator config would
+              # fast-pass and never be exercised.
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/plugin-validator.config.yaml'
 
   build:
     name: Build, lint and unit tests
@@ -119,10 +125,22 @@ jobs:
       # and silently report NOTHING when those are absent. The Docker image
       # bundles all of them, matching the environment the catalog review uses.
       # Bump the image tag to track plugin-validator releases.
+      #
+      # Validate a clean, tracked-only source export (git archive) rather than
+      # the whole workspace: this drops node_modules/.git so clamav/gosec/semgrep
+      # scan only plugin source (minutes vs. ~18), and mirrors the clean checkout
+      # the catalog reviews.
+      - name: Export clean source for validation
+        run: |
+          mkdir -p "$VALIDATOR_SRC"
+          git archive --format=tar HEAD | tar -x -C "$VALIDATOR_SRC"
+        env:
+          VALIDATOR_SRC: ${{ runner.temp }}/validator-src
+
       - name: Validate plugin
         run: |
           docker run --rm \
-            -v "$PWD:/source" \
+            -v "$VALIDATOR_SRC:/source" \
             -w /source \
             -v "$PWD/$PLUGIN_ARCHIVE:/archive.zip" \
             grafana/plugin-validator-cli:v0.49.1 \
@@ -131,6 +149,7 @@ jobs:
             /archive.zip
         env:
           PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
+          VALIDATOR_SRC: ${{ runner.temp }}/validator-src
 
   # Fast pass for release-please PRs (no code changes)
   skip-build:


### PR DESCRIPTION
## What

Follow-up to #220. That PR fixed the `code-rules-access-file-system-with-fs` violation and added a `pip install semgrep` step to CI. This PR replaces the `npx` validator invocation with the official `grafana/plugin-validator-cli` Docker image and tightens the surrounding CI.

## Why

`npx @grafana/plugin-validator` only downloads the validator binary. Analyzers that depend on external security tooling call `exec.LookPath(...)` and, when the tool is missing, return `nil, nil` — reporting **no diagnostics**, not an error. So CI silently skipped:

| Analyzer | Needs | `npx` CI before |
|---|---|---|
| `code-rules` | semgrep | skipped (fixed in #220) |
| `go-sec` | gosec | skipped |
| `govulncheck` | govulncheck | skipped |
| `virusscan` | clamav | skipped |

The validator's own README recommends the Docker image precisely because "it contains all the security scanning tools needed for the full set of analyzers". The image bundles semgrep (1.84.1), gosec (v2.29.0), govulncheck (v1.7.0), clamav (with a fresh DB), and node/npx — i.e. the environment the catalog review uses.

## Changes

**1. Run the validator from the official image** (pinned `v0.49.1`, bump to track releases). This supersedes the `setup-python` + `pip install semgrep` + `npx` steps from #220, which are removed.

**2. Scan a clean source export, not the whole workspace.** `node_modules` was being mounted and scanned by clamav/gosec/semgrep, making the Validate step take ~18 min. Now we export tracked source with `git archive` into a temp dir and mount only that — which also matches the clean checkout the catalog reviews:

```yaml
      - name: Export clean source for validation
        run: |
          mkdir -p "$VALIDATOR_SRC"
          git archive --format=tar HEAD | tar -x -C "$VALIDATOR_SRC"
```

**3. Trigger the build on tooling changes.** `.github/workflows/**`, `.github/actions/**`, and `.github/plugin-validator.config.yaml` are now in the `check-changes` filter. Previously an edit to `ci.yml` or the validator config fast-passed and was never exercised (which is why this PR's own first CI run skipped the build).

`llmreview`/`codediff` and `provenance` still require an LLM API key and a build attestation respectively; those are supplied by the catalog review and intentionally remain out of scope for PR CI.

## Verification

- Validate step: **~18 min → 240s** with the clean source export; full suite (semgrep/gosec/govulncheck/clamav) still runs, same pre-existing warnings only (React 19 / sponsorship / unsigned plugin), no code-rule errors.
- The PR now triggers its own build (filter change works), and `Build, lint and unit tests` passes (~11 min total).
